### PR TITLE
Optimize `BinstallError`: Reduce size from 40B to 32B

### DIFF
--- a/crates/binstalk/src/drivers/crates_io.rs
+++ b/crates/binstalk/src/drivers/crates_io.rs
@@ -6,7 +6,7 @@ use semver::VersionReq;
 use tracing::debug;
 
 use crate::{
-    errors::BinstallError,
+    errors::{BinstallError, CratesIoApiError},
     helpers::{
         download::Download,
         remote::{Client, Url},
@@ -33,14 +33,12 @@ pub async fn fetch_crate_cratesio(
     debug!("Looking up crate information");
 
     // Fetch online crate information
-    let base_info =
-        crates_io_api_client
-            .get_crate(name)
-            .await
-            .map_err(|err| BinstallError::CratesIoApi {
-                crate_name: name.into(),
-                err: Box::new(err),
-            })?;
+    let base_info = crates_io_api_client.get_crate(name).await.map_err(|err| {
+        Box::new(CratesIoApiError {
+            crate_name: name.into(),
+            err,
+        })
+    })?;
 
     // Locate matching version
     let version_iter = base_info.versions.iter().filter(|v| !v.yanked);

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -8,6 +8,7 @@ use binstalk_downloader::{
     download::{DownloadError, ZipError},
     remote::{Error as RemoteError, HttpError, ReqwestError},
 };
+use cargo_toml::Error as CargoTomlError;
 use compact_str::CompactString;
 use miette::{Diagnostic, Report};
 use thiserror::Error;
@@ -149,7 +150,7 @@ pub enum BinstallError {
         code(binstall::cargo_manifest),
         help("If you used --manifest-path, check the Cargo.toml syntax.")
     )]
-    CargoManifest(#[from] cargo_toml::Error),
+    CargoManifest(Box<CargoTomlError>),
 
     /// A version is not valid semver.
     ///
@@ -442,5 +443,11 @@ impl From<DownloadError> for BinstallError {
 impl From<TinyTemplateError> for BinstallError {
     fn from(e: TinyTemplateError) -> Self {
         BinstallError::Template(Box::new(e))
+    }
+}
+
+impl From<CargoTomlError> for BinstallError {
+    fn from(e: CargoTomlError) -> Self {
+        BinstallError::CargoManifest(Box::new(e))
     }
 }

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -35,9 +35,9 @@ pub struct VersionParseError {
 #[derive(Debug, Error)]
 #[error("For crate {crate_name}: {err}")]
 pub struct CrateContextError {
-    pub crate_name: CompactString,
+    crate_name: CompactString,
     #[source]
-    pub err: BinstallError,
+    err: BinstallError,
 }
 
 /// Error kinds emitted by cargo-binstall.

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -24,6 +24,14 @@ pub struct CratesIoApiError {
     pub err: crates_io_api::Error,
 }
 
+#[derive(Debug, Error)]
+#[error("version string '{v}' is not semver: {err}")]
+pub struct VersionParseError {
+    pub v: CompactString,
+    #[source]
+    pub err: semver::Error,
+}
+
 /// Error kinds emitted by cargo-binstall.
 #[derive(Error, Diagnostic, Debug)]
 #[non_exhaustive]
@@ -159,13 +167,9 @@ pub enum BinstallError {
     ///
     /// - Code: `binstall::version::parse`
     /// - Exit: 80
-    #[error("version string '{v}' is not semver")]
+    #[error(transparent)]
     #[diagnostic(severity(error), code(binstall::version::parse))]
-    VersionParse {
-        v: CompactString,
-        #[source]
-        err: semver::Error,
-    },
+    VersionParse(#[from] Box<VersionParseError>),
 
     /// No available version matches the requirements.
     ///

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -100,7 +100,10 @@ pub enum BinstallError {
     /// - Exit: 70
     #[error("subprocess {command} errored with {status}")]
     #[diagnostic(severity(error), code(binstall::subprocess))]
-    SubProcess { command: String, status: ExitStatus },
+    SubProcess {
+        command: Box<str>,
+        status: ExitStatus,
+    },
 
     /// A generic I/O error.
     ///

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -131,8 +131,6 @@ async fn install_from_source(
         cmd.arg("--force");
     }
 
-    let command_string = format!("{cmd:?}");
-
     let mut child = jobserver_client.configure_and_run(&mut cmd, |cmd| cmd.spawn())?;
 
     debug!("Spawned command pid={:?}", child.id());
@@ -144,7 +142,7 @@ async fn install_from_source(
     } else {
         error!("Cargo errored! {status:?}");
         Err(BinstallError::SubProcess {
-            command: command_string.into_boxed_str(),
+            command: format!("{cmd:?}").into_boxed_str(),
             status,
         })
     }

--- a/crates/binstalk/src/ops/install.rs
+++ b/crates/binstalk/src/ops/install.rs
@@ -144,7 +144,7 @@ async fn install_from_source(
     } else {
         error!("Cargo errored! {status:?}");
         Err(BinstallError::SubProcess {
-            command: command_string,
+            command: command_string.into_boxed_str(),
             status,
         })
     }

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -18,7 +18,7 @@ use super::Options;
 use crate::{
     bins,
     drivers::fetch_crate_cratesio,
-    errors::BinstallError,
+    errors::{BinstallError, VersionParseError},
     fetchers::{Data, Fetcher, TargetData},
     helpers::remote::Client,
     manifests::cargo_toml_binstall::{Meta, PkgMeta, PkgOverride},
@@ -409,10 +409,11 @@ impl PackageInfo {
         let new_version = match Version::parse(&new_version_str) {
             Ok(new_version) => new_version,
             Err(err) => {
-                return Err(BinstallError::VersionParse {
+                return Err(Box::new(VersionParseError {
                     v: new_version_str,
                     err,
                 })
+                .into())
             }
         };
 


### PR DESCRIPTION
* Optimize `BinstallError::CratesIoApi`: Extract new type `errors::CratesIoApiError` and box it
   Also improve `<CratesIoApiError as Display>::fmt` impl.
* Optimize `BinstallError::SubProcess`: Use `Box<str>` instead of `String`
* Optimize `BinstallError::CargoManifest`: Box `CargoTomlError`
* Optimize `BinstallError::VersionParse`: Extract `VersionParseError` and box it
   Also improve `<VersionParseError as Display>::fmt` impl.
* Optimize `BinstallError::CrateContext`: Extract `CrateContextError` and box it in
* Optimize `install_from_source`: Only format `cmd` on err

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>