### PR TITLE
Use github source for latest version readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To support `binstall` maintainers must add configuration values to `Cargo.toml` 
 [![Crates.io](https://img.shields.io/crates/v/cargo-binstall.svg)](https://crates.io/crates/cargo-binstall)
 
 NOTE that the docs below are for the `main` branch and may contain unreleased features,
-**[see docs for the latest version](https://github.com/cargo-bins/cargo-binstall/tree/v0.13.0#readme)**
+**[see docs for the latest version](https://github.com/cargo-bins/cargo-binstall/tree/v0.13.1#readme)**
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To support `binstall` maintainers must add configuration values to `Cargo.toml` 
 [![Crates.io](https://img.shields.io/crates/v/cargo-binstall.svg)](https://crates.io/crates/cargo-binstall)
 
 NOTE that the docs below are for the `main` branch and may contain unreleased features,
-**[see docs for the latest version](https://crates.io/crates/cargo-binstall)**
+**[see docs for the latest version](https://github.com/cargo-bins/cargo-binstall/tree/v0.13.0#readme)**
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ To support `binstall` maintainers must add configuration values to `Cargo.toml` 
 [![GitHub tag](https://img.shields.io/github/tag/cargo-bins/cargo-binstall.svg)](https://github.com/cargo-bins/cargo-binstall)
 [![Crates.io](https://img.shields.io/crates/v/cargo-binstall.svg)](https://crates.io/crates/cargo-binstall)
 
-NOTE that the docs below are for the `main` branch and may contain unreleased features,
-**[see docs for the latest version](https://github.com/cargo-bins/cargo-binstall/tree/v0.13.1#readme)**
+You probably want to **[see this page as it was when the latest version was published](https://github.com/cargo-bins/cargo-binstall/tree/v0.13.1#readme)** for accurate documentation.
 
 ## Installation
 


### PR DESCRIPTION
The crate _doesn't_ have the readme snapshot anymore, likely due to the new split crate layout; we should probably fix that but in the meantime this does the trick.