### PR TITLE
Make binaries with `required-features` optional

### DIFF
--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -22,7 +22,7 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
-sccache --help >/dev/null
+CARGO_HOME="$HOME/.cargo" sccache -V
 
 test_resources=".github/scripts/cargo-tomls"
 

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -12,11 +12,8 @@ unset CARGO_HOME
     cargo-release \
     cargo-binstall \
     cargo-watch \
-    miniserve
-
-if [ "$2" != "macos-latest" ]; then
-    "./$1" binstall --log-level debug --no-confirm sccache
-fi
+    miniserve \
+    sccache
 
 # Test that the installed binaries can be run
 b3sum --version

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -22,7 +22,6 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
-CARGO_HOME="$HOME/.cargo" sccache -V
 
 test_resources=".github/scripts/cargo-tomls"
 

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -22,7 +22,7 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
-sccache -V
+sccache --help >/dev/null
 
 test_resources=".github/scripts/cargo-tomls"
 

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -7,7 +7,13 @@ unset CARGO_HOME
 
 # Install binaries using cargo-binstall
 # shellcheck disable=SC2086
-"./$1" binstall --log-level debug --no-confirm b3sum cargo-release cargo-binstall cargo-watch miniserve
+"./$1" binstall --log-level debug --no-confirm \
+    b3sum \
+    cargo-release \
+    cargo-binstall \
+    cargo-watch \
+    miniserve \
+    sccache
 
 # Test that the installed binaries can be run
 b3sum --version
@@ -16,6 +22,7 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
+sccache -V
 
 test_resources=".github/scripts/cargo-tomls"
 

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -12,8 +12,11 @@ unset CARGO_HOME
     cargo-release \
     cargo-binstall \
     cargo-watch \
-    miniserve \
-    sccache
+    miniserve
+
+if [ "$2" != "macos-latest" ]; then
+    "./$1" binstall --log-level debug --no-confirm sccache
+fi
 
 # Test that the installed binaries can be run
 b3sum --version

--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -68,7 +68,6 @@ pub struct BinFile {
     pub source: PathBuf,
     pub dest: PathBuf,
     pub link: Option<PathBuf>,
-    pub pkg_fmt: Option<PkgFmt>,
 }
 
 impl BinFile {
@@ -96,9 +95,7 @@ impl BinFile {
             binary_ext,
         };
 
-        let pkg_fmt = data.meta.pkg_fmt;
-
-        let source = if pkg_fmt == Some(PkgFmt::Bin) {
+        let source = if data.meta.pkg_fmt == Some(PkgFmt::Bin) {
             data.bin_path.clone()
         } else {
             // Generate install paths
@@ -140,7 +137,6 @@ impl BinFile {
             source,
             dest,
             link,
-            pkg_fmt,
         })
     }
 
@@ -184,13 +180,11 @@ impl BinFile {
             self.dest.display()
         );
 
-        if self.pkg_fmt == Some(PkgFmt::Bin) {
-            #[cfg(unix)]
-            fs::set_permissions(
-                &self.source,
-                std::os::unix::fs::PermissionsExt::from_mode(0o755),
-            )?;
-        }
+        #[cfg(unix)]
+        fs::set_permissions(
+            &self.source,
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )?;
 
         atomic_install(&self.source, &self.dest)?;
 

--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -52,7 +52,7 @@ pub fn infer_bin_dir_template(data: &Data) -> Cow<'static, str> {
 
     possible_dirs
         .into_iter()
-        .find(|dirname| Path::new(dirname).is_dir())
+        .find(|dirname| data.bin_path.join(dirname).is_dir())
         .map(|mut dir| {
             dir.reserve_exact(1 + default_bin_dir_template.len());
             dir += "/";

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -348,7 +348,7 @@ async fn download_extract_and_verify(
                             let bin_name = bin.name.as_deref().unwrap();
                             let features = required_features.join(",");
                             warn!(
-                                "When resolving {name} bin {bin_name} is not found.\
+                                "When resolving {name} bin {bin_name} is not found. \
                                 But since it requies features {features}, this bin is ignored."
                             );
                             None


### PR DESCRIPTION
so that crates like `sccache` and `git-cliff` would work as expected.

Fixed #357

This also fixed yet another bug in #417 where I forgot to join `data.bin_path` with the `bin_dir` before checking for its existence.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>