### PR TITLE
Use fork `binstall-zip` here for new features & updated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "binstall-tar",
+ "binstall-zip",
  "bytes",
  "bzip2",
  "cargo_toml",
@@ -117,7 +118,6 @@ dependencies = [
  "trust-dns-resolver",
  "url",
  "xz2",
- "zip",
  "zstd",
 ]
 
@@ -130,6 +130,20 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "binstall-zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5eddcdebe8fe727d81b47734b3302ffa49a6fe50376fe6c52c609198c0709e5"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "zstd",
 ]
 
 [[package]]
@@ -2437,33 +2451,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "zstd",
-]
-
-[[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2471,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -52,18 +52,22 @@ trust-dns-resolver = { version = "0.21.2", optional = true, default-features = f
 url = { version = "2.2.2", features = ["serde"] }
 xz2 = "0.1.7"
 
+# Use a fork here since upstream has not published a new release for a long time
+# while many of its dependencies are updated.
+# Also becasue we need streaming extraction.
+#
 # Disable all features of zip except for features of compression algorithms:
 # Disabled features include:
 #  - aes-crypto: Enables decryption of files which were encrypted with AES, absolutely zero use for
 #    this crate.
 #  - time: Enables features using the [time](https://github.com/time-rs/time) crate,
 #    which is not used by this crate.
-zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2", "zstd"] }
+zip = { package = "binstall-zip", version = "0.6.3", default-features = false, features = ["deflate", "bzip2", "zstd"] }
 
 # zstd is also depended by zip.
-# Since zip 0.6.2 depends on zstd 0.10.0, we also have to use 0.10.0 here,
+# Since zip 0.6.3 depends on zstd 0.11, we also have to use 0.11 here,
 # otherwise there will be a link conflict.
-zstd = { version = "0.10.0", default-features = false }
+zstd = { version = "0.11.2", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/crates/binstalk/src/helpers/download/extracter.rs
+++ b/crates/binstalk/src/helpers/download/extracter.rs
@@ -1,18 +1,12 @@
-use std::{
-    fs::File,
-    io::{self, BufRead, Read},
-    path::Path,
-};
+use std::io::{self, BufRead, Read};
 
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
-use log::debug;
 use tar::Archive;
 use xz2::bufread::XzDecoder;
-use zip::read::ZipArchive;
 use zstd::stream::Decoder as ZstdDecoder;
 
-use crate::{errors::BinstallError, manifests::cargo_toml_binstall::TarBasedFmt};
+use crate::manifests::cargo_toml_binstall::TarBasedFmt;
 
 pub fn create_tar_decoder(
     dat: impl BufRead + 'static,
@@ -34,13 +28,4 @@ pub fn create_tar_decoder(
     };
 
     Ok(Archive::new(r))
-}
-
-pub fn unzip(dat: File, dst: &Path) -> Result<(), BinstallError> {
-    debug!("Decompressing from zip archive to `{dst:?}`");
-
-    let mut zip = ZipArchive::new(dat)?;
-    zip.extract(dst)?;
-
-    Ok(())
 }


### PR DESCRIPTION
Also:
 - update dep zstd
 - [Use zip::read::stream::ZipStreamReader in extract_zip](https://github.com/cargo-bins/cargo-binstall/pull/374/commits/0e93b66feebd802b2741ef42c3e901fc868e787f)

Replace PR #362 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>