### PR TITLE
Add new feature log_release_max_level_debug and enable it on CI release build

### DIFF
--- a/.github/scripts/compile-settings.jq
+++ b/.github/scripts/compile-settings.jq
@@ -4,7 +4,7 @@ if $for_release then {
   # Use build-std to build a std library optimized for size and abort immediately on abort,
   # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
   args: ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"),
-  features: ($matrix.release_features // ["zlib-ng", "static", "rustls", "trust-dns", "fancy-no-backtrace"]),
+  features: ($matrix.release_features // ["zlib-ng", "static", "rustls", "trust-dns", "fancy-no-backtrace", "log_release_max_level_debug"]),
 } else {
   output: "debug",
   profile: "dev",

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -56,3 +56,4 @@ fancy-no-backtrace = ["miette/fancy-no-backtrace"]
 fancy-with-backtrace = ["fancy-no-backtrace", "miette/fancy"]
 
 log_release_max_level_info = ["log/release_max_level_info"]
+log_release_max_level_debug = ["log/release_max_level_debug"]

--- a/crates/bin/src/ui.rs
+++ b/crates/bin/src/ui.rs
@@ -4,27 +4,13 @@ use std::{
     thread,
 };
 
-use log::LevelFilter;
+use log::{LevelFilter, STATIC_MAX_LEVEL};
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
 use tokio::sync::mpsc;
 
 use binstalk::errors::BinstallError;
 
 use crate::args::Args;
-
-const IS_RELEASE_BUILD: bool = !cfg!(debug_assertions);
-
-const MAX_LOG_LEVEL: LevelFilter = if IS_RELEASE_BUILD {
-    if cfg!(feature = "log_release_max_level_info") {
-        LevelFilter::Info
-    } else if cfg!(feature = "log_release_max_level_debug") {
-        LevelFilter::Debug
-    } else {
-        LevelFilter::Trace
-    }
-} else {
-    LevelFilter::Trace
-};
 
 #[derive(Debug)]
 struct UIThreadInner {
@@ -118,7 +104,7 @@ impl UIThread {
 }
 
 pub fn logging(args: &Args) {
-    let log_level = min(args.log_level, MAX_LOG_LEVEL);
+    let log_level = min(args.log_level, STATIC_MAX_LEVEL);
 
     // Setup logging
     let mut log_config = ConfigBuilder::new();


### PR DESCRIPTION
Also [Fix calculation of log_level in logging](https://github.com/cargo-bins/cargo-binstall/commit/1d4627c8637566f01030b1f9197b41008ab92a44) so that all enabling `log_release_max_level_*` in release build would also filter out all log messages except messages coming from `binstalk` and `cargo-binstall`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>