### PR TITLE
Support `--roots`

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -144,6 +144,17 @@ pub struct Args {
     #[clap(help_heading = "Options", long)]
     pub install_path: Option<PathBuf>,
 
+    /// Install binaries with a custom cargo root.
+    ///
+    /// By default, we use `$CARGO_INSTALL_ROOT` or `$CARGO_HOME` as the
+    /// cargo root and global metadata files are updated with the
+    /// package information.
+    ///
+    /// Specifying another path here would install the binaries and update
+    /// the metadata files inside the path you specified.
+    #[clap(help_heading = "Options", long)]
+    pub roots: Option<PathBuf>,
+
     /// Deprecated, here for back-compat only. Secure is now on by default.
     #[clap(hide(true), long)]
     pub secure: bool,

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -152,6 +152,8 @@ pub struct Args {
     ///
     /// Specifying another path here would install the binaries and update
     /// the metadata files inside the path you specified.
+    ///
+    /// NOTE that `--install-path` takes precedence over this option.
     #[clap(help_heading = "Options", long)]
     pub roots: Option<PathBuf>,
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -41,10 +41,17 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     // Initialize UI thread
     let mut uithread = UIThread::new(!args.no_confirm);
 
-    let (install_path, metadata, temp_dir) = block_in_place(|| -> Result<_> {
+    let (install_path, cargo_roots, metadata, temp_dir) = block_in_place(|| -> Result<_> {
+        // Compute cargo_roots
+        let cargo_roots =
+            install_path::get_cargo_roots_path(args.roots.take()).ok_or_else(|| {
+                error!("No viable cargo roots path found of specified, try `--roots`");
+                miette!("No cargo roots path found or specified")
+            })?;
+
         // Compute install directory
         let (install_path, custom_install_path) =
-            install_path::get_install_path(args.install_path.as_deref(), args.roots.as_deref());
+            install_path::get_install_path(args.install_path.as_deref(), Some(&cargo_roots));
         let install_path = install_path.ok_or_else(|| {
             error!("No viable install path found of specified, try `--install-path`");
             miette!("No install path found or specified")
@@ -71,7 +78,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
             .map_err(BinstallError::from)
             .wrap_err("Creating a temporary directory failed.")?;
 
-        Ok((install_path, metadata, temp_dir))
+        Ok((install_path, cargo_roots, metadata, temp_dir))
     })?;
 
     // Remove installed crates

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -44,7 +44,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     let (install_path, metadata, temp_dir) = block_in_place(|| -> Result<_> {
         // Compute install directory
         let (install_path, custom_install_path) =
-            install_path::get_install_path(args.install_path.as_deref());
+            install_path::get_install_path(args.install_path.as_deref(), args.roots.as_deref());
         let install_path = install_path.ok_or_else(|| {
             error!("No viable install path found of specified, try `--install-path`");
             miette!("No install path found or specified")

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -28,7 +28,7 @@ pub fn get_install_path<P: AsRef<Path>>(
     if let Some(p) = var_os("CARGO_INSTALL_ROOT") {
         let p = PathBuf::from(p);
         debug!("using CARGO_INSTALL_ROOT ({})", p.display());
-        return (Some(Arc::from(p.join("bin"))), true);
+        return (Some(Arc::from(p.join("bin"))), false);
     }
 
     if let Ok(p) = cargo_home() {

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use binstalk::helpers::statics::cargo_home;
+use binstalk::home::cargo_home;
 use log::debug;
 
 pub fn get_cargo_roots_path(cargo_roots: Option<PathBuf>) -> Option<PathBuf> {

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -10,10 +10,17 @@ use log::debug;
 /// roughly follows <https://doc.rust-lang.org/cargo/commands/cargo-install.html#description>
 ///
 /// Return (install_path, is_custom_install_path)
-pub fn get_install_path<P: AsRef<Path>>(install_path: Option<P>) -> (Option<Arc<Path>>, bool) {
+pub fn get_install_path<P: AsRef<Path>>(
+    install_path: Option<P>,
+    cargo_roots: Option<P>,
+) -> (Option<Arc<Path>>, bool) {
     // Command line override first first
     if let Some(p) = install_path {
         return (Some(Arc::from(p.as_ref())), true);
+    }
+
+    if let Some(p) = cargo_roots {
+        return (Some(Arc::from(p.as_ref())), false);
     }
 
     // Environmental variables

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -16,12 +16,12 @@ pub fn get_cargo_roots_path(cargo_roots: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(p) = var_os("CARGO_INSTALL_ROOT") {
         let p = PathBuf::from(p);
         debug!("using CARGO_INSTALL_ROOT ({})", p.display());
-        return Some(p.join("bin"));
+        return Some(p);
     }
 
     if let Ok(p) = cargo_home() {
         debug!("using ({}) as cargo home", p.display());
-        Some(p.join("bin"))
+        Some(p)
     } else {
         None
     }

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -1,4 +1,5 @@
 use std::{
+    env::var_os,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -24,10 +25,10 @@ pub fn get_install_path<P: AsRef<Path>>(
     }
 
     // Environmental variables
-    if let Ok(p) = std::env::var("CARGO_INSTALL_ROOT") {
-        debug!("using CARGO_INSTALL_ROOT ({p})");
-        let b = PathBuf::from(p);
-        return (Some(Arc::from(b.join("bin"))), true);
+    if let Some(p) = var_os("CARGO_INSTALL_ROOT") {
+        let p = PathBuf::from(p);
+        debug!("using CARGO_INSTALL_ROOT ({})", p.display());
+        return (Some(Arc::from(p.join("bin"))), true);
     }
 
     if let Ok(p) = cargo_home() {

--- a/crates/binstalk/src/helpers/statics.rs
+++ b/crates/binstalk/src/helpers/statics.rs
@@ -1,19 +1,5 @@
-use std::{
-    io::Error,
-    ops::Deref,
-    path::{Path, PathBuf},
-};
-
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
 use url::Url;
-
-pub fn cargo_home() -> Result<&'static Path, Error> {
-    static CARGO_HOME: OnceCell<PathBuf> = OnceCell::new();
-
-    CARGO_HOME
-        .get_or_try_init(home::cargo_home)
-        .map(Deref::deref)
-}
 
 pub fn cratesio_url() -> &'static Url {
     static CRATESIO: Lazy<Url, fn() -> Url> =

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -8,3 +8,4 @@ pub mod manifests;
 pub mod ops;
 
 pub use detect_targets::{get_desired_targets, DesiredTargets};
+pub use home;

--- a/crates/binstalk/src/manifests/binstall_crates_v1.rs
+++ b/crates/binstalk/src/manifests/binstall_crates_v1.rs
@@ -15,11 +15,12 @@ use std::{
 };
 
 use fs_lock::FileLock;
+use home::cargo_home;
 use miette::Diagnostic;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::{fs::create_if_not_exist, helpers::statics::cargo_home};
+use crate::fs::create_if_not_exist;
 
 use super::crate_info::CrateInfo;
 

--- a/crates/binstalk/src/manifests/cargo_crates_v1.rs
+++ b/crates/binstalk/src/manifests/cargo_crates_v1.rs
@@ -17,11 +17,12 @@ use std::{
 
 use compact_str::CompactString;
 use fs_lock::FileLock;
+use home::cargo_home;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{fs::create_if_not_exist, helpers::statics::cargo_home};
+use crate::fs::create_if_not_exist;
 
 use super::crate_info::CrateInfo;
 


### PR DESCRIPTION
Fixed #388 

This PR:
 - Add `--roots` cmdline option
 - Use `env::var_os` to fetch env `CARGO_INSTALL_ROOTS`
 - [Update manifest if `CARGO_INSTALL_ROOT` is specified](https://github.com/cargo-bins/cargo-binstall/commit/b8412d4a0efcbfeb350f229c1655b9abb72879d7)
 - [Fix updating manifest: Use `cargo_roots` instead of default path](https://github.com/cargo-bins/cargo-binstall/commit/17b9f3b9354959a8df4794565c6d39f8c5960241)
 - [Rm helpers::statics::cargo_home](https://github.com/cargo-bins/cargo-binstall/commit/33dd0b66bca4f2e1475175c206c6d15b0bbd320e) since it is no longer used

I've tested this PR locally by specifing `--roots /tmp/a` and installed crates `cargo-binstall` and `cargo-nextest` which are already installed in `$HOME/.cargo`.
`cargo-binstall` installs these two binaries to `/tmp/a/bin/` and also updates manifest in `/tmp/a`.

Running the command again, `cargo-binstall` skipped installations for them as expected.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>