### PR TITLE
Add new dep tracing v0.1.37 with feat log-always in crates/bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "simplelog",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2162,9 +2163,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2174,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -33,6 +33,7 @@ semver = "1.0.14"
 simplelog = "0.12.0"
 tempfile = "3.3.0"
 tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features = false }
+tracing = { version = "0.1.37", features = ["log-always"], default-features = false }
 
 [build-dependencies]
 embed-resource = "1.7.4"
@@ -55,5 +56,5 @@ trust-dns = ["binstalk/trust-dns"]
 fancy-no-backtrace = ["miette/fancy-no-backtrace"]
 fancy-with-backtrace = ["fancy-no-backtrace", "miette/fancy"]
 
-log_release_max_level_info = ["log/release_max_level_info"]
-log_release_max_level_debug = ["log/release_max_level_debug"]
+log_release_max_level_info = ["log/release_max_level_info", "tracing/release_max_level_info"]
+log_release_max_level_debug = ["log/release_max_level_debug", "tracing/release_max_level_debug"]


### PR DESCRIPTION
to convert all tracing spans and events to log

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>