### PR TITLE
Fix workflow release-pr: Install nightly toolchain

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Configure toolchain
+        run: |
+          rustup toolchain install --profile minimal --no-self-update nightly
+          rustup default nightly
       - uses: chainguard-dev/actions/setup-gitsign@main
       - name: Install cargo-release
         uses: taiki-e/install-action@v1


### PR DESCRIPTION
Default rust in ubuntu-latest is too old.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>