### PR TITLE
Fix unit test & integration CI and the release CI

### DIFF
--- a/.github/scripts/compile-settings.jq
+++ b/.github/scripts/compile-settings.jq
@@ -3,7 +3,9 @@ if $for_release then {
   profile: "release",
   # Use build-std to build a std library optimized for size and abort immediately on abort,
   # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
-  args: ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"),
+  args: if $matrix.target != "aarch64-unknown-linux-gnu"
+        then ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort")
+        else $matrin.release_build_args end,
   features: ($matrix.release_features // ["static", "rustls", "trust-dns", "fancy-no-backtrace", "log_release_max_level_debug"]),
 } else {
   output: "debug",

--- a/.github/scripts/compile-settings.jq
+++ b/.github/scripts/compile-settings.jq
@@ -4,7 +4,7 @@ if $for_release then {
   # Use build-std to build a std library optimized for size and abort immediately on abort,
   # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
   args: ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"),
-  features: ($matrix.release_features // ["zlib-ng", "static", "rustls", "trust-dns", "fancy-no-backtrace", "log_release_max_level_debug"]),
+  features: ($matrix.release_features // ["static", "rustls", "trust-dns", "fancy-no-backtrace", "log_release_max_level_debug"]),
 } else {
   output: "debug",
   profile: "dev",

--- a/.github/scripts/compile-settings.jq
+++ b/.github/scripts/compile-settings.jq
@@ -1,11 +1,17 @@
+if $matrix.target != "aarch64-unknown-linux-gnu" then {
+  # Use build-std to build a std library optimized for size and abort immediately on abort,
+  # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
+  #
+  # Disable it on aarch64-unknown-linux-gnu as it caused the build to fail.
+  release_build_std_args: "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"
+} else {
+  release_build_std_args: ""
+} end
+|
 if $for_release then {
   output: "release",
   profile: "release",
-  # Use build-std to build a std library optimized for size and abort immediately on abort,
-  # so that format string for `unwrap`/`expect`/`unreachable`/`panic` can be optimized out.
-  args: if $matrix.target != "aarch64-unknown-linux-gnu"
-        then ($matrix.release_build_args // "-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort")
-        else $matrin.release_build_args end,
+  args: ($matrix.release_build_args // .release_build_std_args),
   features: ($matrix.release_features // ["static", "rustls", "trust-dns", "fancy-no-backtrace", "log_release_max_level_debug"]),
 } else {
   output: "debug",

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -12,11 +12,11 @@ if [ "$2" = "Windows" ]; then
     "./$1" --log-level debug --no-confirm $crates
 else
     export CARGO_HOME=/tmp/cargo-home-for-test
-    export PATH="$CARGO_HOME/bin:$PATH"
+    export PATH="/tmp/t/bin:$PATH"
     
-    mkdir -p "$CARGO_HOME/bin"
+    mkdir -p "/tmp/t/bin"
     # Copy it to bin to test use of env var `CARGO`
-    cp "./$1" "$CARGO_HOME/bin/cargo-binstall"
+    cp "./$1" "/tmp/t/bin/cargo-binstall"
     
     # Install binaries using cargo-binstall
     # shellcheck disable=SC2086

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -12,7 +12,7 @@ if [ "$2" = "Windows" ]; then
     "./$1" --log-level debug --no-confirm $crates
 else
     export CARGO_HOME=/tmp/cargo-home-for-test
-    export PATH="/tmp/t/bin:$CARGO_HOME/bin:$PATH"
+    export PATH="$CARGO_HOME/bin:/tmp/t/bin:$PATH"
     
     mkdir -p "/tmp/t/bin"
     # Copy it to bin to test use of env var `CARGO`
@@ -21,6 +21,8 @@ else
     # Install binaries using cargo-binstall
     # shellcheck disable=SC2086
     cargo binstall --log-level debug --no-confirm $crates
+
+    rm -r /tmp/t
 fi
 
 # Test that the installed binaries can be run

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -12,7 +12,7 @@ if [ "$2" = "Windows" ]; then
     "./$1" --log-level debug --no-confirm $crates
 else
     export CARGO_HOME=/tmp/cargo-home-for-test
-    export PATH="/tmp/t/bin:$PATH"
+    export PATH="/tmp/t/bin:$CARGO_HOME/bin:$PATH"
     
     mkdir -p "/tmp/t/bin"
     # Copy it to bin to test use of env var `CARGO`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ env.COUTPUT }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          ${{ runner.os }}-cargo-${{ matrix.target }}-
-          ${{ runner.os }}-cargo-
 
     - name: Install musl-tools
       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}

--- a/crates/bin/src/ui.rs
+++ b/crates/bin/src/ui.rs
@@ -77,7 +77,7 @@ impl UIThreadInner {
         self.confirm_rx
             .recv()
             .await
-            .unwrap_or(Err(BinstallError::UserAbort))
+            .unwrap_or_else(|| Err(BinstallError::UserAbort))
     }
 }
 


### PR DESCRIPTION
* Fix integration test: Make sure `cargo build cargo-binstall` would not fail due to binary already present
* Disable feature `zlib-ng` for release build
* Disable build-std for release build on aarch64-unknown-linux-gnu
* Fix clippy warning in unit test CI
* Fix compile-settings.jq
* Fix caching: Rm `restores-keys`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>