### PR TITLE
Fix passing `--quiet` to `cargo-install`

### DIFF
--- a/src/binstall/install.rs
+++ b/src/binstall/install.rs
@@ -147,7 +147,7 @@ async fn install_from_source(
         .arg(&*target);
 
     if quiet {
-        cmd.arg("quiet");
+        cmd.arg("--quiet");
     }
 
     let mut child = cmd


### PR DESCRIPTION
Fixed bug introduced in #281 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>