### PR TITLE
Optimize `drivers::crates_io::Vfs`: Use `BTreeMap`

### DIFF
--- a/crates/lib/src/drivers/crates_io/vfs.rs
+++ b/crates/lib/src/drivers/crates_io/vfs.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::HashMap, hash_set::HashSet},
+    collections::{hash_set::HashSet, BTreeMap},
     io,
     path::Path,
 };
@@ -10,14 +10,10 @@ use normalize_path::NormalizePath;
 /// This type stores the filesystem structure for the crate tarball
 /// extracted in memory and can be passed to
 /// `cargo_toml::Manifest::complete_from_abstract_filesystem`.
-#[derive(Debug)]
-pub(super) struct Vfs(HashMap<Box<Path>, HashSet<Box<str>>>);
+#[derive(Debug, Default)]
+pub(super) struct Vfs(BTreeMap<Box<Path>, HashSet<Box<str>>>);
 
 impl Vfs {
-    pub(super) fn new() -> Self {
-        Self(HashMap::with_capacity(16))
-    }
-
     /// * `path` - must be canonical, must not be empty.
     pub(super) fn add_path(&mut self, mut path: &Path) {
         while let Some(parent) = path.parent() {

--- a/crates/lib/src/drivers/crates_io/visitor.rs
+++ b/crates/lib/src/drivers/crates_io/visitor.rs
@@ -29,7 +29,7 @@ impl ManifestVisitor {
             // Cargo.toml is quite large usually.
             cargo_toml_content: Vec::with_capacity(2000),
             manifest_dir_path,
-            vfs: Vfs::new(),
+            vfs: Vfs::default(),
         }
     }
 }


### PR DESCRIPTION
instead of `HashMap`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>