### PR TITLE
Optimize use of `tokio::select!`: Use biased selection

### DIFF
--- a/crates/binstalk-downloader/src/download/stream_readable.rs
+++ b/crates/binstalk-downloader/src/download/stream_readable.rs
@@ -122,10 +122,12 @@ where
             let option = self.handle.block_on(async {
                 if let Some(cancellation_future) = self.cancellation_future.as_mut() {
                     tokio::select! {
-                        res = next_stream(&mut self.stream) => res,
+                        biased;
+
                         res = cancellation_future => {
                             Err(res.err().unwrap_or_else(|| io::Error::from(DownloadError::UserAbort)))
                         },
+                        res = next_stream(&mut self.stream) => res,
                     }
                 } else {
                     next_stream(&mut self.stream).await


### PR DESCRIPTION
as there is no need to randomize the first one to be polled.

For `cancel_on_user_sig_term` and `StreamReadable::fill_buf`, the cancellation future should always to be polled first so that user would feel responsive.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>