### PR TITLE
Fix `install_from_source`: Set `cmd` to be kill_on_drop

### DIFF
--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -121,7 +121,8 @@ async fn install_from_source(
         .arg("--version")
         .arg(version)
         .arg("--target")
-        .arg(target);
+        .arg(target)
+        .kill_on_drop(true);
 
     if quiet {
         cmd.arg("--quiet");


### PR DESCRIPTION
If user interrupts `cargo-binstall` by signal while it is running `cargo-install`, then the `cargo-install` would continue to run at background even after `cargo-binstall` terminates.

Setting `cmd` to be kill_on_drop fixed this.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>