### PR TITLE
Add Signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.32"
 tinytemplate = "1.2.1"
-tokio = { version = "1.20.1", features = ["rt-multi-thread", "process", "sync", "signal"], default-features = false }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "process", "sync", "signal"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 url = { version = "2.2.2", features = ["serde"] }
 xz2 = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.32"
 tinytemplate = "1.2.1"
-tokio = { version = "1.20.1", features = ["rt-multi-thread", "process", "sync"], default-features = false }
+tokio = { version = "1.20.1", features = ["rt-multi-thread", "process", "sync", "signal"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 url = { version = "2.2.2", features = ["serde"] }
 xz2 = "0.1.7"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,9 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::internal::task_join))]
     TaskJoinError(#[from] task::JoinError),
 
-    /// The installation was cancelled by a user at a confirmation prompt.
+    /// The installation was cancelled by a user at a confirmation prompt,
+    /// or user send a ctrl_c on all platforms or
+    /// `SIGINT`, `SIGHUP`, `SIGTERM` or `SIGQUIT` on unix to the program.
     ///
     /// - Code: `binstall::user_abort`
     /// - Exit: 32

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -64,7 +64,7 @@ impl MultiFetcher {
     pub fn add(&mut self, fetcher: Arc<dyn Fetcher>) {
         self.0.push((
             fetcher.clone(),
-            AutoAbortJoinHandle::new(tokio::spawn(async move { fetcher.find().await })),
+            AutoAbortJoinHandle::spawn(async move { fetcher.find().await }),
         ));
     }
 

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -41,13 +41,13 @@ impl super::Fetcher for GhCrateMeta {
         let checks = urls
             .map(|url| {
                 let client = self.client.clone();
-                AutoAbortJoinHandle::new(tokio::spawn(async move {
+                AutoAbortJoinHandle::spawn(async move {
                     let url = url?;
                     info!("Checking for package at: '{url}'");
                     remote_exists(client, url.clone(), Method::HEAD)
                         .await
                         .map(|exists| (url.clone(), exists))
-                }))
+                })
             })
             .collect::<Vec<_>>();
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -47,6 +47,9 @@ pub use crate_name::CrateName;
 mod flock;
 pub use flock::FileLock;
 
+mod signal;
+pub use signal::cancel_on_user_sig_term;
+
 pub fn cargo_home() -> Result<&'static Path, io::Error> {
     static CARGO_HOME: OnceCell<PathBuf> = OnceCell::new();
 

--- a/src/helpers/auto_abort_join_handle.rs
+++ b/src/helpers/auto_abort_join_handle.rs
@@ -16,6 +16,18 @@ impl<T> AutoAbortJoinHandle<T> {
     }
 }
 
+impl<T> AutoAbortJoinHandle<T>
+where
+    T: Send + 'static,
+{
+    pub fn spawn<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + Send + 'static,
+    {
+        Self(tokio::spawn(future))
+    }
+}
+
 impl<T> Drop for AutoAbortJoinHandle<T> {
     fn drop(&mut self) {
         self.0.abort();

--- a/src/helpers/signal.rs
+++ b/src/helpers/signal.rs
@@ -1,0 +1,80 @@
+use futures_util::future::pending;
+use std::io;
+use tokio::signal;
+
+use super::{AutoAbortJoinHandle, BinstallError};
+
+/// This function will poll the handle while listening for ctrl_c,
+/// `SIGINT`, `SIGHUP`, `SIGTERM` and `SIGQUIT`.
+///
+/// When signal is received, [`BinstallError::UserAbort`] will be returned.
+///
+/// It would also ignore `SIGUSER1` and `SIGUSER2` on unix.
+///
+/// This function uses [`tokio::signal`] and once exit, does not reset the default
+/// signal handler, so be careful when using it.
+pub async fn cancel_on_user_sig_term<T>(
+    handle: AutoAbortJoinHandle<T>,
+) -> Result<T, BinstallError> {
+    #[cfg(unix)]
+    unix::ignore_signals_on_unix()?;
+
+    tokio::select! {
+        res = handle => res,
+        res = wait_on_cancellation_signal() => {
+            res.map_err(BinstallError::Io).and(Err(BinstallError::UserAbort))
+        }
+    }
+}
+
+async fn wait_on_cancellation_signal() -> Result<(), io::Error> {
+    #[cfg(unix)]
+    async fn inner() -> Result<(), io::Error> {
+        unix::wait_on_cancellation_signal_unix().await
+    }
+
+    #[cfg(not(unix))]
+    async fn inner() -> Result<(), io::Error> {
+        // Use pending here so that tokio::select! would just skip this branch.
+        pending().await
+    }
+
+    tokio::select! {
+        res = signal::ctrl_c() => res,
+        res = inner() => res,
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use signal::unix::{signal, SignalKind};
+
+    /// Same as [`wait_on_cancellation_signal`] but is only available on unix.
+    pub async fn wait_on_cancellation_signal_unix() -> Result<(), io::Error> {
+        tokio::select! {
+            res = wait_for_signal_unix(SignalKind::interrupt()) => res,
+            res = wait_for_signal_unix(SignalKind::hangup()) => res,
+            res = wait_for_signal_unix(SignalKind::terminate()) => res,
+            res = wait_for_signal_unix(SignalKind::quit()) => res,
+        }
+    }
+
+    /// Wait for first arrival of signal.
+    pub async fn wait_for_signal_unix(kind: signal::unix::SignalKind) -> Result<(), io::Error> {
+        let mut sig_listener = signal::unix::signal(kind)?;
+        if sig_listener.recv().await.is_some() {
+            Ok(())
+        } else {
+            // Use pending() here for the same reason as above.
+            pending().await
+        }
+    }
+
+    pub fn ignore_signals_on_unix() -> Result<(), BinstallError> {
+        drop(signal(SignalKind::user_defined1())?);
+        drop(signal(SignalKind::user_defined2())?);
+
+        Ok(())
+    }
+}

--- a/src/helpers/ui_thread.rs
+++ b/src/helpers/ui_thread.rs
@@ -32,14 +32,14 @@ impl UIThreadInner {
                     break;
                 }
 
-                // Lock stdout so that nobody can interfere
-                // with confirmation.
-                let mut stdout = io::stdout().lock();
-
                 let res = loop {
-                    writeln!(&mut stdout, "Do you wish to continue? yes/[no]").unwrap();
-                    write!(&mut stdout, "? ").unwrap();
-                    stdout.flush().unwrap();
+                    {
+                        let mut stdout = io::stdout().lock();
+
+                        writeln!(&mut stdout, "Do you wish to continue? yes/[no]").unwrap();
+                        write!(&mut stdout, "? ").unwrap();
+                        stdout.flush().unwrap();
+                    }
 
                     input.clear();
                     stdin.read_line(&mut input).unwrap();

--- a/src/helpers/ui_thread.rs
+++ b/src/helpers/ui_thread.rs
@@ -1,7 +1,9 @@
-use std::io::{self, BufRead, Write};
+use std::{
+    io::{self, BufRead, Write},
+    thread,
+};
 
 use tokio::sync::mpsc;
-use tokio::task::spawn_blocking;
 
 use crate::BinstallError;
 
@@ -19,7 +21,7 @@ impl UIThreadInner {
         let (request_tx, mut request_rx) = mpsc::channel(1);
         let (confirm_tx, confirm_rx) = mpsc::channel(10);
 
-        spawn_blocking(move || {
+        thread::spawn(move || {
             // This task should be the only one able to
             // access stdin
             let mut stdin = io::stdin().lock();


### PR DESCRIPTION
This PR added signal handling for:
 - `ctrl_c`
 - `SIGINT` (unix)
 - `SIGHUP` (unix)
 - `SIGTERM` (unix)
 - `SIGQUIT` (unix)

It will abort the program and clean up the resource if received any of the signals listed above.

It also ignores `SIGUSR1` and `SIGUSR2` on unix.

This PR fixed #268 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>