### PR TITLE
Optimization: Box variants in Error to reduce size and remove unused variants in `BinstallError`

### DIFF
--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -29,7 +29,7 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
 
     #[error(transparent)]
-    Http(HttpError),
+    Http(Box<HttpError>),
 }
 
 #[derive(Debug, ThisError)]
@@ -138,7 +138,7 @@ impl Client {
                     Ok(response)
                 }
             })
-            .map_err(|err| Error::Http(HttpError { method, url, err }))
+            .map_err(|err| Error::Http(Box::new(HttpError { method, url, err })))
     }
 
     /// Check if remote exists using `method`.

--- a/crates/binstalk/src/drivers/crates_io.rs
+++ b/crates/binstalk/src/drivers/crates_io.rs
@@ -38,7 +38,7 @@ pub async fn fetch_crate_cratesio(
         .await
         .map_err(|err| BinstallError::CratesIoApi {
             crate_name: name.into(),
-            err,
+            err: Box::new(err),
         })?;
 
     // Locate matching version

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -9,6 +9,7 @@ use binstalk_downloader::{
     remote::{Error as RemoteError, HttpError, ReqwestError},
 };
 use compact_str::CompactString;
+use crates_io_api::Error as CratesIoApiError;
 use miette::{Diagnostic, Report};
 use thiserror::Error;
 use tinytemplate::error::Error as TinyTemplateError;
@@ -117,7 +118,7 @@ pub enum BinstallError {
     CratesIoApi {
         crate_name: CompactString,
         #[source]
-        err: crates_io_api::Error,
+        err: Box<CratesIoApiError>,
     },
 
     /// The override path to the cargo manifest is invalid or cannot be resolved.

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -443,7 +443,7 @@ impl From<RemoteError> for BinstallError {
 
         match e {
             Reqwest(reqwest_error) => reqwest_error.into(),
-            Http(http_error) => http_error.into(),
+            Http(http_error) => (*http_error).into(),
         }
     }
 }

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -81,7 +81,7 @@ pub enum BinstallError {
     /// - Exit: 69
     #[error(transparent)]
     #[diagnostic(severity(error), code(binstall::http))]
-    Http(#[from] HttpError),
+    Http(#[from] Box<HttpError>),
 
     /// A subprocess failed.
     ///
@@ -443,7 +443,7 @@ impl From<RemoteError> for BinstallError {
 
         match e {
             Reqwest(reqwest_error) => reqwest_error.into(),
-            Http(http_error) => (*http_error).into(),
+            Http(http_error) => http_error.into(),
         }
     }
 }

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -160,23 +160,6 @@ pub enum BinstallError {
         err: semver::Error,
     },
 
-    /// A version requirement is not valid.
-    ///
-    /// This is usually provided via the `--version` option.
-    ///
-    /// Note that we use the [`semver`] crate, which parses Cargo version requirement syntax; they
-    /// may be slightly different from other semver requirements expressions implementations.
-    ///
-    /// - Code: `binstall::version::requirement`
-    /// - Exit: 81
-    #[error("version requirement '{req}' is not semver")]
-    #[diagnostic(severity(error), code(binstall::version::requirement))]
-    VersionReq {
-        req: CompactString,
-        #[source]
-        err: semver::Error,
-    },
-
     /// No available version matches the requirements.
     ///
     /// This may be the case when using the `--version` option.
@@ -344,7 +327,6 @@ impl BinstallError {
             CargoManifestPath => 77,
             CargoManifest { .. } => 78,
             VersionParse { .. } => 80,
-            VersionReq { .. } => 81,
             VersionMismatch { .. } => 82,
             SuperfluousVersionOption => 84,
             OverrideOptionUsedWithMultiInstall { .. } => 85,

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -319,7 +319,7 @@ pub enum BinstallError {
     NoFallbackToCargoInstall,
 
     /// A wrapped error providing the context of which crate the error is about.
-    #[error("for crate {crate_name}")]
+    #[error("For crate {crate_name}: {error}")]
     CrateContext {
         #[source]
         error: Box<BinstallError>,

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -188,17 +188,6 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::version::mismatch))]
     VersionMismatch { req: semver::VersionReq },
 
-    /// The crates.io API doesn't have manifest metadata for the given version.
-    ///
-    /// - Code: `binstall::version::unavailable`
-    /// - Exit: 83
-    #[error("no crate information available for '{crate_name}' version '{v}'")]
-    #[diagnostic(severity(error), code(binstall::version::unavailable))]
-    VersionUnavailable {
-        crate_name: CompactString,
-        v: semver::Version,
-    },
-
     /// The crate@version syntax was used at the same time as the --version option.
     ///
     /// You can't do that as it's ambiguous which should apply.
@@ -356,7 +345,6 @@ impl BinstallError {
             VersionParse { .. } => 80,
             VersionReq { .. } => 81,
             VersionMismatch { .. } => 82,
-            VersionUnavailable { .. } => 83,
             SuperfluousVersionOption => 84,
             OverrideOptionUsedWithMultiInstall { .. } => 85,
             UnspecifiedBinaries => 86,

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -11,6 +11,7 @@ use binstalk_downloader::{
 use compact_str::CompactString;
 use miette::{Diagnostic, Report};
 use thiserror::Error;
+use tinytemplate::error::Error as TinyTemplateError;
 use tokio::task;
 use tracing::{error, warn};
 
@@ -60,7 +61,7 @@ pub enum BinstallError {
     /// - Exit: 67
     #[error(transparent)]
     #[diagnostic(severity(error), code(binstall::template))]
-    Template(#[from] tinytemplate::error::Error),
+    Template(Box<TinyTemplateError>),
 
     /// A generic error from our HTTP client, reqwest.
     ///
@@ -458,5 +459,11 @@ impl From<DownloadError> for BinstallError {
             Io(io_error) => io_error.into(),
             UserAbort => BinstallError::UserAbort,
         }
+    }
+}
+
+impl From<TinyTemplateError> for BinstallError {
+    fn from(e: TinyTemplateError) -> Self {
+        BinstallError::Template(Box::new(e))
     }
 }


### PR DESCRIPTION
* Box `HttpError` in `binsalk_downloader::remote::Error::Http`
   as `HttpError` contains `Url` which are too big.
* Box `HttpError` in `BinstallError::Http` same as the previous commit.
* Box `TinyTemplateError` in `BinstallError::Template`
  since `TinyTemplateError` is 56 bytes large where most of the other variants are below 40 bytes large.
* Rm unsed variant `BinstallError::VersionUnavailable`
* Box `CratesIoApiError` in `BinstallError::CratesIoApi`
   It is 32 bytes large while other variants are below 40 bytes large.
* Improve err msg for `BinstallError::CrateContext`
* Rm unused variant `BinstallError::VersionReq`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>