### PR TITLE
Minor refactor and optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,8 @@ dependencies = [
  "mimalloc",
  "once_cell",
  "semver",
+ "strum",
+ "strum_macros",
  "supports-color",
  "tempfile",
  "tokio",

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -32,6 +32,8 @@ miette = "5.4.1"
 mimalloc = { version = "0.1.32", default-features = false, optional = true }
 once_cell = "1.16.0"
 semver = "1.0.14"
+strum = "0.24.1"
+strum_macros = "0.24.3"
 supports-color = "1.3.1"
 tempfile = "3.3.0"
 tokio = { version = "1.21.2", features = ["rt-multi-thread"], default-features = false }

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -312,7 +312,7 @@ pub fn parse() -> Result<Args, BinstallError> {
     // `cargo run -- --help` gives ["target/debug/cargo-binstall", "--help"]
     // `cargo binstall --help` gives ["/home/ryan/.cargo/bin/cargo-binstall", "binstall", "--help"]
     let mut args: Vec<OsString> = std::env::args_os().collect();
-    let args = if args.len() > 1 && args[1] == "binstall" {
+    let args = if args.get(1).map(|arg| arg == "binstall").unwrap_or_default() {
         // Equivalent to
         //
         //     args.remove(1);

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -15,6 +15,7 @@ use binstalk::{
 use clap::{Parser, ValueEnum};
 use log::LevelFilter;
 use semver::VersionReq;
+use strum_macros::EnumCount;
 
 #[derive(Debug, Parser)]
 #[clap(
@@ -296,7 +297,7 @@ impl Default for RateLimit {
 }
 
 /// Strategy for installing the package
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum, EnumCount)]
 pub enum Strategy {
     /// Attempt to download official pre-built artifacts using
     /// information provided in `Cargo.toml`.

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -25,6 +25,10 @@ use crate::{
 };
 
 pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClient) -> Result<()> {
+    // Launch target detection
+    let desired_targets = get_desired_targets(args.targets.take());
+
+    // Compute strategies
     let mut strategies = vec![];
 
     // Remove duplicate strategies
@@ -78,9 +82,6 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
         pkg_fmt: args.pkg_fmt.take(),
         bin_dir: args.bin_dir.take(),
     };
-
-    // Launch target detection
-    let desired_targets = get_desired_targets(args.targets.take());
 
     let rate_limit = args.rate_limit;
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -59,6 +59,7 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
     let rate_limit = args.rate_limit;
 
     let client = Client::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
         args.min_tls_version.map(|v| v.into()),
         Duration::from_millis(rate_limit.duration.get()),
         rate_limit.request_count,

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -99,7 +99,6 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
     let tasks: Vec<_> = if !dry_run && !no_confirm {
         // Resolve crates
         let tasks: Vec<_> = crate_names
-            .into_iter()
             .map(|(crate_name, current_version)| {
                 AutoAbortJoinHandle::spawn(ops::resolve::resolve(
                     binstall_opts.clone(),
@@ -136,7 +135,6 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
     } else {
         // Resolve crates and install without confirmation
         crate_names
-            .into_iter()
             .map(|(crate_name, current_version)| {
                 let opts = binstall_opts.clone();
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -99,9 +99,6 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
         Duration::from_millis(100),
     );
 
-    // Initialize UI thread
-    let mut uithread = UIThread::new(!args.no_confirm);
-
     let (install_path, cargo_roots, metadata, temp_dir) = block_in_place(|| -> Result<_> {
         // Compute cargo_roots
         let cargo_roots =
@@ -228,7 +225,8 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
             return Ok(());
         }
 
-        uithread.confirm().await?;
+        // Initialize UI thread
+        UIThread::new(!args.no_confirm).confirm().await?;
 
         // Install
         resolutions

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -157,7 +157,7 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
     })?;
 
     // Remove installed crates
-    let crate_names = CrateName::dedup(&args.crate_names)
+    let crate_names = CrateName::dedup(args.crate_names)
     .filter_map(|crate_name| {
         match (
             args.force,

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -108,7 +108,7 @@ pub async fn install_crates(mut args: Args, jobserver_client: LazyJobserverClien
 
         // Compute install directory
         let (install_path, custom_install_path) =
-            install_path::get_install_path(args.install_path.as_deref(), Some(&cargo_roots));
+            install_path::get_install_path(args.install_path.take(), Some(&cargo_roots));
         let install_path = install_path.ok_or_else(|| {
             error!("No viable install path found of specified, try `--install-path`");
             miette!("No install path found or specified")

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     args::{Args, Strategy},
     install_path,
-    ui::UIThread,
+    ui::confirm,
 };
 
 pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -> Result<()> {
@@ -123,8 +123,7 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
             return Ok(());
         }
 
-        // Initialize UI thread
-        UIThread::new(!no_confirm).confirm().await?;
+        confirm().await?;
 
         // Install
         resolutions

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -30,13 +30,13 @@ pub fn get_cargo_roots_path(cargo_roots: Option<PathBuf>) -> Option<PathBuf> {
 /// roughly follows <https://doc.rust-lang.org/cargo/commands/cargo-install.html#description>
 ///
 /// Return (install_path, is_custom_install_path)
-pub fn get_install_path<P: AsRef<Path>>(
-    install_path: Option<P>,
-    cargo_roots: Option<P>,
+pub fn get_install_path(
+    install_path: Option<PathBuf>,
+    cargo_roots: Option<impl AsRef<Path>>,
 ) -> (Option<PathBuf>, bool) {
     // Command line override first first
     if let Some(p) = install_path {
-        return (Some(p.as_ref().to_owned()), true);
+        return (Some(p), true);
     }
 
     // Then cargo_roots

--- a/crates/bin/src/install_path.rs
+++ b/crates/bin/src/install_path.rs
@@ -1,7 +1,6 @@
 use std::{
     env::var_os,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use binstalk::home::cargo_home;
@@ -34,15 +33,15 @@ pub fn get_cargo_roots_path(cargo_roots: Option<PathBuf>) -> Option<PathBuf> {
 pub fn get_install_path<P: AsRef<Path>>(
     install_path: Option<P>,
     cargo_roots: Option<P>,
-) -> (Option<Arc<Path>>, bool) {
+) -> (Option<PathBuf>, bool) {
     // Command line override first first
     if let Some(p) = install_path {
-        return (Some(Arc::from(p.as_ref())), true);
+        return (Some(p.as_ref().to_owned()), true);
     }
 
     // Then cargo_roots
     if let Some(p) = cargo_roots {
-        return (Some(Arc::from(p.as_ref().join("bin"))), false);
+        return (Some(p.as_ref().join("bin")), false);
     }
 
     // Local executable dir if no cargo is found
@@ -52,5 +51,5 @@ pub fn get_install_path<P: AsRef<Path>>(
         debug!("Fallback to {}", d.display());
     }
 
-    (dir.map(Arc::from), true)
+    (dir, true)
 }

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -13,8 +13,6 @@ use tracing_core::{identify_callsite, metadata::Kind, subscriber::Subscriber};
 use tracing_log::AsTrace;
 use tracing_subscriber::{filter::targets::Targets, fmt::fmt, layer::SubscriberExt};
 
-use crate::args::Args;
-
 // Shamelessly taken from tracing-log
 
 struct Fields {
@@ -131,9 +129,9 @@ impl Log for Logger {
     fn flush(&self) {}
 }
 
-pub fn logging(args: &Args) {
+pub fn logging(log_level: LevelFilter, json_output: bool) {
     // Calculate log_level
-    let log_level = min(args.log_level, STATIC_MAX_LEVEL);
+    let log_level = min(log_level, STATIC_MAX_LEVEL);
 
     let allowed_targets =
         (log_level != LevelFilter::Trace).then_some(["binstalk", "cargo_binstall"]);
@@ -145,7 +143,7 @@ pub fn logging(args: &Args) {
     let log_level = log_level.as_trace();
     let subscriber_builder = fmt().with_max_level(log_level);
 
-    let subscriber: Box<dyn Subscriber + Send + Sync> = if args.json_output {
+    let subscriber: Box<dyn Subscriber + Send + Sync> = if json_output {
         Box::new(subscriber_builder.json().finish())
     } else {
         // Disable time, target, file, line_num, thread name/ids to make the

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> MainExit {
         println!("{}", env!("CARGO_PKG_VERSION"));
         MainExit::Success(None)
     } else {
-        logging(&args);
+        logging(args.log_level, args.json_output);
 
         let start = Instant::now();
 

--- a/crates/bin/src/ui.rs
+++ b/crates/bin/src/ui.rs
@@ -19,7 +19,7 @@ pub async fn confirm() -> Result<(), BinstallError> {
             {
                 let mut stdout = io::stdout().lock();
 
-                writeln!(&mut stdout, "Do you wish to continue? yes/[no]\n? ").unwrap();
+                write!(&mut stdout, "Do you wish to continue? yes/[no]\n? ").unwrap();
                 stdout.flush().unwrap();
             }
 

--- a/crates/bin/src/ui.rs
+++ b/crates/bin/src/ui.rs
@@ -4,95 +4,45 @@ use std::{
 };
 
 use binstalk::errors::BinstallError;
-use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
-#[derive(Debug)]
-struct UIThreadInner {
-    /// Request for confirmation
-    request_tx: mpsc::Sender<()>,
+pub async fn confirm() -> Result<(), BinstallError> {
+    let (tx, rx) = oneshot::channel();
 
-    /// Confirmation
-    confirm_rx: mpsc::Receiver<Result<(), BinstallError>>,
-}
+    thread::spawn(move || {
+        // This task should be the only one able to
+        // access stdin
+        let mut stdin = io::stdin().lock();
+        let mut input = String::with_capacity(16);
 
-impl UIThreadInner {
-    fn new() -> Self {
-        let (request_tx, mut request_rx) = mpsc::channel(1);
-        let (confirm_tx, confirm_rx) = mpsc::channel(10);
+        let res = loop {
+            {
+                let mut stdout = io::stdout().lock();
 
-        thread::spawn(move || {
-            // This task should be the only one able to
-            // access stdin
-            let mut stdin = io::stdin().lock();
-            let mut input = String::with_capacity(16);
-
-            loop {
-                if request_rx.blocking_recv().is_none() {
-                    break;
-                }
-
-                let res = loop {
-                    {
-                        let mut stdout = io::stdout().lock();
-
-                        writeln!(&mut stdout, "Do you wish to continue? yes/[no]").unwrap();
-                        write!(&mut stdout, "? ").unwrap();
-                        stdout.flush().unwrap();
-                    }
-
-                    input.clear();
-                    stdin.read_line(&mut input).unwrap();
-
-                    match input.as_str().trim() {
-                        "yes" | "y" | "YES" | "Y" => break Ok(()),
-                        "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
-                        _ => continue,
-                    }
-                };
-
-                confirm_tx
-                    .blocking_send(res)
-                    .expect("entry exits when confirming request");
+                writeln!(&mut stdout, "Do you wish to continue? yes/[no]\n? ").unwrap();
+                stdout.flush().unwrap();
             }
-        });
 
-        Self {
-            request_tx,
-            confirm_rx,
-        }
-    }
+            stdin.read_line(&mut input).unwrap();
 
-    async fn confirm(&mut self) -> Result<(), BinstallError> {
-        self.request_tx
-            .send(())
-            .await
-            .map_err(|_| BinstallError::UserAbort)?;
+            match input.as_str().trim() {
+                "yes" | "y" | "YES" | "Y" => break true,
+                "no" | "n" | "NO" | "N" | "" => break false,
+                _ => {
+                    input.clear();
+                    continue;
+                }
+            }
+        };
 
-        self.confirm_rx
-            .recv()
-            .await
-            .unwrap_or(Err(BinstallError::UserAbort))
-    }
-}
+        // The main thread might be terminated by signal and thus cancelled
+        // the confirmation.
+        tx.send(res).ok();
+    });
 
-#[derive(Debug)]
-pub struct UIThread(Option<UIThreadInner>);
-
-impl UIThread {
-    ///  * `enable` - `true` to enable confirmation, `false` to disable it.
-    pub fn new(enable: bool) -> Self {
-        Self(if enable {
-            Some(UIThreadInner::new())
-        } else {
-            None
-        })
-    }
-
-    pub async fn confirm(&mut self) -> Result<(), BinstallError> {
-        if let Some(inner) = self.0.as_mut() {
-            inner.confirm().await
-        } else {
-            Ok(())
-        }
+    if rx.await.unwrap() {
+        Ok(())
+    } else {
+        Err(BinstallError::UserAbort)
     }
 }

--- a/crates/binstalk/src/drivers/version.rs
+++ b/crates/binstalk/src/drivers/version.rs
@@ -45,7 +45,7 @@ pub(super) fn find_version<Item: Version, VersionIter: Iterator<Item = Item>>(
             }
         })
         // Return highest version
-        .max_by_key(|(_item, ver)| ver.clone())
+        .max_by(|(_item_x, ver_x), (_item_y, ver_y)| ver_x.cmp(ver_y))
         .ok_or(BinstallError::VersionMismatch {
             req: version_req.clone(),
         })

--- a/crates/binstalk/src/helpers/jobserver_client.rs
+++ b/crates/binstalk/src/helpers/jobserver_client.rs
@@ -1,12 +1,11 @@
-use std::{num::NonZeroUsize, sync::Arc, thread::available_parallelism};
+use std::{num::NonZeroUsize, thread::available_parallelism};
 
 use jobslot::Client;
 use tokio::sync::OnceCell;
 
 use crate::errors::BinstallError;
 
-#[derive(Clone)]
-pub struct LazyJobserverClient(Arc<OnceCell<Client>>);
+pub struct LazyJobserverClient(OnceCell<Client>);
 
 impl LazyJobserverClient {
     /// This must be called at the start of the program since
@@ -19,7 +18,7 @@ impl LazyJobserverClient {
         // It doesn't do anything that is actually unsafe, like
         // dereferencing pointer.
         let opt = unsafe { Client::from_env() };
-        Self(Arc::new(OnceCell::new_with(opt)))
+        Self(OnceCell::new_with(opt))
     }
 
     pub async fn get(&self) -> Result<&Client, BinstallError> {

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -2,11 +2,12 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use crates_io_api::AsyncClient as CratesIoApiClient;
 use semver::VersionReq;
 
 use crate::{
     fetchers::{Data, Fetcher},
-    helpers::remote::Client,
+    helpers::{jobserver_client::LazyJobserverClient, remote::Client},
     manifests::cargo_toml_binstall::PkgOverride,
     DesiredTargets,
 };
@@ -20,11 +21,19 @@ pub struct Options {
     pub no_symlinks: bool,
     pub dry_run: bool,
     pub force: bool,
+    pub quiet: bool,
+
     pub version_req: Option<VersionReq>,
     pub manifest_path: Option<PathBuf>,
     pub cli_overrides: PkgOverride,
+
     pub desired_targets: DesiredTargets,
-    pub quiet: bool,
     pub resolvers: Vec<Resolver>,
     pub cargo_install_fallback: bool,
+
+    pub temp_dir: PathBuf,
+    pub install_path: PathBuf,
+    pub client: Client,
+    pub crates_io_api_client: CratesIoApiClient,
+    pub jobserver_client: LazyJobserverClient,
 }

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -16,7 +16,6 @@ use crate::{
 pub async fn install(
     resolution: Resolution,
     opts: Arc<Options>,
-    jobserver_client: LazyJobserverClient,
 ) -> Result<Option<CrateInfo>, BinstallError> {
     match resolution {
         Resolution::AlreadyUpToDate => Ok(None),
@@ -51,7 +50,7 @@ pub async fn install(
                     &name,
                     &version,
                     target,
-                    jobserver_client,
+                    &opts.jobserver_client,
                     opts.quiet,
                     opts.force,
                 )
@@ -99,7 +98,7 @@ async fn install_from_source(
     name: &str,
     version: &str,
     target: &str,
-    lazy_jobserver_client: LazyJobserverClient,
+    lazy_jobserver_client: &LazyJobserverClient,
     quiet: bool,
     force: bool,
 ) -> Result<(), BinstallError> {

--- a/crates/binstalk/src/ops/resolve/crate_name.rs
+++ b/crates/binstalk/src/ops/resolve/crate_name.rs
@@ -43,8 +43,7 @@ impl FromStr for CrateName {
 }
 
 impl CrateName {
-    pub fn dedup(crate_names: &[Self]) -> impl Iterator<Item = Self> {
-        let mut crate_names = crate_names.to_vec();
+    pub fn dedup(mut crate_names: Vec<Self>) -> impl Iterator<Item = Self> {
         crate_names.sort_by(|x, y| x.name.cmp(&y.name));
         crate_names.into_iter().coalesce(|previous, current| {
             if previous.name == current.name {
@@ -62,7 +61,7 @@ mod tests {
 
     macro_rules! assert_dedup {
         ([ $( ( $input_name:expr, $input_version:expr ) ),*  ], [ $( ( $output_name:expr, $output_version:expr ) ),*  ]) => {
-            let input_crate_names = [$( CrateName {
+            let input_crate_names = vec![$( CrateName {
                 name: $input_name.into(),
                 version_req: Some($input_version.parse().unwrap())
             }, )*];
@@ -72,7 +71,7 @@ mod tests {
             }, )*];
             output_crate_names.sort_by(|x, y| x.name.cmp(&y.name));
 
-            let crate_names: Vec<_> = CrateName::dedup(&input_crate_names).collect();
+            let crate_names: Vec<_> = CrateName::dedup(input_crate_names).collect();
             assert_eq!(crate_names, output_crate_names);
         };
     }


### PR DESCRIPTION
* Avoid potential panicking in `args::parse` by using `Vec::get` instead of indexing
* Refactor: Simplify `opts::{resolve, install}` API
   Many parameters can be shared and put into `opts::Options` intead and
   that would also avoid a few `Arc<Path>`.
* Optimize `get_install_path`: Avoid cloning `install_path`
* Optimize `LazyJobserverClient`: Un`Arc` & remove `Clone` impl
   to avoid additional boxing
* Optimize `find_version`: Avoid cloning `semver::Version`
* Optimize `GhCrateMeta::launch_baseline_find_tasks`
   return `impl Iterator<Item = impl Future<Output = ...>>`
   instead of `impl Iterator<Item = AutoAbortJoinHandle<...>>`
   to avoid unnecessary spawning.
   
   Each task spawned has to be boxed and then polled by tokio runtime.
   They might also be moved.
   
   While they increase parallelism, spawning these futures does not justify
   the costs because:
    - Each `Future` only calls `remote_exists`
    - Each `remote_exists` call send requests to the same domain, which is
      likely to share the same http2 connection.
      Since the conn is shared anyway, spawning does not speedup anything
      but merely add communication overhead.
    - Plus the tokio runtime spawning cost
* Optimize `install_crates`: Destruct `Args` before any `.await` point
   to reduce size of the future
* Refactor `logging`: Replace param `arg` with `log_level` & `json_output`
   to avoid dep on `Args`
* Add dep strum & strum_macros to crates/bin
* Derive `strum_macros::EnumCount` for `Strategy`
* Optimize strategies parsing in `install_crates`
* Fix panic in `install_crates` when `Compile` is not the last strategy specified
* Optimize: Take `Vec<Self>` instead of slice in `CrateName::dedup`
* Refactor: Extract new fn `compute_resolvers`
* Refactor: Extract new fn `compute_paths_and_load_manifests`
* Refactor: Extract new fn `filter_out_installed_crates`
* Reorder `install_crates`: Only run target detection if args are valid
   and there are some crates to be installed.
* Optimize `filter_out_installed_crates`: Avoid allocation
   by returning an `Iterator`
* Fix user_agent of `remote::Client`: Let user specify it
* Refactor: Replace `UIThread` with `ui::confirm`
   which is much simpler.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>