### PR TITLE
Support default filename with underscores.

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -66,9 +66,13 @@ are:
 - `{ name }-{ target }-v{ version }{ archive-suffix }`
 - `{ name }-{ version }-{ target }{ archive-suffix }`
 - `{ name }-v{ version }-{ target }{ archive-suffix }`
-- `{ name }-{ version }-{ target }{ archive-suffix }`
-- `{ name }-v{ version }-{ target }{ archive-suffix }`
+- `{ name }_{ target }_{ version }{ archive-suffix }`
+- `{ name }_{ target }_v{ version }{ archive-suffix }`
+- `{ name }_{ version }_{ target }{ archive-suffix }`
+- `{ name }_v{ version }_{ target }{ archive-suffix }`
 - `{ name }-{ target }{ archive-suffix }` ("versionless")
+- `{ name }{ archive-suffix }` ("versionless")
+- `{ name }_{ target }{ archive-suffix }` ("versionless")
 
 The paths are:
 

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -18,11 +18,16 @@ pub const FULL_FILENAMES: &[&str] = &[
     "{ name }-{ target }-{ version }{ archive-suffix }",
     "{ name }-{ version }-{ target }{ archive-suffix }",
     "{ name }-v{ version }-{ target }{ archive-suffix }",
+    "{ name }_{ target }_v{ version }{ archive-suffix }",
+    "{ name }_{ target }_{ version }{ archive-suffix }",
+    "{ name }_{ version }_{ target }{ archive-suffix }",
+    "{ name }_v{ version }_{ target }{ archive-suffix }",
 ];
 
 pub const NOVERSION_FILENAMES: &[&str] = &[
     "{ name }-{ target }{ archive-suffix }",
     "{ name }{ archive-suffix }",
+    "{ name }_{ target }{ archive-suffix }",
 ];
 
 impl RepositoryHost {


### PR DESCRIPTION
This is the default format used by github action rust-build/rust-build.