### PR TITLE
Improve release-pr usage

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,19 +17,22 @@ on:
         description: Version to release
         required: true
         type: string
+        default: patch
 
 jobs:
   make-release-pr:
+    permissions:
+      id-token: write # Enable OIDC
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: chainguard-dev/actions/setup-gitsign@main
       - name: Install cargo-release
         uses: taiki-e/install-action@v1
         with:
           tool: cargo-release
-
-      - uses: actions/checkout@v3
-        with:
-          ref: main
 
       - uses: cargo-bins/release-pr@v1
         with:


### PR DESCRIPTION
This is stuff I've learned/done over at watchexec:

- Enable commit signing with [gitsign](https://github.com/sigstore/gitsign)
- Use the short form of the checkout and do it first
- Default the version field to `patch` (less typing!)