### PR TITLE
Minor optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "compact_str",
  "crates_io_api",
  "detect-targets",
+ "either",
  "futures-util",
  "home",
  "itertools",

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -17,6 +17,7 @@ cargo_toml = "0.13.0"
 compact_str = { version = "0.6.0", features = ["serde"] }
 crates_io_api = { version = "0.8.1", default-features = false }
 detect-targets = { version = "0.1.2", path = "../detect-targets" }
+either = "1.8.0"
 futures-util = { version = "0.3.25", default-features = false, features = ["std"] }
 home = "0.5.4"
 itertools = "0.10.5"

--- a/crates/binstalk/src/drivers/crates_io/visitor.rs
+++ b/crates/binstalk/src/drivers/crates_io/visitor.rs
@@ -43,9 +43,8 @@ impl TarEntriesVisitor for ManifestVisitor {
             let path = entry.path()?;
             let path = path.normalize();
 
-            let path = if let Ok(path) = path.strip_prefix(&self.manifest_dir_path) {
-                path
-            } else {
+            let Ok(path) = path.strip_prefix(&self.manifest_dir_path)
+                else {
                 // The path is outside of the curr dir (manifest dir),
                 // ignore it.
                 continue;

--- a/crates/binstalk/src/drivers/version.rs
+++ b/crates/binstalk/src/drivers/version.rs
@@ -44,7 +44,7 @@ pub(super) fn find_version<Item: Version, VersionIter: Iterator<Item = Item>>(
         })
         // Return highest version
         .max_by(|(_item_x, ver_x), (_item_y, ver_y)| ver_x.cmp(ver_y))
-        .ok_or(BinstallError::VersionMismatch {
+        .ok_or_else(|| BinstallError::VersionMismatch {
             req: version_req.clone(),
         })
 }

--- a/crates/binstalk/src/drivers/version.rs
+++ b/crates/binstalk/src/drivers/version.rs
@@ -36,11 +36,7 @@ pub(super) fn find_version<Item: Version, VersionIter: Iterator<Item = Item>>(
             let ver = item.get_version()?;
 
             // Filter by version match
-            if version_req.matches(&ver) {
-                Some((item, ver))
-            } else {
-                None
-            }
+            version_req.matches(&ver).then_some((item, ver))
         })
         // Return highest version
         .max_by(|(_item_x, ver_x), (_item_y, ver_y)| ver_x.cmp(ver_y))

--- a/crates/binstalk/src/drivers/version.rs
+++ b/crates/binstalk/src/drivers/version.rs
@@ -1,5 +1,4 @@
 use semver::VersionReq;
-use tracing::debug;
 
 use crate::errors::BinstallError;
 
@@ -38,7 +37,6 @@ pub(super) fn find_version<Item: Version, VersionIter: Iterator<Item = Item>>(
 
             // Filter by version match
             if version_req.matches(&ver) {
-                debug!("Version: {:?}", ver);
                 Some((item, ver))
             } else {
                 None

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -17,7 +17,7 @@ pub(crate) mod quickinstall;
 pub trait Fetcher: Send + Sync {
     /// Create a new fetcher from some data
     #[allow(clippy::new_ret_no_self)]
-    fn new(client: &Client, data: &Arc<Data>) -> Arc<dyn Fetcher>
+    fn new(client: Client, data: Arc<Data>, target_data: Arc<TargetData>) -> Arc<dyn Fetcher>
     where
         Self: Sized;
 
@@ -61,8 +61,13 @@ pub trait Fetcher: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct Data {
     pub name: CompactString,
-    pub target: String,
     pub version: CompactString,
     pub repo: Option<String>,
+}
+
+/// Target specific data required to fetch a package
+#[derive(Clone, Debug)]
+pub struct TargetData {
+    pub target: String,
     pub meta: PkgMeta,
 }

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -23,7 +23,6 @@ const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
 pub struct QuickInstall {
     client: Client,
     package: String,
-    target: String,
     data: Arc<Data>,
 }
 
@@ -32,11 +31,10 @@ impl super::Fetcher for QuickInstall {
     fn new(client: &Client, data: &Arc<Data>) -> Arc<dyn super::Fetcher> {
         let crate_name = &data.name;
         let version = &data.version;
-        let target = data.target.clone();
+        let target = &data.target;
         Arc::new(Self {
             client: client.clone(),
             package: format!("{crate_name}-{version}-{target}"),
-            target,
             data: data.clone(),
         })
     }
@@ -87,7 +85,7 @@ impl super::Fetcher for QuickInstall {
     }
 
     fn target(&self) -> &str {
-        &self.target
+        &self.data.target
     }
 }
 

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -23,7 +23,6 @@ const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
 pub struct QuickInstall {
     client: Client,
     package: String,
-    data: Arc<Data>,
     target_data: Arc<TargetData>,
 }
 
@@ -40,7 +39,6 @@ impl super::Fetcher for QuickInstall {
         Arc::new(Self {
             client,
             package: format!("{crate_name}-{version}-{target}"),
-            data,
             target_data,
         })
     }

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -6,7 +6,7 @@ use crates_io_api::AsyncClient as CratesIoApiClient;
 use semver::VersionReq;
 
 use crate::{
-    fetchers::{Data, Fetcher},
+    fetchers::{Data, Fetcher, TargetData},
     helpers::{jobserver_client::LazyJobserverClient, remote::Client},
     manifests::cargo_toml_binstall::PkgOverride,
     DesiredTargets,
@@ -15,7 +15,7 @@ use crate::{
 pub mod install;
 pub mod resolve;
 
-pub type Resolver = fn(&Client, &Arc<Data>) -> Arc<dyn Fetcher>;
+pub type Resolver = fn(Client, Arc<Data>, Arc<TargetData>) -> Arc<dyn Fetcher>;
 
 pub struct Options {
     pub no_symlinks: bool,

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -28,7 +28,7 @@ pub async fn install(
         } => {
             let target = fetcher.target().into();
 
-            install_from_package(opts, bin_files).await.map(|option| {
+            install_from_package(opts, bin_files).map(|option| {
                 option.map(|bins| CrateInfo {
                     name,
                     version_req,
@@ -66,7 +66,7 @@ pub async fn install(
     }
 }
 
-async fn install_from_package(
+fn install_from_package(
     opts: Arc<Options>,
     bin_files: Vec<bins::BinFile>,
 ) -> Result<Option<Vec<CompactString>>, BinstallError> {

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -163,7 +163,7 @@ async fn resolve_inner(
             })
             .cartesian_product(resolvers)
             .map(|(target_data, f)| {
-                let fetcher = f(opts.client.clone(), data.clone(), target_data.clone());
+                let fetcher = f(opts.client.clone(), data.clone(), target_data);
                 (
                     fetcher.clone(),
                     AutoAbortJoinHandle::spawn(async move { fetcher.find().await }),

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -58,17 +58,15 @@ impl Resolution {
                     fetcher.source_name()
                 );
 
-                if fetcher.is_third_party() {
-                    warn!(
-                        "The package will be downloaded from third-party source {}",
-                        fetcher.source_name()
-                    );
-                } else {
-                    info!(
-                        "The package will be downloaded from {}",
-                        fetcher.source_name()
-                    );
-                }
+                warn!(
+                    "The package will be downloaded from {}{}",
+                    if fetcher.is_third_party() {
+                        "third-party source "
+                    } else {
+                        ""
+                    },
+                    fetcher.source_name()
+                );
 
                 info!("This will install the following binaries:");
                 for file in bin_files {


### PR DESCRIPTION
* Optimization: Rm `debug!` in `find_version`
   printing all version iterated obviously doesn't help much in debugging
   in the problem but rather just confusing.
   
   Also this makes it hard for the compiler to optimize the iterators.
* Use let-else in `ManifestVisitor`
* Optimize `BinFile::preview_{bin, link}` for zero-copy
   Return `impl Display` that lazily format instead of allocating a `String`
* Optimize `infer_bin_dir_template`: Generate dir lazily
* Optimize `find_version`: Lazily clone `version_req` only on err
* Refactor `find_version`: Use `bool::then_some`
* Add dep either v1.8.0 to binstalk
* Optimize `GhCrateMeta::find`: Avoid cloning and `Vec` creation
   by using `Either`
* Optimize `ops::install::install_from_package`: Make it a regular fn
   instead of async fn since it does not `.await` on any async fn.
* Optimize `QuickInstall`: Rm field `target`
   since `Arc<Data>` already contains that field.
* Optimize `Fetcher`s: Extract new struct `TargetData`
   so that `Data` can be shared by all fetchers, regardless of the target.
* Optimize `QuickInstall`: Rm unused field `data`
* Optimize `Resolution::print`: Replace branching with conditional move

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>