### PR TITLE
fix: `pkg-fmt` parsing should be case insensitive

### DIFF
--- a/crates/binstalk/src/manifests/cargo_toml_binstall/package_formats.rs
+++ b/crates/binstalk/src/manifests/cargo_toml_binstall/package_formats.rs
@@ -6,6 +6,7 @@ use strum_macros::{Display, EnumIter, EnumString};
     Debug, Display, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, EnumString, EnumIter,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(ascii_case_insensitive)]
 pub enum PkgFmt {
     /// Download format is TAR (uncompressed)
     Tar,


### PR DESCRIPTION
Fixes: #377

Before;

```shell
❯ cargo run fnm --no-symlinks --pkg-url="https://github.com/Schniz/fnm/releases/download/v1.31.1/fnm-linux.zip" --pkg-fmt zip --bin-dir "{ bin }" --install-path /tmp/foo
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `/home/user/playground/cargo-binstall/target/debug/cargo-binstall fnm --no-symlinks '--pkg-url=https://github.com/Schniz/fnm/releases/download/v1.31.1/fnm-linux.zip' --pkg-fmt zip --bin-dir '{ bin }' --install-path /tmp/foo`
error: Invalid value "zip" for '--pkg-fmt <PKG_FMT>': Matching variant not found

For more information try --help
```

After:

```shell
❯ cargo run fnm --no-symlinks --pkg-url="https://github.com/Schniz/fnm/releases/download/v1.31.1/fnm-linux.zip" --pkg-fmt zip --bin-dir "{ bin }" --install-path /tmp/foo
   Compiling binstalk v0.1.0 (/home/user/playground/cargo-binstall/crates/binstalk)
   Compiling cargo-binstall v0.13.0 (/home/user/playground/cargo-binstall/crates/bin)
    Finished dev [unoptimized + debuginfo] target(s) in 5.45s
     Running `/home/user/playground/cargo-binstall/target/debug/cargo-binstall fnm --no-symlinks '--pkg-url=https://github.com/Schniz/fnm/releases/download/v1.31.1/fnm-linux.zip' --pkg-fmt zip --bin-dir '{ bin }' --install-path /tmp/foo`
02:07:27 [INFO] Resolving package: 'fnm'
02:07:30 [INFO] The package will be downloaded from github.com
02:07:30 [INFO] This will install the following binaries:
02:07:30 [INFO]   - fnm (fnm -> /tmp/foo/fnm-v1.31.1)
Do you wish to continue? yes/[no]
? ^C02:07:30 [WARN] Installation cancelled
```