### PR TITLE
Disable zlib-ng for the default cargo-install build

### DIFF
--- a/.github/scripts/compile-settings.jq
+++ b/.github/scripts/compile-settings.jq
@@ -4,7 +4,7 @@ if $for_release then {
   # Use build-std to build a std library optimized for size and abort immediately on abort,
   # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
   args: ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"),
-  features: ($matrix.release_features // []),
+  features: ($matrix.release_features // ["zlib-ng", "static", "rustls", "trust-dns", "fancy-no-backtrace"]),
 } else {
   output: "debug",
   profile: "dev",

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.20.1", features = ["rt-multi-thread"], default-features =
 embed-resource = "1.7.3"
 
 [features]
-default = ["static", "zlib-ng", "rustls", "trust-dns", "fancy-no-backtrace"]
+default = ["static", "rustls", "trust-dns", "fancy-no-backtrace"]
 
 mimalloc = ["dep:mimalloc"]
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -65,7 +65,7 @@ zstd = { version = "0.10.0", default-features = false }
 env_logger = "0.9.0"
 
 [features]
-default = ["static", "zlib-ng", "rustls"]
+default = ["static", "rustls"]
 
 static = ["bzip2/static", "xz2/static"]
 pkg-config = ["zstd/pkg-config"]


### PR DESCRIPTION
but explicitly enable it in our own builds.

This is because using zlib-ng sometimes does not compile easily on Windows, and using the pure miniz_oxide offers a better install story from source.

For our binary builds, we can provide the optimal performance, and still do that for most users as they will update with cargo-binstall, getting our build as a second pass.