### PR TITLE
Enable coloring in console log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "mimalloc",
  "once_cell",
  "semver",
+ "supports-color",
  "tempfile",
  "tokio",
  "tracing",
@@ -1915,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "supports-color"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
 dependencies = [
  "atty",
  "is_ci",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,6 +1270,16 @@ name = "normalize-path"
 version = "0.2.0"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1382,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2250,6 +2266,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "nu-ansi-term",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,17 +2181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
+ "tracing",
  "url",
  "xz2",
 ]
@@ -2184,7 +2185,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
@@ -447,16 +446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1309,15 +1298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,17 +2025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,17 +2185,6 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
-dependencies = [
- "crossbeam-channel",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -36,7 +36,6 @@ tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features =
 tracing-core = "0.1.30"
 tracing = { version = "0.1.37", default-features = false }
 tracing-log = { version = "0.1.3", default-features = false }
-tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "json", "ansi"], default-features = false }
 
 [build-dependencies]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -31,6 +31,7 @@ miette = "5.4.1"
 mimalloc = { version = "0.1.31", default-features = false, optional = true }
 once_cell = "1.16.0"
 semver = "1.0.14"
+supports-color = "1.3.1"
 tempfile = "3.3.0"
 tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features = false }
 tracing-core = "0.1.30"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -37,7 +37,7 @@ tracing-core = "0.1.30"
 tracing = { version = "0.1.37", default-features = false }
 tracing-log = { version = "0.1.3", default-features = false }
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.16", features = ["fmt", "json"], default-features = false }
+tracing-subscriber = { version = "0.3.16", features = ["fmt", "json", "ansi"], default-features = false }
 
 [build-dependencies]
 embed-resource = "1.7.4"

--- a/crates/bin/src/bin_util.rs
+++ b/crates/bin/src/bin_util.rs
@@ -1,6 +1,5 @@
 use std::{
     future::Future,
-    io::{self, Write},
     process::{ExitCode, Termination},
     time::Duration,
 };
@@ -9,6 +8,7 @@ use binstalk::errors::BinstallError;
 use binstalk::helpers::{signal::cancel_on_user_sig_term, tasks::AutoAbortJoinHandle};
 use miette::Result;
 use tokio::runtime::Runtime;
+use tracing::{error, info};
 
 pub enum MainExit {
     Success(Option<Duration>),
@@ -21,13 +21,13 @@ impl Termination for MainExit {
         match self {
             Self::Success(spent) => {
                 if let Some(spent) = spent {
-                    writeln!(io::stdout(), "Done in {spent:?}").ok();
+                    info!("Done in {spent:?}");
                 }
                 ExitCode::SUCCESS
             }
             Self::Error(err) => err.report(),
             Self::Report(err) => {
-                writeln!(io::stderr(), "Fatal error:\n{err:?}").ok();
+                error!("Fatal error:\n{err:?}");
                 ExitCode::from(16)
             }
         }

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -155,7 +155,7 @@ pub fn logging(args: &Args) -> WorkerGuard {
     } else {
         Box::new(
             subscriber_builder
-                .compact()
+                .with_ansi(true)
                 // Disable time, target, file, line_num, thread name/ids to make the
                 // output more readable
                 .without_time()

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> MainExit {
         println!("{}", env!("CARGO_PKG_VERSION"));
         MainExit::Success(None)
     } else {
-        let _guard = logging(&args);
+        logging(&args);
 
         let start = Instant::now();
 

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0.37"
 tinytemplate = "1.2.1"
 # parking_lot for `tokio::sync::OnceCell::const_new`
 tokio = { version = "1.21.2", features = ["rt", "process", "sync", "signal", "parking_lot"], default-features = false }
+tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"
 

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -12,7 +12,7 @@ use compact_str::CompactString;
 use miette::{Diagnostic, Report};
 use thiserror::Error;
 use tokio::task;
-use tracing::{error, info};
+use tracing::{error, warn};
 
 /// Error kinds emitted by cargo-binstall.
 #[derive(Error, Diagnostic, Debug)]
@@ -400,7 +400,7 @@ impl Termination for BinstallError {
     fn report(self) -> ExitCode {
         let code = self.exit_code();
         if let BinstallError::UserAbort = self {
-            info!("Installation cancelled");
+            warn!("Installation cancelled");
         } else {
             error!("Fatal error:\n{:?}", Report::new(self));
         }

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Write},
+    io,
     path::PathBuf,
     process::{ExitCode, ExitStatus, Termination},
 };
@@ -12,6 +12,7 @@ use compact_str::CompactString;
 use miette::{Diagnostic, Report};
 use thiserror::Error;
 use tokio::task;
+use tracing::{error, info};
 
 /// Error kinds emitted by cargo-binstall.
 #[derive(Error, Diagnostic, Debug)]
@@ -399,9 +400,9 @@ impl Termination for BinstallError {
     fn report(self) -> ExitCode {
         let code = self.exit_code();
         if let BinstallError::UserAbort = self {
-            writeln!(io::stdout(), "Installation cancelled").ok();
+            info!("Installation cancelled");
         } else {
-            writeln!(io::stderr(), "Fatal error:\n{:?}", Report::new(self)).ok();
+            error!("Fatal error:\n{:?}", Report::new(self));
         }
 
         code


### PR DESCRIPTION
* Enable feat ansi of dep tracing-subscriber
* Rm use of `tracing_appender::non_blocking`
  since `cargo-binstall` is so simple that it doesn't need it.
* Use `tracing::{error, info}` in `MainExit::report`
* Use `tracing::{error, warn}` in `BinstallError::report`
* Add dep supports-color v1.3.1 to crates/bin
* Enable ansi of `tracing_subscriber::fmt` if stdout supports it

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>