### PR TITLE
Disable `tcp_nodelay` for `reqwest::Client` and add rate limiting for https requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "toml_edit",
+ "tower",
  "trust-dns-resolver",
  "url",
  "xz2",
@@ -2095,6 +2096,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ dependencies = [
  "log",
  "miette",
  "mimalloc",
- "reqwest",
  "semver",
  "simplelog",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2122,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
+ "futures-util",
+ "pin-project",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -32,7 +32,7 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 semver = "1.0.14"
 simplelog = "0.12.0"
 tempfile = "3.3.0"
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "time"], default-features = false }
+tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features = false }
 
 [build-dependencies]
 embed-resource = "1.7.3"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.11.12", default-features = false }
 semver = "1.0.14"
 simplelog = "0.12.0"
 tempfile = "3.3.0"
-tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features = false }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "time"], default-features = false }
 
 [build-dependencies]
 embed-resource = "1.7.3"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -29,7 +29,6 @@ dirs = "4.0.0"
 log = "0.4.17"
 miette = "5.3.0"
 mimalloc = { version = "0.1.29", default-features = false, optional = true }
-reqwest = { version = "0.11.12", default-features = false }
 semver = "1.0.14"
 simplelog = "0.12.0"
 tempfile = "3.3.0"

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -109,7 +109,7 @@ pub struct Args {
     pub pkg_url: Option<String>,
 
     /// Override the delay for each request, the unit is milliseconds.
-    #[clap(help_heading = "Overrides", long, default_value_t = 100)]
+    #[clap(help_heading = "Overrides", long, default_value_t = 5)]
     pub request_delay: u64,
 
     /// Disable symlinking / versioned updates.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, path::PathBuf};
+use std::{ffi::OsString, num::NonZeroU64, path::PathBuf};
 
 use binstalk::{
     errors::BinstallError,
@@ -111,6 +111,10 @@ pub struct Args {
     /// Override the rate limit duration, the unit is milliseconds.
     #[clap(help_heading = "Overrides", long, default_value_t = 5)]
     pub rate_limit_duration: u64,
+
+    /// Override the number of requests allowed in the rate limit duration.
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(20).unwrap())]
+    pub rate_limit_request_count: NonZeroU64,
 
     /// Disable symlinking / versioned updates.
     ///

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -109,11 +109,11 @@ pub struct Args {
     pub pkg_url: Option<String>,
 
     /// Override the rate limit duration, the unit is milliseconds.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(6).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(5).unwrap())]
     pub rate_limit_duration: NonZeroU64,
 
     /// Override the number of requests allowed in the rate limit duration.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(3).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(2).unwrap())]
     pub rate_limit_request_count: NonZeroU64,
 
     /// Disable symlinking / versioned updates.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -113,7 +113,7 @@ pub struct Args {
     pub rate_limit_duration: NonZeroU64,
 
     /// Override the number of requests allowed in the rate limit duration.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(20).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(1).unwrap())]
     pub rate_limit_request_count: NonZeroU64,
 
     /// Disable symlinking / versioned updates.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -109,8 +109,8 @@ pub struct Args {
     pub pkg_url: Option<String>,
 
     /// Override the rate limit duration, the unit is milliseconds.
-    #[clap(help_heading = "Overrides", long, default_value_t = 5)]
-    pub rate_limit_duration: u64,
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(5).unwrap())]
+    pub rate_limit_duration: NonZeroU64,
 
     /// Override the number of requests allowed in the rate limit duration.
     #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(20).unwrap())]

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -2,12 +2,12 @@ use std::{ffi::OsString, path::PathBuf};
 
 use binstalk::{
     errors::BinstallError,
+    helpers::remote::tls::Version,
     manifests::cargo_toml_binstall::PkgFmt,
     ops::resolve::{CrateName, VersionReqExt},
 };
 use clap::{Parser, ValueEnum};
 use log::LevelFilter;
-use reqwest::tls::Version;
 use semver::VersionReq;
 
 #[derive(Debug, Parser)]

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -109,11 +109,11 @@ pub struct Args {
     pub pkg_url: Option<String>,
 
     /// Override the rate limit duration, the unit is milliseconds.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(5).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(6).unwrap())]
     pub rate_limit_duration: NonZeroU64,
 
     /// Override the number of requests allowed in the rate limit duration.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(1).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(3).unwrap())]
     pub rate_limit_request_count: NonZeroU64,
 
     /// Disable symlinking / versioned updates.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -108,9 +108,9 @@ pub struct Args {
     #[clap(help_heading = "Overrides", long)]
     pub pkg_url: Option<String>,
 
-    /// Override the delay for each request, the unit is milliseconds.
+    /// Override the rate limit duration, the unit is milliseconds.
     #[clap(help_heading = "Overrides", long, default_value_t = 5)]
-    pub request_delay: u64,
+    pub rate_limit_duration: u64,
 
     /// Disable symlinking / versioned updates.
     ///

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -108,6 +108,10 @@ pub struct Args {
     #[clap(help_heading = "Overrides", long)]
     pub pkg_url: Option<String>,
 
+    /// Override the delay for each request, the unit is milliseconds.
+    #[clap(help_heading = "Overrides", long, default_value_t = 100)]
+    pub request_delay: u64,
+
     /// Disable symlinking / versioned updates.
     ///
     /// By default, Binstall will install a binary named `<name>-<version>` in the install path, and

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -113,7 +113,7 @@ pub struct Args {
     pub rate_limit_duration: NonZeroU64,
 
     /// Override the number of requests allowed in the rate limit duration.
-    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(2).unwrap())]
+    #[clap(help_heading = "Overrides", long, default_value_t = NonZeroU64::new(1).unwrap())]
     pub rate_limit_request_count: NonZeroU64,
 
     /// Disable symlinking / versioned updates.

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -31,7 +31,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     // Initialize reqwest client
     let client = Client::new(
         args.min_tls_version.map(|v| v.into()),
-        Duration::from_millis(args.rate_limit_duration),
+        Duration::from_millis(args.rate_limit_duration.get()),
         args.rate_limit_request_count,
     )?;
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -32,6 +32,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     let client = Client::new(
         args.min_tls_version.map(|v| v.into()),
         Duration::from_millis(args.rate_limit_duration),
+        args.rate_limit_request_count,
     )?;
 
     // Build crates.io api client

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -31,7 +31,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     // Initialize reqwest client
     let client = Client::new(
         args.min_tls_version.map(|v| v.into()),
-        Duration::from_millis(args.request_delay),
+        Duration::from_millis(args.rate_limit_duration),
     )?;
 
     // Build crates.io api client

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -28,11 +28,13 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     // Launch target detection
     let desired_targets = get_desired_targets(args.targets.take());
 
+    let rate_limit = args.rate_limit;
+
     // Initialize reqwest client
     let client = Client::new(
         args.min_tls_version.map(|v| v.into()),
-        Duration::from_millis(args.rate_limit_duration.get()),
-        args.rate_limit_request_count,
+        Duration::from_millis(rate_limit.duration.get()),
+        rate_limit.request_count,
     )?;
 
     // Build crates.io api client

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -18,9 +18,6 @@ use tokio::task::block_in_place;
 
 use crate::{args::Args, install_path, ui::UIThread};
 
-/// The time to delay for tasks resolving crates.
-const TASK_DELAY: Duration = Duration::from_millis(200);
-
 pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClient) -> Result<()> {
     let cli_overrides = PkgOverride {
         pkg_url: args.pkg_url.take(),
@@ -32,7 +29,10 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
     let desired_targets = get_desired_targets(args.targets.take());
 
     // Initialize reqwest client
-    let client = Client::new(args.min_tls_version.map(|v| v.into()), TASK_DELAY)?;
+    let client = Client::new(
+        args.min_tls_version.map(|v| v.into()),
+        Duration::from_millis(args.request_delay),
+    )?;
 
     // Build crates.io api client
     let crates_io_api_client = crates_io_api::AsyncClient::with_http_client(

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = "1.0.37"
 tinytemplate = "1.2.1"
 tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
-tower = { version = "0.4.13", features = ["limit"] }
+tower = { version = "0.4.13", features = ["limit", "util"] }
 trust-dns-resolver = { version = "0.21.2", optional = true, default-features = false, features = ["dnssec-ring"] }
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -45,7 +45,7 @@ tar = { package = "binstall-tar", version = "0.4.39" }
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 tinytemplate = "1.2.1"
-tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal", "time"], default-features = false }
+tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 tower = { version = "0.4.13", features = ["limit"] }
 trust-dns-resolver = { version = "0.21.2", optional = true, default-features = false, features = ["dnssec-ring"] }

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -45,7 +45,7 @@ tar = { package = "binstall-tar", version = "0.4.39" }
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 tinytemplate = "1.2.1"
-tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal"], default-features = false }
+tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal", "time"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 trust-dns-resolver = { version = "0.21.2", optional = true, default-features = false, features = ["dnssec-ring"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = "1.0.37"
 tinytemplate = "1.2.1"
 tokio = { version = "1.21.2", features = ["macros", "rt", "process", "sync", "signal", "time"], default-features = false }
 toml_edit = { version = "0.14.4", features = ["easy"] }
+tower = { version = "0.4.13", features = ["limit"] }
 trust-dns-resolver = { version = "0.21.2", optional = true, default-features = false, features = ["dnssec-ring"] }
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"

--- a/crates/binstalk/src/drivers/crates_io.rs
+++ b/crates/binstalk/src/drivers/crates_io.rs
@@ -3,13 +3,14 @@ use std::path::PathBuf;
 use cargo_toml::Manifest;
 use crates_io_api::AsyncClient;
 use log::debug;
-use reqwest::Client;
 use semver::VersionReq;
-use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::download::Download,
+    helpers::{
+        download::Download,
+        remote::{Client, Url},
+    },
     manifests::cargo_toml_binstall::{Meta, TarBasedFmt},
 };
 

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -4,10 +4,10 @@ use compact_str::CompactString;
 pub use gh_crate_meta::*;
 pub use log::debug;
 pub use quickinstall::*;
-use reqwest::Client;
 
 use crate::{
     errors::BinstallError,
+    helpers::remote::Client,
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
 

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -115,16 +115,7 @@ impl QuickInstall {
             let url = Url::parse(&stats_url)?;
             debug!("Sending installation report to quickinstall ({url})");
 
-            client
-                .request(Method::HEAD, url.clone())
-                .await
-                .send()
-                .await
-                .map_err(|err| BinstallError::Http {
-                    method: Method::HEAD,
-                    url,
-                    err,
-                })?;
+            client.remote_exists(url, Method::HEAD).await?;
 
             Ok(())
         })

--- a/crates/binstalk/src/helpers/download.rs
+++ b/crates/binstalk/src/helpers/download.rs
@@ -2,11 +2,10 @@ use std::{fmt::Debug, marker::PhantomData, path::Path};
 
 use digest::{Digest, FixedOutput, HashMarker, Output, OutputSizeUser, Update};
 use log::debug;
-use reqwest::{Client, Url};
 
 use crate::{
     errors::BinstallError,
-    helpers::remote::create_request,
+    helpers::remote::{Client, Url},
     manifests::cargo_toml_binstall::{PkgFmt, PkgFmtDecomposed, TarBasedFmt},
 };
 
@@ -48,7 +47,7 @@ impl Download {
         fmt: TarBasedFmt,
         visitor: V,
     ) -> Result<V::Target, BinstallError> {
-        let stream = create_request(self.client, self.url).await?;
+        let stream = self.client.create_request(self.url).await?;
 
         debug!("Downloading and extracting then in-memory processing");
 
@@ -65,7 +64,7 @@ impl Download {
         fmt: PkgFmt,
         path: impl AsRef<Path>,
     ) -> Result<(), BinstallError> {
-        let stream = create_request(self.client, self.url).await?;
+        let stream = self.client.create_request(self.url).await?;
 
         let path = path.as_ref();
         debug!("Downloading and extracting to: '{}'", path.display());

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -1,70 +1,105 @@
-use std::env;
+use std::{env, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use futures_util::stream::Stream;
 use log::debug;
-use reqwest::{tls, Client, ClientBuilder, Method, Response};
-use url::Url;
+use tokio::{
+    sync::Mutex,
+    time::{interval, Interval, MissedTickBehavior},
+};
 
 use crate::errors::BinstallError;
 
-pub fn create_reqwest_client(min_tls: Option<tls::Version>) -> Result<Client, BinstallError> {
-    const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+pub use reqwest::{tls, ClientBuilder, Method, RequestBuilder, Response};
+pub use url::Url;
 
-    let mut builder = ClientBuilder::new()
-        .user_agent(USER_AGENT)
-        .https_only(true)
-        .min_tls_version(tls::Version::TLS_1_2)
-        .tcp_nodelay(false);
+#[derive(Clone, Debug)]
+pub struct Client {
+    client: reqwest::Client,
+    interval: Arc<Mutex<Interval>>,
+}
 
-    if let Some(ver) = min_tls {
-        builder = builder.min_tls_version(ver);
+impl Client {
+    /// * `delay` - delay between launching next reqwests.
+    pub fn new(min_tls: Option<tls::Version>, delay: Duration) -> Result<Self, BinstallError> {
+        const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+        let mut builder = ClientBuilder::new()
+            .user_agent(USER_AGENT)
+            .https_only(true)
+            .min_tls_version(tls::Version::TLS_1_2)
+            .tcp_nodelay(false);
+
+        if let Some(ver) = min_tls {
+            builder = builder.min_tls_version(ver);
+        }
+
+        let client = builder.build()?;
+
+        let mut interval = interval(delay);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        Ok(Self {
+            client,
+            interval: Arc::new(Mutex::new(interval)),
+        })
     }
 
-    Ok(builder.build()?)
-}
+    pub fn get_inner(&self) -> &reqwest::Client {
+        &self.client
+    }
 
-pub async fn remote_exists(
-    client: Client,
-    url: Url,
-    method: Method,
-) -> Result<bool, BinstallError> {
-    let req = client
-        .request(method.clone(), url.clone())
-        .send()
-        .await
-        .map_err(|err| BinstallError::Http { method, url, err })?;
-    Ok(req.status().is_success())
-}
+    /// Wait until rate limiting permits us to launch
+    /// the next request.
+    async fn wait(&self) {
+        self.interval.lock().await.tick().await;
+    }
 
-pub async fn get_redirected_final_url(client: &Client, url: Url) -> Result<Url, BinstallError> {
-    let method = Method::HEAD;
+    pub async fn request(&self, method: Method, url: Url) -> RequestBuilder {
+        self.wait().await;
 
-    let req = client
-        .request(method.clone(), url.clone())
-        .send()
-        .await
-        .and_then(Response::error_for_status)
-        .map_err(|err| BinstallError::Http { method, url, err })?;
+        self.client.request(method, url)
+    }
 
-    Ok(req.url().clone())
-}
+    pub async fn remote_exists(&self, url: Url, method: Method) -> Result<bool, BinstallError> {
+        let req = self
+            .request(method.clone(), url.clone())
+            .await
+            .send()
+            .await
+            .map_err(|err| BinstallError::Http { method, url, err })?;
 
-pub(crate) async fn create_request(
-    client: Client,
-    url: Url,
-) -> Result<impl Stream<Item = reqwest::Result<Bytes>>, BinstallError> {
-    debug!("Downloading from: '{url}'");
+        Ok(req.status().is_success())
+    }
 
-    client
-        .get(url.clone())
-        .send()
-        .await
-        .and_then(|r| r.error_for_status())
-        .map_err(|err| BinstallError::Http {
-            method: Method::GET,
-            url,
-            err,
-        })
-        .map(Response::bytes_stream)
+    pub async fn get_redirected_final_url(&self, url: Url) -> Result<Url, BinstallError> {
+        let method = Method::HEAD;
+
+        let req = self
+            .request(method.clone(), url.clone())
+            .await
+            .send()
+            .await
+            .and_then(Response::error_for_status)
+            .map_err(|err| BinstallError::Http { method, url, err })?;
+
+        Ok(req.url().clone())
+    }
+
+    pub(crate) async fn create_request(
+        &self,
+        url: Url,
+    ) -> Result<impl Stream<Item = reqwest::Result<Bytes>>, BinstallError> {
+        debug!("Downloading from: '{url}'");
+
+        let method = Method::GET;
+
+        self.request(method.clone(), url.clone())
+            .await
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|err| BinstallError::Http { method, url, err })
+            .map(Response::bytes_stream)
+    }
 }

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -49,26 +49,16 @@ impl Client {
         &self.client
     }
 
-    /// Wait until rate limiting permits us to launch
-    /// the next request.
-    async fn wait(&self) {
-        self.interval.lock().await.tick().await;
-    }
-
-    async fn request(&self, method: Method, url: Url) -> RequestBuilder {
-        self.wait().await;
-
-        self.client.request(method, url)
-    }
-
     async fn send_request(
         &self,
         method: Method,
         url: Url,
         error_for_status: bool,
     ) -> Result<Response, BinstallError> {
-        self.request(method.clone(), url.clone())
-            .await
+        self.interval.lock().await.tick().await;
+
+        self.client
+            .request(method.clone(), url.clone())
             .send()
             .await
             .and_then(|response| {

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -3,12 +3,13 @@ use std::{env, sync::Arc, time::Duration};
 use bytes::Bytes;
 use futures_util::stream::Stream;
 use log::debug;
+use reqwest::{Request, Response};
 use tokio::sync::Mutex;
 use tower::{limit::rate::RateLimit, Service, ServiceBuilder, ServiceExt};
 
 use crate::errors::BinstallError;
 
-pub use reqwest::{tls, Method, Request, RequestBuilder, Response};
+pub use reqwest::{tls, Method};
 pub use url::Url;
 
 #[derive(Clone, Debug)]

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -14,7 +14,8 @@ pub fn create_reqwest_client(min_tls: Option<tls::Version>) -> Result<Client, Bi
     let mut builder = ClientBuilder::new()
         .user_agent(USER_AGENT)
         .https_only(true)
-        .min_tls_version(tls::Version::TLS_1_2);
+        .min_tls_version(tls::Version::TLS_1_2)
+        .tcp_nodelay(false);
 
     if let Some(ver) = min_tls {
         builder = builder.min_tls_version(ver);

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -19,7 +19,7 @@ pub struct Client {
 }
 
 impl Client {
-    /// * `delay` - delay between launching next reqwests.
+    /// * `per` - must not be 0.
     pub fn new(
         min_tls: Option<tls::Version>,
         per: Duration,

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -10,7 +10,7 @@ use tokio::{
 
 use crate::errors::BinstallError;
 
-pub use reqwest::{tls, ClientBuilder, Method, RequestBuilder, Response};
+pub use reqwest::{tls, Method, RequestBuilder, Response};
 pub use url::Url;
 
 #[derive(Clone, Debug)]
@@ -24,7 +24,7 @@ impl Client {
     pub fn new(min_tls: Option<tls::Version>, delay: Duration) -> Result<Self, BinstallError> {
         const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-        let mut builder = ClientBuilder::new()
+        let mut builder = reqwest::ClientBuilder::new()
             .user_agent(USER_AGENT)
             .https_only(true)
             .min_tls_version(tls::Version::TLS_1_2)

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -10,7 +10,6 @@ use cargo_toml::{Manifest, Package, Product};
 use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use log::{debug, info, warn};
-use reqwest::Client;
 use semver::{Version, VersionReq};
 use tokio::task::block_in_place;
 
@@ -20,7 +19,7 @@ use crate::{
     drivers::fetch_crate_cratesio,
     errors::BinstallError,
     fetchers::{Data, Fetcher, GhCrateMeta, QuickInstall},
-    helpers::tasks::AutoAbortJoinHandle,
+    helpers::{remote::Client, tasks::AutoAbortJoinHandle},
     manifests::cargo_toml_binstall::{Meta, PkgMeta},
 };
 


### PR DESCRIPTION
* Disable tcp_nodelay for `reqwest::Client`
* Add new dep tower v0.4.13 with feature "limit" and "util" eabled
* Use `tower::limit::rate::RateLimit` for rate limiting
* Rm dep reqwest from crates/bin
* Add new arg `rate_limit` with default set to `5/1`
* Refactor `QuickInstall::report`: Use remote_exists instead of request

Fixed #457.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>