### PR TITLE
Enforce strict strategies parsing rule: Reject duplicate strategy in `--strategies`

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -302,11 +302,11 @@ impl Default for RateLimit {
 pub enum Strategy {
     /// Attempt to download official pre-built artifacts using
     /// information provided in `Cargo.toml`.
-    CrateMetaData = 0,
+    CrateMetaData,
     /// Query third-party QuickInstall for the crates.
-    QuickInstall = 1,
+    QuickInstall,
     /// Build the crates from source using `cargo-build`.
-    Compile = 2,
+    Compile,
 }
 
 pub fn parse() -> Result<Args, BinstallError> {

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -298,14 +298,15 @@ impl Default for RateLimit {
 
 /// Strategy for installing the package
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum, EnumCount)]
+#[repr(u8)]
 pub enum Strategy {
     /// Attempt to download official pre-built artifacts using
     /// information provided in `Cargo.toml`.
-    CrateMetaData,
+    CrateMetaData = 0,
     /// Query third-party QuickInstall for the crates.
-    QuickInstall,
+    QuickInstall = 1,
     /// Build the crates from source using `cargo-build`.
-    Compile,
+    Compile = 2,
 }
 
 pub fn parse() -> Result<Args, BinstallError> {

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -193,7 +193,7 @@ fn compute_resolvers(
 
     if strategies.len() > Strategy::COUNT {
         // If len of strategies is larger than number of variants of Strategy,
-        // then there must be duplicates by pieon hole principle.
+        // then there must be duplicates by pigeon hole principle.
         return Err(dup_strategy_err);
     }
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -185,22 +185,20 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
 
 /// Return (resolvers, cargo_install_fallback)
 fn compute_resolvers(
-    input_strategies: Vec<Strategy>,
+    mut strategies: Vec<Strategy>,
     mut disable_strategies: Vec<Strategy>,
 ) -> Result<(Vec<Resolver>, bool), BinstallError> {
-    // Compute strategies
-    let mut strategies = vec![];
+    // Whether specific variant of Strategy is present
+    let mut is_variant_present = [false; Strategy::COUNT];
 
-    // Remove duplicate strategies
-    for strategy in input_strategies {
-        if strategies.len() == Strategy::COUNT {
-            // All variants of Strategy is present in strategies,
-            // there is no need to continue since all the remaining
-            // args.strategies must be present in stratetgies.
-            break;
-        }
-        if !strategies.contains(&strategy) {
-            strategies.push(strategy);
+    for strategy in &strategies {
+        let index = *strategy as u8 as usize;
+        if is_variant_present[index] {
+            return Err(BinstallError::InvalidStrategies(
+                &"--strategies should not contain duplicate strategy",
+            ));
+        } else {
+            is_variant_present[index] = true;
         }
     }
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -228,7 +228,9 @@ fn compute_resolvers(
     }
 
     if strategies.is_empty() {
-        return Err(BinstallError::InvalidStrategies(&"No strategy is provided"));
+        return Err(BinstallError::InvalidStrategies(
+            &"You have disabled all strategies",
+        ));
     }
 
     let cargo_install_fallback = *strategies.last().unwrap() == Strategy::Compile;

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -218,12 +218,15 @@ fn compute_resolvers(
         ];
     }
 
+    // Filter out all disabled strategies
     if !disable_strategies.is_empty() {
         // Since order doesn't matter, we can sort it and remove all duplicates
         // to speedup checking.
         disable_strategies.sort_unstable();
         disable_strategies.dedup();
 
+        // disable_strategies.len() <= Strategy::COUNT, of which is faster
+        // to just use [T]::contains rather than [T]::binary_search
         strategies.retain(|strategy| !disable_strategies.contains(strategy));
 
         if strategies.is_empty() {

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -211,19 +211,14 @@ fn compute_resolvers(
         ];
     }
 
-    let mut strategies: Vec<Strategy> = if !disable_strategies.is_empty() {
+    if !disable_strategies.is_empty() {
         // Since order doesn't matter, we can sort it and remove all duplicates
         // to speedup checking.
         disable_strategies.sort_unstable();
         disable_strategies.dedup();
 
-        strategies
-            .into_iter()
-            .filter(|strategy| !disable_strategies.contains(strategy))
-            .collect()
-    } else {
-        strategies
-    };
+        strategies.retain(|strategy| !disable_strategies.contains(strategy));
+    }
 
     if strategies.is_empty() {
         return Err(BinstallError::InvalidStrategies(&"No strategy is provided"));

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -225,12 +225,12 @@ fn compute_resolvers(
         disable_strategies.dedup();
 
         strategies.retain(|strategy| !disable_strategies.contains(strategy));
-    }
 
-    if strategies.is_empty() {
-        return Err(BinstallError::InvalidStrategies(
-            &"You have disabled all strategies",
-        ));
+        if strategies.is_empty() {
+            return Err(BinstallError::InvalidStrategies(
+                &"You have disabled all strategies",
+            ));
+        }
     }
 
     let cargo_install_fallback = *strategies.last().unwrap() == Strategy::Compile;

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -188,15 +188,22 @@ fn compute_resolvers(
     mut strategies: Vec<Strategy>,
     mut disable_strategies: Vec<Strategy>,
 ) -> Result<(Vec<Resolver>, bool), BinstallError> {
+    let dup_strategy_err =
+        BinstallError::InvalidStrategies(&"--strategies should not contain duplicate strategy");
+
+    if strategies.len() > Strategy::COUNT {
+        // If len of strategies is larger than number of variants of Strategy,
+        // then there must be duplicates by pieon hole principle.
+        return Err(dup_strategy_err);
+    }
+
     // Whether specific variant of Strategy is present
     let mut is_variant_present = [false; Strategy::COUNT];
 
     for strategy in &strategies {
         let index = *strategy as u8 as usize;
         if is_variant_present[index] {
-            return Err(BinstallError::InvalidStrategies(
-                &"--strategies should not contain duplicate strategy",
-            ));
+            return Err(dup_strategy_err);
         } else {
             is_variant_present[index] = true;
         }

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -189,7 +189,7 @@ fn compute_resolvers(
     mut disable_strategies: Vec<Strategy>,
 ) -> Result<(Vec<Resolver>, bool), BinstallError> {
     let dup_strategy_err =
-        BinstallError::InvalidStrategies(&"--strategies should not contain duplicate strategy");
+        BinstallError::InvalidStrategies("--strategies should not contain duplicate strategy");
 
     if strategies.len() > Strategy::COUNT {
         // If len of strategies is larger than number of variants of Strategy,
@@ -231,7 +231,7 @@ fn compute_resolvers(
 
         if strategies.is_empty() {
             return Err(BinstallError::InvalidStrategies(
-                &"You have disabled all strategies",
+                "You have disabled all strategies",
             ));
         }
     }
@@ -248,7 +248,7 @@ fn compute_resolvers(
             Strategy::CrateMetaData => Ok(GhCrateMeta::new as Resolver),
             Strategy::QuickInstall => Ok(QuickInstall::new as Resolver),
             Strategy::Compile => Err(BinstallError::InvalidStrategies(
-                &"Compile strategy must be the last one",
+                "Compile strategy must be the last one",
             )),
         })
         .collect::<Result<Vec<_>, BinstallError>>()?;

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -291,7 +291,7 @@ pub enum BinstallError {
     /// - Exit: 93
     #[error("Invalid strategies configured: {0}")]
     #[diagnostic(severity(error), code(binstall::strategies))]
-    InvalidStrategies(&'static &'static str),
+    InvalidStrategies(&'static str),
 
     /// Fallback to `cargo-install` is disabled.
     ///


### PR DESCRIPTION
`cargo-binstall` should reject duplicate strategy in `--strategies` as it is illegal input and it cannot be interpreted reasonably.

* Reject duplicate strategy in `--strategies`
* Optimize `compute_resolvers`: Use `Vec::retain`
   instead of `Iterator::filter` plus collecting into `Vec`.
* Optimize `compute_resolvers`: Reject `strategies.len() > Strategy::COUNT`
* Improve err msg for cases where user disabled all strategies
* Simplify `BinstallError::InvalidStrategies`: Takes `&'static str`
   instead of `&'static &'static str` since other variants are larger than 8B.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>