### PR TITLE
Fix macos detection: Use built-time `TARGET` as fallback

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -141,17 +141,20 @@ mod linux {
 
 #[cfg(target_os = "macos")]
 mod macos {
+    use super::TARGET;
     use guess_host_triple::guess_host_triple;
 
     pub(super) const AARCH64: &str = "aarch64-apple-darwin";
     pub(super) const X86: &str = "x86_64-apple-darwin";
 
     pub(super) fn detect_targets_macos() -> Vec<String> {
-        if guess_host_triple() == Some(AARCH64) {
-            vec![AARCH64.into(), X86.into()]
-        } else {
-            vec![X86.into()]
+        let mut targets = vec![guess_host_triple().unwrap_or(TARGET).to_string()];
+
+        if targets[0] == AARCH64 {
+            targets.push(X86.into());
         }
+
+        targets
     }
 }
 


### PR DESCRIPTION
When `guess_host_triple` failed to detect the target, use the target detected at built time as fallback.
Since `cargo-binstall` can be run, then the built-time target must be supported by the environment.

This also unifies the behavior with the newly added windows target detection.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>