### PR TITLE
Don't prompt if there's nothing to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,15 @@
 `binstall` works by fetching the crate information from `crates.io`, then searching the linked `repository` for matching releases and artifacts, with fallbacks to [quickinstall](https://github.com/alsuren/cargo-quickinstall) and finally `cargo install` if these are not found.
 To support `binstall` maintainers must add configuration values to `Cargo.toml` to allow the tool to locate the appropriate binary package for a given version and target. See [SUPPORT.md](./SUPPORT.md) for more detail.
 
-
 ## Status
 
-![Build](https://github.com/ryankurte/cargo-binstall/workflows/Rust/badge.svg)
-[![GitHub tag](https://img.shields.io/github/tag/ryankurte/cargo-binstall.svg)](https://github.com/ryankurte/cargo-binstall)
+![Build](https://github.com/cargo-bins/cargo-binstall/workflows/Rust/badge.svg)
+[![GitHub tag](https://img.shields.io/github/tag/cargo-bins/cargo-binstall.svg)](https://github.com/cargo-bins/cargo-binstall)
 [![Crates.io](https://img.shields.io/crates/v/cargo-binstall.svg)](https://crates.io/crates/cargo-binstall)
-[![Docs.rs](https://docs.rs/cargo-binstall/badge.svg)](https://docs.rs/cargo-binstall)
 
 ## Installation
 
-To get started _using_ `cargo-binstall` first install the binary (either via `cargo install cargo-binstall` or by downloading a pre-compiled [release](https://github.com/ryankurte/cargo-binstall/releases)).
-
+To get started _using_ `cargo-binstall` first install the binary (either via `cargo install cargo-binstall` or by downloading a pre-compiled [release](https://github.com/cargo-bins/cargo-binstall/releases)).
 
 | OS      | Arch    | URL                                                          |
 | ------- | ------- | ------------------------------------------------------------ |
@@ -27,7 +24,7 @@ To get started _using_ `cargo-binstall` first install the binary (either via `ca
 | macos   | m1      | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-aarch64-apple-darwin.zip |
 | windows | x86\_64 | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-pc-windows-msvc.zip |
 
-
+To upgrade, use `cargo binstall cargo-binstall`!
 
 ## Usage
 
@@ -37,16 +34,15 @@ Package versions and targets may be specified using the `--version` and `--targe
 
 ```
 [garry] ➜  ~ cargo binstall radio-sx128x --version 0.14.1-alpha.5
-21:14:09 [INFO] Installing package: 'radio-sx128x'
-21:14:13 [INFO] Downloading package from: 'https://github.com/rust-iot/rust-radio-sx128x/releases/download/v0.14.1-alpha.5/sx128x-util-x86_64-apple-darwin.tgz'
+21:14:15 [INFO] Resolving package: 'radio-sx128x'
 21:14:18 [INFO] This will install the following binaries:
 21:14:18 [INFO]   - sx128x-util (sx128x-util-x86_64-apple-darwin -> /Users/ryankurte/.cargo/bin/sx128x-util-v0.14.1-alpha.5)
 21:14:18 [INFO] And create (or update) the following symlinks:
 21:14:18 [INFO]   - sx128x-util (/Users/ryankurte/.cargo/bin/sx128x-util-v0.14.1-alpha.5 -> /Users/ryankurte/.cargo/bin/sx128x-util)
-21:14:18 [INFO] Do you wish to continue? yes/no
-yes
-21:15:30 [INFO] Installing binaries...
-21:15:30 [INFO] Installation complete!
+21:14:18 [INFO] Do you wish to continue? yes/[no]
+? yes
+21:14:20 [INFO] Installing binaries...
+21:14:21 [INFO] Done in 6.212736s
 ```
 
 ### Unsupported crates
@@ -59,7 +55,6 @@ $ binstall \
   --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }" \
   --pkg-fmt="txz" crate_name
 ```
-
 
 ## FAQ
 

--- a/ci-scripts/tests.sh
+++ b/ci-scripts/tests.sh
@@ -48,12 +48,12 @@ cargo binstall --help >/dev/null
 cargo binstall --help >/dev/null
 
 # Test skip when installed
-"./$1" binstall --no-confirm cargo-binstall | grep -q 'cargo-binstall v0.11.1 is already installed'
+"./$1" binstall --no-confirm --force cargo-binstall@0.11.1
 "./$1" binstall --no-confirm cargo-binstall@0.11.1 | grep -q 'cargo-binstall v0.11.1 is already installed'
 
 "./$1" binstall --no-confirm cargo-binstall@0.10.0 | grep -q -v 'cargo-binstall v0.10.0 is already installed'
 
 ## Test When 0.11.0 is installed but can be upgraded.
-"./$1" binstall --force --log-level debug --no-confirm cargo-binstall@0.11.0
+"./$1" binstall --no-confirm cargo-binstall@0.11.0
 "./$1" binstall --no-confirm cargo-binstall@0.11.0 | grep -q 'cargo-binstall v0.11.0 is already installed'
 "./$1" binstall --no-confirm cargo-binstall@^0.11.0 | grep -q -v 'cargo-binstall v0.11.0 is already installed'

--- a/ci-scripts/tests.sh
+++ b/ci-scripts/tests.sh
@@ -48,11 +48,12 @@ cargo binstall --help >/dev/null
 cargo binstall --help >/dev/null
 
 # Test skip when installed
-"./$1" binstall --no-confirm cargo-binstall | grep -q 'package cargo-binstall is already installed'
-"./$1" binstall --no-confirm cargo-binstall@0.11.1 | grep -q 'package cargo-binstall@=0.11.1 is already installed'
+"./$1" binstall --no-confirm cargo-binstall | grep -q 'cargo-binstall v0.11.1 is already installed'
+"./$1" binstall --no-confirm cargo-binstall@0.11.1 | grep -q 'cargo-binstall v0.11.1 is already installed'
 
-"./$1" binstall --no-confirm cargo-binstall@0.10.0 | grep -q -v 'package cargo-binstall@=0.10.0 is already installed'
+"./$1" binstall --no-confirm cargo-binstall@0.10.0 | grep -q -v 'cargo-binstall v0.10.0 is already installed'
 
 ## Test When 0.11.0 is installed but can be upgraded.
 "./$1" binstall --force --log-level debug --no-confirm cargo-binstall@0.11.0
-"./$1" binstall --no-confirm cargo-binstall@^0.11.0 | grep -q -v 'package cargo-binstall@^0.11.0 is already installed'
+"./$1" binstall --no-confirm cargo-binstall@0.11.0 | grep -q 'cargo-binstall v0.11.0 is already installed'
+"./$1" binstall --no-confirm cargo-binstall@^0.11.0 | grep -q -v 'cargo-binstall v0.11.0 is already installed'

--- a/src/binstall/resolve.rs
+++ b/src/binstall/resolve.rs
@@ -120,7 +120,10 @@ pub async fn resolve(
             })?;
 
         if new_version == curr_version {
-            info!("package {crate_name} is already up to date {curr_version}");
+            info!(
+                "{} v{curr_version} is already installed, use --force to override",
+                crate_name.name
+            );
             return Ok(Resolution::AlreadyUpToDate);
         }
     }

--- a/src/binstall/resolve.rs
+++ b/src/binstall/resolve.rs
@@ -5,8 +5,7 @@ use std::{
 
 use cargo_toml::{Package, Product};
 use compact_str::{CompactString, ToCompactString};
-use log::{debug, error, info, warn};
-use miette::{miette, Result};
+use log::{debug, info, warn};
 use reqwest::Client;
 use semver::{Version, VersionReq};
 
@@ -14,7 +13,7 @@ use super::Options;
 use crate::{
     bins,
     fetchers::{Data, Fetcher, GhCrateMeta, MultiFetcher, QuickInstall},
-    *,
+    BinstallError, *,
 };
 
 pub enum Resolution {
@@ -84,7 +83,30 @@ pub async fn resolve(
     install_path: Arc<Path>,
     client: Client,
     crates_io_api_client: crates_io_api::AsyncClient,
-) -> Result<Resolution> {
+) -> Result<Resolution, BinstallError> {
+    let crate_name_name = crate_name.name.clone();
+    resolve_inner(
+        opts,
+        crate_name,
+        curr_version,
+        temp_dir,
+        install_path,
+        client,
+        crates_io_api_client,
+    )
+    .await
+    .map_err(|err| err.crate_context(crate_name_name))
+}
+
+async fn resolve_inner(
+    opts: Arc<Options>,
+    crate_name: CrateName,
+    curr_version: Option<Version>,
+    temp_dir: Arc<Path>,
+    install_path: Arc<Path>,
+    client: Client,
+    crates_io_api_client: crates_io_api::AsyncClient,
+) -> Result<Resolution, BinstallError> {
     info!("Installing package: '{}'", crate_name);
 
     let version_req: VersionReq = match (&crate_name.version_req, &opts.version_req) {
@@ -211,7 +233,7 @@ fn collect_bin_files(
     binaries: Vec<Product>,
     bin_path: PathBuf,
     install_path: PathBuf,
-) -> Result<Vec<bins::BinFile>> {
+) -> Result<Vec<bins::BinFile>, BinstallError> {
     // Update meta
     if fetcher.source_name() == "QuickInstall" {
         // TODO: less of a hack?
@@ -220,10 +242,7 @@ fn collect_bin_files(
 
     // Check binaries
     if binaries.is_empty() {
-        error!("No binaries specified (or inferred from file system)");
-        return Err(miette!(
-            "No binaries specified (or inferred from file system)"
-        ));
+        return Err(BinstallError::UnspecifiedBinaries);
     }
 
     // List files to be installed

--- a/src/binstall/resolve.rs
+++ b/src/binstall/resolve.rs
@@ -107,7 +107,7 @@ async fn resolve_inner(
     client: Client,
     crates_io_api_client: crates_io_api::AsyncClient,
 ) -> Result<Resolution, BinstallError> {
-    info!("Installing package: '{}'", crate_name);
+    info!("Resolving package: '{}'", crate_name);
 
     let version_req: VersionReq = match (&crate_name.version_req, &opts.version_req) {
         (Some(version), None) => version.clone(),

--- a/src/drivers/crates_io.rs
+++ b/src/drivers/crates_io.rs
@@ -36,7 +36,8 @@ pub async fn fetch_crate_cratesio(
 
     // Locate matching version
     let version_iter = base_info.versions.iter().filter(|v| !v.yanked);
-    let (version, version_name) = find_version(version_req, version_iter)?;
+    let (version, version_name) =
+        find_version(version_req, version_iter).map_err(|err| err.crate_context(name))?;
 
     debug!("Found information for crate version: '{}'", version.num);
 

--- a/src/drivers/crates_io.rs
+++ b/src/drivers/crates_io.rs
@@ -36,8 +36,7 @@ pub async fn fetch_crate_cratesio(
 
     // Locate matching version
     let version_iter = base_info.versions.iter().filter(|v| !v.yanked);
-    let (version, version_name) =
-        find_version(version_req, version_iter).map_err(|err| err.crate_context(name))?;
+    let (version, version_name) = find_version(version_req, version_iter)?;
 
     debug!("Found information for crate version: '{}'", version.num);
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,7 +71,7 @@ pub enum BinstallError {
     ///
     /// - Code: `binstall::http`
     /// - Exit: 69
-    #[error("could not {method} {url}: {err}")]
+    #[error("could not {method} {url}")]
     #[diagnostic(severity(error), code(binstall::http))]
     Http {
         method: reqwest::Method,
@@ -94,7 +94,7 @@ pub enum BinstallError {
     ///
     /// - Code: `binstall::crates_io_api`
     /// - Exit: 76
-    #[error("crates.io api error fetching crate information for '{crate_name}': {err}")]
+    #[error("crates.io API error")]
     #[diagnostic(
         severity(error),
         code(binstall::crates_io_api),
@@ -137,7 +137,7 @@ pub enum BinstallError {
     ///
     /// - Code: `binstall::version::parse`
     /// - Exit: 80
-    #[error("version string '{v}' is not semver: {err}")]
+    #[error("version string '{v}' is not semver")]
     #[diagnostic(severity(error), code(binstall::version::parse))]
     VersionParse {
         v: String,
@@ -154,7 +154,7 @@ pub enum BinstallError {
     ///
     /// - Code: `binstall::version::requirement`
     /// - Exit: 81
-    #[error("version requirement '{req}' is not semver: {err}")]
+    #[error("version requirement '{req}' is not semver")]
     #[diagnostic(severity(error), code(binstall::version::requirement))]
     VersionReq {
         req: String,
@@ -221,6 +221,22 @@ pub enum BinstallError {
     )]
     OverrideOptionUsedWithMultiInstall { option: &'static str },
 
+    /// No binaries were found for the crate.
+    ///
+    /// When installing, either the binaries are specified in the crate's Cargo.toml, or they're
+    /// inferred from the crate layout (e.g. src/main.rs or src/bins/name.rs). If no binaries are
+    /// found through these methods, we can't know what to install!
+    ///
+    /// - Code: `binstall::resolve::binaries`
+    /// - Exit: 86
+    #[error("no binaries specified nor inferred")]
+    #[diagnostic(
+        severity(error),
+        code(binstall::resolve::binaries),
+        help("This crate doesn't specify any binaries, so there's nothing to install.")
+    )]
+    UnspecifiedBinaries,
+
     /// A wrapped error providing the context of which crate the error is about.
     #[error("for crate {crate_name}")]
     CrateContext {
@@ -251,6 +267,7 @@ impl BinstallError {
             VersionUnavailable { .. } => 83,
             SuperfluousVersionOption => 84,
             OverrideOptionUsedWithMultiInstall { .. } => 85,
+            UnspecifiedBinaries => 86,
             CrateContext { error, .. } => error.exit_number(),
         };
 

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use compact_str::{CompactString, ToCompactString};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use reqwest::Method;
@@ -43,7 +43,7 @@ impl super::Fetcher for GhCrateMeta {
                 let client = self.client.clone();
                 AutoAbortJoinHandle::spawn(async move {
                     let url = url?;
-                    info!("Checking for package at: '{url}'");
+                    debug!("Checking for package at: '{url}'");
                     remote_exists(client, url.clone(), Method::HEAD)
                         .await
                         .map(|exists| (url.clone(), exists))
@@ -61,7 +61,7 @@ impl super::Fetcher for GhCrateMeta {
                     );
                 }
 
-                info!("Winning URL is {url}");
+                debug!("Winning URL is {url}");
                 self.url.set(url).unwrap(); // find() is called first
                 return Ok(true);
             }
@@ -72,7 +72,7 @@ impl super::Fetcher for GhCrateMeta {
 
     async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.url.get().unwrap(); // find() is called first
-        info!("Downloading package from: '{url}'");
+        debug!("Downloading package from: '{url}'");
         download_and_extract(&self.client, url, self.pkg_fmt(), dst).await
     }
 

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use compact_str::CompactString;
-use log::{debug, info};
+use log::debug;
 use reqwest::Client;
 use reqwest::Method;
 use tokio::task::JoinHandle;
@@ -36,13 +36,13 @@ impl super::Fetcher for QuickInstall {
     async fn find(&self) -> Result<bool, BinstallError> {
         let url = self.package_url();
         self.report();
-        info!("Checking for package at: '{url}'");
+        debug!("Checking for package at: '{url}'");
         remote_exists(self.client.clone(), Url::parse(&url)?, Method::HEAD).await
     }
 
     async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.package_url();
-        info!("Downloading package from: '{url}'");
+        debug!("Downloading package from: '{url}'");
         download_and_extract(&self.client, &Url::parse(&url)?, self.pkg_fmt(), dst).await
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ impl Termination for MainExit {
     fn report(self) -> ExitCode {
         match self {
             Self::Success(spent) => {
-                info!("Installation completed in {spent:?}");
+                info!("Done in {spent:?}");
                 ExitCode::SUCCESS
             }
             Self::Error(err) => err.report(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,23 +354,29 @@ async fn entry(jobserver_client: LazyJobserverClient) -> Result<()> {
     })?;
 
     // Remove installed crates
-    let crate_names = CrateName::dedup(crate_names).filter_map(|crate_name| {
-        if opts.force {
-            Some((crate_name, None))
-        } else if let Some(records) = &metadata {
-            if let Some(metadata) = records.get(&crate_name.name) {
-                if let Some(version_req) = &crate_name.version_req {
-                    if version_req.is_latest_compatible(&metadata.current_version) {
-                        info!(
-                            "package {crate_name} is already installed and cannot be upgraded, use --force to override"
-                        );
-                        None
+    let crate_names = CrateName::dedup(crate_names)
+        .filter_map(|crate_name| {
+            if opts.force {
+                Some((crate_name, None))
+            } else if let Some(records) = &metadata {
+                if let Some(metadata) = records.get(&crate_name.name) {
+                    if let Some(version_req) = &crate_name.version_req {
+                        if version_req.is_latest_compatible(&metadata.current_version) {
+                            info!(
+                                "{} v{} is already installed, use --force to override",
+                                crate_name.name, metadata.current_version
+                            );
+                            None
+                        } else {
+                            Some((crate_name, Some(metadata.current_version.clone())))
+                        }
                     } else {
+                        // we have to assume that the version req is *, and so that a remote
+                        // upgraded version could exist
                         Some((crate_name, Some(metadata.current_version.clone())))
                     }
                 } else {
-                    info!("package {crate_name} is already installed, use --force to override");
-                    None
+                    Some((crate_name, None))
                 }
             } else {
                 Some((crate_name, None))

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ struct Options {
     ///
     /// If duplicate names are provided, the last one (and their version requirement)
     /// is kept.
-    #[clap(help_heading = "Package selection", value_name = "crate[@version]")]
+    #[clap(
+        help_heading = "Package selection",
+        value_name = "crate[@version]",
+        required_unless_present_any = ["version", "help"],
+    )]
     crate_names: Vec<CrateName>,
 
     /// Package version to install.


### PR DESCRIPTION
Resolves #291.

Also improves errors a bit, e.g.

```console
$ cargo binstall cargo-watch@9
16:00:25 [INFO] Installing package: 'cargo-watch@=9'
16:00:26 [ERROR] Fatal error:

  × for crate cargo-watch
  ╰─▶ no version matching requirement '=9'
```