### PR TITLE
Optimize `Fetcher::find` and fix quickinstall reporting

### DIFF
--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -6,7 +6,7 @@ pub use quickinstall::*;
 
 use crate::{
     errors::BinstallError,
-    helpers::remote::Client,
+    helpers::{remote::Client, tasks::AutoAbortJoinHandle},
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
 
@@ -32,7 +32,7 @@ pub trait Fetcher: Send + Sync {
     ///
     /// Must return `true` if a package is available, `false` if none is, and reserve errors to
     /// fatal conditions only.
-    async fn find(&self) -> Result<bool, BinstallError>;
+    fn find(self: Arc<Self>) -> AutoAbortJoinHandle<Result<bool, BinstallError>>;
 
     /// Return the package format
     fn pkg_fmt(&self) -> PkgFmt;

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use compact_str::CompactString;
-use tracing::debug;
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
@@ -47,7 +47,12 @@ impl super::Fetcher for QuickInstall {
         AutoAbortJoinHandle::spawn(async move {
             let this = self.clone();
             tokio::spawn(async move {
-                let _ = this.report().await;
+                if let Err(err) = this.report().await {
+                    warn!(
+                        "Failed to send quickinstall report for package {}: {err}",
+                        this.package
+                    )
+                }
             });
 
             let url = self.package_url();

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -20,7 +20,7 @@ use crate::{
     drivers::fetch_crate_cratesio,
     errors::BinstallError,
     fetchers::{Data, Fetcher, TargetData},
-    helpers::{remote::Client, tasks::AutoAbortJoinHandle},
+    helpers::remote::Client,
     manifests::cargo_toml_binstall::{Meta, PkgMeta, PkgOverride},
 };
 
@@ -162,10 +162,7 @@ async fn resolve_inner(
             .cartesian_product(resolvers)
             .map(|(target_data, f)| {
                 let fetcher = f(opts.client.clone(), data.clone(), target_data);
-                (
-                    fetcher.clone(),
-                    AutoAbortJoinHandle::spawn(async move { fetcher.find().await }),
-                )
+                (fetcher.clone(), fetcher.find())
             }),
     );
 


### PR DESCRIPTION
* Optimize `Fetcher::find`: Make it non-async to avoid boxing
   and return `AutoAbortJoinHandle<...>` instead.
   
   Since spawning a new task in tokio box the future anyway, boxing the
   returned future again in `Fetcher::find` merely adds unnecessary
   overheads.
* Optimize `QuickInstall::report`: Make it async fn instead of ret `JoinHandle`
   
   This provides several benefits:
    - On debug build, no task will be spawned
    - The calls to `self.stats_url()` can be evaluated in parallel.
    - The task now returns `()` so that the task spawned is smaller.
* Fix `QuickInstall::find`: `warn!` if quickinstall report fails

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>