### PR TITLE
Support other git hosting services

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -60,14 +60,14 @@ For github, the `pkg-url` is set to
 "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"
 ```
 
-or 
+which does not overwrite different targets or versions when manually downloaded
+
+or
 
 ```rust
 "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
 ```
 
-- an archive named `{ name }-{ target }-v{ version }.{ archive-format }`
-  - so that this does not overwrite different targets or versions when manually downloaded
 - located at `{ repo }/releases/download/v{ version }/`
   - compatible with github tags / releases
 - containing a folder named `{ name }-{ target }-v{ version }`

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -66,7 +66,6 @@ For github, the `pkg-url` is set to
   - compatible with github tags / releases
 - containing a folder named `{ name }-{ target }-v{ version }`
   - so that prior binary files are not overwritten when manually executing `tar -xvf ...`
-- containing binary files in the form `{ bin }{ binary-ext }`
 
 If your package already uses this approach, you shouldn't need to set anything.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -75,7 +75,7 @@ or
 
 If your package already uses this approach, you shouldn't need to set anything.
 
-#### Gitlab
+#### GitLab
 
 For gitlab, the `pkg-url` is set to
 
@@ -89,7 +89,7 @@ This will attempt to find the release assets with `filepath` set to
 Note that this uses the [Permanent links to release assets](https://gitlab.kitware.com/help/user/project/releases/index#permanent-links-to-latest-release-assets) feature of gitlab, it requires you to
 create an asset as a link with a `filepath`, which can be set only using gitlab api as of the writing.
 
-#### bitbucket
+#### BitBucket
 
 For bitbucket, the `pkg-url` is set to
 
@@ -100,7 +100,7 @@ For bitbucket, the `pkg-url` is set to
 You basically just upload the binary into bitbucket downloads page of your project,
 with its name set to be `{ name }-{ target }-v{ version }.{ archive-format }`.
 
-#### source forge
+#### SourceForge
 
 For source forge, the `pkg-url` is set to
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,10 @@
 `binstall` works with existing CI-built binary outputs, with configuration via `[package.metadata.binstall]` keys in the relevant crate manifest.
 When configuring `binstall` you can test against a local manifest with `--manifest-path=PATH` argument to use the crate and manifest at the provided `PATH`, skipping crate discovery and download.
 
-To get started, add a `[package.metadata.binstall]` section to your `Cargo.toml`. As an example, the default configuration would be:
+To get started, check the [default](#Defaults) first, only add a `[package.metadata.binstall]` section
+to your `Cargo.toml` if the default does not work for you.
+
+As an example, the configuration would be like this:
 
 ```toml
 [package.metadata.binstall]
@@ -40,7 +43,22 @@ pkg-fmt = "zip"
 
 ### Defaults
 
-By default `binstall` is setup to work with github releases, and expects to find:
+By default, `binstall` will try all supported package format and would have `bin-dir` set to
+`"{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"` (where `bin` is the cargo binary name and
+`binary-ext` is `.exe` on windows and empty on other platforms).
+
+The default value for `pkg-url` will depend on the repository of the package.
+
+It is setup to work with github releases, gitlab releases, bitbucket downloads
+and source forge downloads.
+
+#### Github
+
+For github, the `pkg-url` is set to
+
+```rust
+"{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"
+```
 
 - an archive named `{ name }-{ target }-v{ version }.{ archive-format }`
   - so that this does not overwrite different targets or versions when manually downloaded
@@ -48,9 +66,50 @@ By default `binstall` is setup to work with github releases, and expects to find
   - compatible with github tags / releases
 - containing a folder named `{ name }-{ target }-v{ version }`
   - so that prior binary files are not overwritten when manually executing `tar -xvf ...`
-- containing binary files in the form `{ bin }{ binary-ext }` (where `bin` is the cargo binary name and `binary-ext` is `.exe` on windows and empty on other platforms)
+- containing binary files in the form `{ bin }{ binary-ext }`
 
 If your package already uses this approach, you shouldn't need to set anything.
+
+#### Gitlab
+
+For gitlab, the `pkg-url` is set to
+
+```rust
+"{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"
+```
+
+This will attempt to find the release assets with `filepath` set to
+`binaries/{ name }-{ target }.{ archive-format }`
+
+Note that this uses the [Permanent links to release assets](https://gitlab.kitware.com/help/user/project/releases/index#permanent-links-to-latest-release-assets) feature of gitlab, it requires you to
+create an asset as a link with a `filepath`, which can be set only using gitlab api as of the writing.
+
+#### bitbucket
+
+For bitbucket, the `pkg-url` is set to
+
+```rust
+"{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"
+```
+
+You basically just upload the binary into bitbucket downloads page of your project,
+with its name set to be `{ name }-{ target }-v{ version }.{ archive-format }`.
+
+#### source forge
+
+For source forge, the `pkg-url` is set to
+
+```rust
+"{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"
+```
+
+You just need to upload the binary to the file page of your project, under the directory
+`binaries/v{ version }` with the filename `{ name }-{ target }.{ archive-format }`.
+
+#### Others
+
+For all other situations, `binstall` does not provide a default `pkg-url` and you need to manually
+specify it.
 
 ### QuickInstall
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -68,7 +68,7 @@ For github, the `pkg-url` is set to
 ]
 ```
 
-The first version does not overwrite different targets or versions when manually downloaded.
+The first 3 versions does not overwrite different targets or versions when manually downloaded.
 
 All `pkg-url` templates download binaries located at `{ repo }/releases/download/v{ version }/`, which
 is compatible with github tags / releases.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -84,6 +84,12 @@ For gitlab, the `pkg-url` is set to
 "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"
 ```
 
+or
+
+```rust
+"{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }-v{ version }.{ archive-format }"
+```
+
 This will attempt to find the release assets with `filepath` set to
 `binaries/{ name }-{ target }.{ archive-format }`
 
@@ -107,6 +113,12 @@ For source forge, the `pkg-url` is set to
 
 ```rust
 "{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"
+```
+
+or
+
+```rust
+"{ repo }/files/binaries/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }/download"
 ```
 
 To setup the package for binstall, upload the binary to the file page of your project,

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -47,6 +47,9 @@ By default, `binstall` will try all supported package format and would have `bin
 `"{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"` (where `bin` is the cargo binary name and
 `binary-ext` is `.exe` on windows and empty on other platforms).
 
+All binaries must contain a folder named `{ name }-{ target }-v{ version }` (so that prior binary
+files are not overwritten when manually executing `tar -xvf ...`).
+
 The default value for `pkg-url` will depend on the repository of the package.
 
 It is setup to work with github releases, gitlab releases, bitbucket downloads
@@ -68,10 +71,8 @@ or
 "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
 ```
 
-- located at `{ repo }/releases/download/v{ version }/`
-  - compatible with github tags / releases
-- containing a folder named `{ name }-{ target }-v{ version }`
-  - so that prior binary files are not overwritten when manually executing `tar -xvf ...`
+Both `pkg-url` template download binaries located at `{ repo }/releases/download/v{ version }/`, which
+is compatible with github tags / releases.
 
 If your package already uses this approach, you shouldn't need to set anything.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -97,7 +97,7 @@ For bitbucket, the `pkg-url` is set to
 "{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"
 ```
 
-You basically just upload the binary into bitbucket downloads page of your project,
+To setup the package for binstall, upload the binary into bitbucket downloads page of your project,
 with its name set to be `{ name }-{ target }-v{ version }.{ archive-format }`.
 
 #### SourceForge
@@ -108,8 +108,8 @@ For source forge, the `pkg-url` is set to
 "{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"
 ```
 
-You just need to upload the binary to the file page of your project, under the directory
-`binaries/v{ version }` with the filename `{ name }-{ target }.{ archive-format }`.
+To setup the package for binstall, upload the binary to the file page of your project,
+under the directory `binaries/v{ version }` with the filename `{ name }-{ target }.{ archive-format }`.
 
 #### Others
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -60,18 +60,17 @@ and source forge downloads.
 For github, the `pkg-url` is set to
 
 ```rust
-"{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"
+[
+    "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }",
+    "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }",
+    "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.{ archive-format }",
+    "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }",
+]
 ```
 
-which does not overwrite different targets or versions when manually downloaded
+The first version does not overwrite different targets or versions when manually downloaded.
 
-or
-
-```rust
-"{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
-```
-
-Both `pkg-url` template download binaries located at `{ repo }/releases/download/v{ version }/`, which
+All `pkg-url` templates download binaries located at `{ repo }/releases/download/v{ version }/`, which
 is compatible with github tags / releases.
 
 If your package already uses this approach, you shouldn't need to set anything.
@@ -81,13 +80,12 @@ If your package already uses this approach, you shouldn't need to set anything.
 For gitlab, the `pkg-url` is set to
 
 ```rust
-"{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"
-```
-
-or
-
-```rust
-"{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }-v{ version }.{ archive-format }"
+[
+    "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }-v{ version }.{ archive-format }",
+    "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-v{ version }-{ target }.{ archive-format }",
+    "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ version }-{ target }.{ archive-format }",
+    "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }",
+]
 ```
 
 This will attempt to find the release assets with `filepath` set to
@@ -101,7 +99,11 @@ create an asset as a link with a `filepath`, which can be set only using gitlab 
 For bitbucket, the `pkg-url` is set to
 
 ```rust
-"{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"
+[
+    "{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }",
+    "{ repo }/downloads/{ name }-v{ version }-{ target }.{ archive-format }",
+    "{ repo }/downloads/{ name }-{ version }-{ target }.{ archive-format }",
+]
 ```
 
 To setup the package for binstall, upload the binary into bitbucket downloads page of your project,
@@ -112,13 +114,12 @@ with its name set to be `{ name }-{ target }-v{ version }.{ archive-format }`.
 For source forge, the `pkg-url` is set to
 
 ```rust
-"{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"
-```
-
-or
-
-```rust
-"{ repo }/files/binaries/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }/download"
+[
+    "{ repo }/files/binaries/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }/download",
+    "{ repo }/files/binaries/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }/download",
+    "{ repo }/files/binaries/v{ version }/{ name }-{ version }-{ target }.{ archive-format }/download",
+    "{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download",
+]
 ```
 
 To setup the package for binstall, upload the binary to the file page of your project,

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -60,6 +60,12 @@ For github, the `pkg-url` is set to
 "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"
 ```
 
+or 
+
+```rust
+"{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+```
+
 - an archive named `{ name }-{ target }-v{ version }.{ archive-format }`
   - so that this does not overwrite different targets or versions when manually downloaded
 - located at `{ repo }/releases/download/v{ version }/`

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 license = "GPL-3.0"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
 bin-dir = "{ bin }{ binary-ext }"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]

--- a/crates/lib/src/fetchers/gh_crate_meta.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta.rs
@@ -17,6 +17,8 @@ use crate::{
 
 use super::Data;
 
+mod hosting;
+
 pub struct GhCrateMeta {
     client: Client,
     data: Arc<Data>,

--- a/crates/lib/src/fetchers/gh_crate_meta.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta.rs
@@ -114,13 +114,14 @@ impl super::Fetcher for GhCrateMeta {
         };
 
         let repo = repo.as_ref().map(Url::as_str);
+        let launch_baseline_find_tasks =
+            |pkg_fmt| self.launch_baseline_find_tasks(pkg_fmt, pkg_url, repo);
 
         let handles: Vec<_> = if let Some(pkg_fmt) = self.data.meta.pkg_fmt {
-            self.launch_baseline_find_tasks(pkg_fmt, pkg_url, repo)
-                .collect()
+            launch_baseline_find_tasks(pkg_fmt).collect()
         } else {
             PkgFmt::iter()
-                .flat_map(|pkg_fmt| self.launch_baseline_find_tasks(pkg_fmt, pkg_url, repo))
+                .flat_map(launch_baseline_find_tasks)
                 .collect()
         };
 

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -23,14 +23,15 @@ impl GitHostingServices {
         }
     }
 
-    pub fn get_default_pkg_url_template(self) -> Option<&'static str> {
+    pub fn get_default_pkg_url_template(self) -> Option<&'static [&'static str]> {
         use GitHostingServices::*;
 
         match self {
-            GitHub => Some("{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"),
-            GitLab => Some("{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"),
-            BitBucket => Some("{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"),
-            SourceForge => Some("{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"),
+            GitHub => Some(&[
+                "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"]),
+            GitLab => Some(&["{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"]),
+            BitBucket => Some(&["{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"]),
+            SourceForge => Some(&["{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"]),
             Unknown  => None,
         }
     }

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -11,12 +11,10 @@ pub enum GitHostingServices {
     Unknown,
 }
 impl GitHostingServices {
-    pub fn guess_git_hosting_services(repo: &str) -> Result<Self, BinstallError> {
+    pub fn guess_git_hosting_services(repo: &Url) -> Result<Self, BinstallError> {
         use GitHostingServices::*;
 
-        let url = Url::parse(repo)?;
-
-        match url.domain() {
+        match repo.domain() {
             Some(domain) if domain.starts_with("github") => Ok(GitHub),
             Some(domain) if domain.starts_with("gitlab") => Ok(GitLab),
             Some(domain) if domain == "bitbucket.org" => Ok(BitBucket),

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -31,9 +31,15 @@ impl GitHostingServices {
                 "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }",
                 "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }",
             ]),
-            GitLab => Some(&["{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"]),
+            GitLab => Some(&[
+                "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }-v{ version }.{ archive-format }",
+                "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }",
+            ]),
             BitBucket => Some(&["{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"]),
-            SourceForge => Some(&["{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"]),
+            SourceForge => Some(&[
+                "{ repo }/files/binaries/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }/download",
+                "{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download",
+            ]),
             Unknown  => None,
         }
     }

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -11,6 +11,20 @@ pub enum GitHostingServices {
     Unknown,
 }
 impl GitHostingServices {
+    pub fn guess_git_hosting_services(repo: &str) -> Result<Self, BinstallError> {
+        use GitHostingServices::*;
+
+        let url = Url::parse(repo)?;
+
+        match url.domain() {
+            Some(domain) if domain.starts_with("github") => Ok(GitHub),
+            Some(domain) if domain.starts_with("gitlab") => Ok(GitLab),
+            Some(domain) if domain == "bitbucket.org" => Ok(BitBucket),
+            Some(domain) if domain == "sourceforge.net" => Ok(SourceForge),
+            _ => Ok(Unknown),
+        }
+    }
+
     pub fn get_default_pkg_url_template(self) -> Option<&'static str> {
         use GitHostingServices::*;
 
@@ -21,17 +35,5 @@ impl GitHostingServices {
             SourceForge => Some("{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"),
             Unknown  => None,
         }
-    }
-}
-
-pub fn guess_git_hosting_services(repo: &str) -> Result<GitHostingServices, BinstallError> {
-    let url = Url::parse(repo)?;
-
-    match url.domain() {
-        Some(domain) if domain.starts_with("github") => Ok(GitHostingServices::GitHub),
-        Some(domain) if domain.starts_with("gitlab") => Ok(GitHostingServices::GitLab),
-        Some(domain) if domain == "bitbucket.org" => Ok(GitHostingServices::BitBucket),
-        Some(domain) if domain == "sourceforge.net" => Ok(GitHostingServices::SourceForge),
-        _ => Ok(GitHostingServices::Unknown),
     }
 }

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -28,7 +28,9 @@ impl GitHostingServices {
 
         match self {
             GitHub => Some(&[
-                "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"]),
+                "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }",
+                "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }",
+            ]),
             GitLab => Some(&["{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"]),
             BitBucket => Some(&["{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"]),
             SourceForge => Some(&["{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"]),

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -29,15 +29,25 @@ impl GitHostingServices {
         match self {
             GitHub => Some(&[
                 "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }",
+                "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }",
+                "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.{ archive-format }",
                 "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }",
             ]),
             GitLab => Some(&[
                 "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }-v{ version }.{ archive-format }",
+                "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-v{ version }-{ target }.{ archive-format }",
+                "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ version }-{ target }.{ archive-format }",
                 "{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }",
             ]),
-            BitBucket => Some(&["{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"]),
+            BitBucket => Some(&[
+                "{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }",
+                "{ repo }/downloads/{ name }-v{ version }-{ target }.{ archive-format }",
+                "{ repo }/downloads/{ name }-{ version }-{ target }.{ archive-format }",
+            ]),
             SourceForge => Some(&[
                 "{ repo }/files/binaries/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }/download",
+                "{ repo }/files/binaries/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }/download",
+                "{ repo }/files/binaries/v{ version }/{ name }-{ version }-{ target }.{ archive-format }/download",
                 "{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download",
             ]),
             Unknown  => None,

--- a/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta/hosting.rs
@@ -1,0 +1,37 @@
+use url::Url;
+
+use crate::errors::BinstallError;
+
+#[derive(Copy, Clone, Debug)]
+pub enum GitHostingServices {
+    GitHub,
+    GitLab,
+    BitBucket,
+    SourceForge,
+    Unknown,
+}
+impl GitHostingServices {
+    pub fn get_default_pkg_url_template(self) -> Option<&'static str> {
+        use GitHostingServices::*;
+
+        match self {
+            GitHub => Some("{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"),
+            GitLab => Some("{ repo }/-/releases/v{ version }/downloads/binaries/{ name }-{ target }.{ archive-format }"),
+            BitBucket => Some("{ repo }/downloads/{ name }-{ target }-v{ version }.{ archive-format }"),
+            SourceForge => Some("{ repo }/files/binaries/v{ version }/{ name }-{ target }.{ archive-format }/download"),
+            Unknown  => None,
+        }
+    }
+}
+
+pub fn guess_git_hosting_services(repo: &str) -> Result<GitHostingServices, BinstallError> {
+    let url = Url::parse(repo)?;
+
+    match url.domain() {
+        Some(domain) if domain.starts_with("github") => Ok(GitHostingServices::GitHub),
+        Some(domain) if domain.starts_with("gitlab") => Ok(GitHostingServices::GitLab),
+        Some(domain) if domain == "bitbucket.org" => Ok(GitHostingServices::BitBucket),
+        Some(domain) if domain == "sourceforge.net" => Ok(GitHostingServices::SourceForge),
+        _ => Ok(GitHostingServices::Unknown),
+    }
+}

--- a/crates/lib/src/helpers/remote.rs
+++ b/crates/lib/src/helpers/remote.rs
@@ -42,6 +42,19 @@ pub async fn remote_exists(
     Ok(req.status().is_success())
 }
 
+pub async fn get_redirected_final_url(client: &Client, url: Url) -> Result<Url, BinstallError> {
+    let method = Method::HEAD;
+
+    let req = client
+        .request(method.clone(), url.clone())
+        .send()
+        .await
+        .and_then(Response::error_for_status)
+        .map_err(|err| BinstallError::Http { method, url, err })?;
+
+    Ok(req.url().clone())
+}
+
 pub(crate) async fn create_request(
     client: &Client,
     url: Url,

--- a/crates/lib/src/manifests/cargo_toml_binstall.rs
+++ b/crates/lib/src/manifests/cargo_toml_binstall.rs
@@ -11,10 +11,6 @@ pub use package_formats::*;
 
 mod package_formats;
 
-/// Default package path template (may be overridden in package Cargo.toml)
-pub const DEFAULT_PKG_URL: &str =
-    "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }";
-
 /// Default binary name template (may be overridden in package Cargo.toml)
 pub const DEFAULT_BIN_DIR: &str = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }";
 
@@ -34,7 +30,7 @@ pub struct Meta {
 #[serde(rename_all = "kebab-case", default)]
 pub struct PkgMeta {
     /// URL template for package downloads
-    pub pkg_url: String,
+    pub pkg_url: Option<String>,
 
     /// Format for package downloads
     pub pkg_fmt: Option<PkgFmt>,
@@ -52,7 +48,7 @@ pub struct PkgMeta {
 impl Default for PkgMeta {
     fn default() -> Self {
         Self {
-            pkg_url: DEFAULT_PKG_URL.to_string(),
+            pkg_url: None,
             pkg_fmt: None,
             bin_dir: DEFAULT_BIN_DIR.to_string(),
             pub_key: None,
@@ -75,7 +71,7 @@ impl PkgMeta {
     /// Merge configuration overrides into object
     pub fn merge(&mut self, pkg_override: &PkgOverride) {
         if let Some(o) = &pkg_override.pkg_url {
-            self.pkg_url = o.clone();
+            self.pkg_url = Some(o.clone());
         }
         if let Some(o) = &pkg_override.pkg_fmt {
             self.pkg_fmt = Some(*o);

--- a/crates/lib/tests/parse-meta.rs
+++ b/crates/lib/tests/parse-meta.rs
@@ -15,7 +15,7 @@ fn parse_meta() {
     assert_eq!(&package.name, "cargo-binstall-test");
 
     assert_eq!(
-        &meta.pkg_url,
+        meta.pkg_url.as_deref().unwrap(),
         "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
     );
 


### PR DESCRIPTION
Resolved #296 

# TODO
 - [x] Update `support.md`/`README.md`
 - [x] Supports url like `www.github.com` by applying redirect before guessing the git hosting services
 - [x] ~~Support git.sr.ht (https://github.com/cargo-bins/cargo-binstall/issues/124#issuecomment-1224297964)~~ SourceHut requires payment for creating a repo on it, so I will skip it for now. 
 - [ ] Add testing