### PR TITLE
Replace use of `log` with `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
+ "tracing",
  "url",
  "xz2",
 ]
@@ -2199,6 +2200,7 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
@@ -2211,6 +2213,17 @@ dependencies = [
  "crossbeam-channel",
  "time",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
  "home",
  "itertools",
  "jobslot",
- "log",
  "miette",
  "normalize-path",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ dependencies = [
  "futures-util",
  "generic-array",
  "httpdate",
- "log",
  "reqwest",
  "scopeguard",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "tracing",
  "trust-dns-resolver",
  "url",
  "xz2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,6 @@ dependencies = [
  "compact_str",
  "crates_io_api",
  "detect-targets",
- "env_logger",
  "futures-util",
  "home",
  "itertools",
@@ -573,19 +572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,12 +893,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -26,7 +26,7 @@ binstalk = { path = "../binstalk", version = "0.4.1" }
 clap = { version = "4.0.22", features = ["derive"] }
 crates_io_api = { version = "0.8.1", default-features = false }
 dirs = "4.0.0"
-log = "0.4.17"
+log = { version = "0.4.17", features = ["std"] }
 miette = "5.4.1"
 mimalloc = { version = "0.1.31", default-features = false, optional = true }
 once_cell = "1.16.0"

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -13,9 +13,10 @@ use binstalk::{
         resolve::{CrateName, Resolution, VersionReqExt},
     },
 };
-use log::{debug, error, info, warn, LevelFilter};
+use log::LevelFilter;
 use miette::{miette, Result, WrapErr};
 use tokio::task::block_in_place;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     args::{Args, Strategy},

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use binstalk::home::cargo_home;
-use log::debug;
+use tracing::debug;
 
 pub fn get_cargo_roots_path(cargo_roots: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(p) = cargo_roots {

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use binstalk::helpers::jobserver_client::LazyJobserverClient;
-use log::debug;
+use tracing::debug;
 
 use cargo_binstall::{
     args,

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3.3.0"
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread", "sync", "time"], default-features = false }
 tower = { version = "0.4.13", features = ["limit", "util"] }
+tracing = "0.1.37"
 trust-dns-resolver = { version = "0.21.2", optional = true, default-features = false, features = ["dnssec-ring"] }
 url = "2.3.1"
 

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -18,7 +18,6 @@ flate2 = { version = "1.0.24", default-features = false }
 futures-util = { version = "0.3.25", default-features = false, features = ["std"] }
 generic-array = "0.14.6"
 httpdate = "1.0.2"
-log = { version = "0.4.17", features = ["std"] }
 reqwest = { version = "0.11.12", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 scopeguard = "1.1.0"
 # Use a fork here since we need PAX support, but the upstream

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -2,8 +2,8 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, path::Path, pin::
 
 use binstalk_manifests::cargo_toml_binstall::{PkgFmtDecomposed, TarBasedFmt};
 use digest::{Digest, FixedOutput, HashMarker, Output, OutputSizeUser, Update};
-use log::debug;
 use thiserror::Error as ThisError;
+use tracing::debug;
 
 pub use binstalk_manifests::cargo_toml_binstall::PkgFmt;
 pub use tar::Entries;

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, path::Path, pin::
 use binstalk_manifests::cargo_toml_binstall::{PkgFmtDecomposed, TarBasedFmt};
 use digest::{Digest, FixedOutput, HashMarker, Output, OutputSizeUser, Update};
 use thiserror::Error as ThisError;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub use binstalk_manifests::cargo_toml_binstall::PkgFmt;
 pub use tar::Entries;
@@ -92,6 +92,7 @@ impl Download {
     ///
     /// `cancellation_future` can be used to cancel the extraction and return
     /// [`DownloadError::UserAbort`] error.
+    #[instrument(skip(visitor, cancellation_future))]
     pub async fn and_visit_tar<V: TarEntriesVisitor + Debug + Send + 'static>(
         self,
         fmt: TarBasedFmt,
@@ -114,6 +115,7 @@ impl Download {
     ///
     /// `cancellation_future` can be used to cancel the extraction and return
     /// [`DownloadError::UserAbort`] error.
+    #[instrument(skip(path, cancellation_future))]
     pub async fn and_extract(
         self,
         fmt: PkgFmt,

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -7,11 +7,11 @@ use std::{
 
 use bytes::Bytes;
 use futures_util::stream::Stream;
-use log::debug;
 use scopeguard::{guard, ScopeGuard};
 use tar::Entries;
 use tempfile::tempfile;
 use tokio::task::block_in_place;
+use tracing::debug;
 
 use super::{
     extracter::*, stream_readable::StreamReadable, CancellationFuture, DownloadError, TarBasedFmt,

--- a/crates/binstalk-downloader/src/download/extracter.rs
+++ b/crates/binstalk-downloader/src/download/extracter.rs
@@ -6,8 +6,8 @@ use std::{
 
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
-use log::debug;
 use tar::Archive;
+use tracing::debug;
 use xz2::bufread::XzDecoder;
 use zip::read::ZipArchive;
 use zstd::stream::Decoder as ZstdDecoder;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -8,7 +8,6 @@ use std::{
 use bytes::Bytes;
 use futures_util::stream::{Stream, StreamExt};
 use httpdate::parse_http_date;
-use log::{debug, info};
 use reqwest::{
     header::{HeaderMap, RETRY_AFTER},
     Request, Response, StatusCode,
@@ -16,6 +15,7 @@ use reqwest::{
 use thiserror::Error as ThisError;
 use tokio::{sync::Mutex, time::sleep};
 use tower::{limit::rate::RateLimit, Service, ServiceBuilder, ServiceExt};
+use tracing::{debug, info};
 
 pub use reqwest::{tls, Error as ReqwestError, Method};
 pub use url::Url;

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -21,7 +21,6 @@ futures-util = { version = "0.3.25", default-features = false, features = ["std"
 home = "0.5.4"
 itertools = "0.10.5"
 jobslot = { version = "0.2.6", features = ["tokio"] }
-log = { version = "0.4.17", features = ["std"] }
 miette = "5.4.1"
 normalize-path = { version = "0.2.0", path = "../normalize-path" }
 once_cell = "1.16.0"

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -37,9 +37,6 @@ tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"
 
-[dev-dependencies]
-env_logger = "0.9.3"
-
 [features]
 default = ["static", "rustls"]
 

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0.37"
 tinytemplate = "1.2.1"
 # parking_lot for `tokio::sync::OnceCell::const_new`
 tokio = { version = "1.21.2", features = ["rt", "process", "sync", "signal", "parking_lot"], default-features = false }
+tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"
 

--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -6,10 +6,10 @@ use std::{
 
 use cargo_toml::Product;
 use compact_str::CompactString;
-use log::debug;
 use normalize_path::NormalizePath;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
+use tracing::debug;
 
 use crate::{
     errors::BinstallError,

--- a/crates/binstalk/src/drivers/crates_io.rs
+++ b/crates/binstalk/src/drivers/crates_io.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use cargo_toml::Manifest;
 use crates_io_api::AsyncClient;
-use log::debug;
 use semver::VersionReq;
+use tracing::debug;
 
 use crate::{
     errors::BinstallError,

--- a/crates/binstalk/src/drivers/crates_io/visitor.rs
+++ b/crates/binstalk/src/drivers/crates_io/visitor.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use cargo_toml::Manifest;
-use log::debug;
 use normalize_path::NormalizePath;
+use tracing::debug;
 
 use super::vfs::Vfs;
 use crate::{

--- a/crates/binstalk/src/drivers/version.rs
+++ b/crates/binstalk/src/drivers/version.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use semver::VersionReq;
+use tracing::debug;
 
 use crate::errors::BinstallError;
 

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -2,7 +2,6 @@ use std::{path::Path, sync::Arc};
 
 use compact_str::CompactString;
 pub use gh_crate_meta::*;
-pub use log::debug;
 pub use quickinstall::*;
 
 use crate::{

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -2,11 +2,11 @@ use std::{path::Path, sync::Arc};
 
 use compact_str::{CompactString, ToCompactString};
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use log::{debug, warn};
 use once_cell::sync::OnceCell;
 use serde::Serialize;
 use strum::IntoEnumIterator;
 use tinytemplate::TinyTemplate;
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::{

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use compact_str::CompactString;
-use log::debug;
 use tokio::task::JoinHandle;
+use tracing::debug;
 use url::Url;
 
 use crate::{

--- a/crates/binstalk/src/fs.rs
+++ b/crates/binstalk/src/fs.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, path::Path};
 
-use log::debug;
 use tempfile::NamedTempFile;
+use tracing::debug;
 
 /// Atomically install a file.
 ///

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, env, ffi::OsStr, sync::Arc};
 
 use compact_str::CompactString;
 use tokio::{process::Command, task::block_in_place};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, instrument};
 
 use super::{resolve::Resolution, Options};
 use crate::{
@@ -12,6 +12,7 @@ use crate::{
     manifests::crate_info::{CrateInfo, CrateSource},
 };
 
+#[instrument(skip_all)]
 pub async fn install(
     resolution: Resolution,
     opts: Arc<Options>,

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, env, ffi::OsStr, sync::Arc};
 
 use compact_str::CompactString;
-use log::{debug, error, info};
 use tokio::{process::Command, task::block_in_place};
+use tracing::{debug, error, info};
 
 use super::{resolve::Resolution, Options};
 use crate::{

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -11,7 +11,7 @@ use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use semver::{Version, VersionReq};
 use tokio::task::block_in_place;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 use super::Options;
 use crate::{
@@ -89,6 +89,7 @@ impl Resolution {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn resolve(
     opts: Arc<Options>,
     crate_name: CrateName,

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -9,9 +9,9 @@ use std::{
 use cargo_toml::{Manifest, Package, Product};
 use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
-use log::{debug, info, warn};
 use semver::{Version, VersionReq};
 use tokio::task::block_in_place;
+use tracing::{debug, info, warn};
 
 use super::Options;
 use crate::{

--- a/crates/binstalk/tests/parse-meta.rs
+++ b/crates/binstalk/tests/parse-meta.rs
@@ -3,8 +3,6 @@ use cargo_toml::Product;
 
 #[test]
 fn parse_meta() {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     let mut manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     manifest_dir.push_str("/tests/parse-meta.Cargo.toml");
 


### PR DESCRIPTION
Resolved #522

* Add dep tracing v0.1.37 to binstalk
* Use `tracing` instead of `log` for logging in binstalk
* Rm dev dep `env_logger` since `log` is no longer used
* Rm unused dep `log` from binstalk

* Replace use of `log` with `tracing` in crates/bin
* Enable feat std of dep log in crates/bin

* Add dep tracing v0.1.37 to binstalk-downloader
* Replace use of `log` with `tracing` in binstalk-downloader
* Rm unused dep `log` from binstalk-downlaoder


* Wrap `ops::{install, resolve}` in `tracing::instrument`
* Wrap `Download::and_{extract, visit_tar}` in `instrument`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>