### PR TITLE
Return `Future + 'static` in `GhCrateMeta::launch_baseline_find_tasks`

### DIFF
--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -40,7 +40,7 @@ impl GhCrateMeta {
         pkg_fmt: PkgFmt,
         pkg_url: &'a str,
         repo: Option<&'a str>,
-    ) -> impl Iterator<Item = impl Future<Output = FindTaskRes> + 'a> + 'a {
+    ) -> impl Iterator<Item = impl Future<Output = FindTaskRes> + 'static> + 'a {
         // build up list of potential URLs
         let urls = pkg_fmt.extensions().iter().filter_map(move |ext| {
             let ctx = Context::from_data_with_repo(&self.data, &self.target_data.target, ext, repo);


### PR DESCRIPTION
So that the borrow checker know that `FuturesUnordered<F>` holds no reference to any data and thus it can further optimize future returned by `GhCrateMeta::find`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>