### PR TITLE
Fix error reporting in main and move all arg validation into fn `args::parse`

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -427,3 +427,13 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
 
     opts
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn verify_cli() {
+        Args::command().debug_assert()
+    }
+}

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -348,12 +348,15 @@ pub fn parse() -> Args {
         };
 
         if !option.is_empty() {
-            let msg = format!(
-                r#"override option used with multi package syntax.
+            command
+                .error(
+                    ErrorKind::ArgumentConflict,
+                    format_args!(
+                        r#"override option used with multi package syntax.
 You cannot use --{option} and specify multiple packages at the same time. Do one or the other."#
-            );
-
-            command.error(ErrorKind::ArgumentConflict, msg).exit();
+                    ),
+                )
+                .exit();
         }
     }
 

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -17,7 +17,6 @@ use binstalk_manifests::{
 use crates_io_api::AsyncClient as CratesIoApiClient;
 use log::LevelFilter;
 use miette::{miette, Result, WrapErr};
-use strum::EnumCount;
 use tokio::task::block_in_place;
 use tracing::{debug, error, info, warn};
 
@@ -28,9 +27,21 @@ use crate::{
 };
 
 pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -> Result<()> {
-    // Compute strategies
-    let (resolvers, cargo_install_fallback) =
-        compute_resolvers(args.strategies, args.disable_strategies)?;
+    // Compute Resolvers
+    let mut cargo_install_fallback = false;
+
+    let resolvers: Vec<_> = args
+        .strategies
+        .into_iter()
+        .filter_map(|strategy| match strategy {
+            Strategy::CrateMetaData => Some(GhCrateMeta::new as Resolver),
+            Strategy::QuickInstall => Some(QuickInstall::new as Resolver),
+            Strategy::Compile => {
+                cargo_install_fallback = true;
+                None
+            }
+        })
+        .collect();
 
     // Compute paths
     let (install_path, cargo_roots, metadata, temp_dir) =
@@ -181,79 +192,6 @@ pub async fn install_crates(args: Args, jobserver_client: LazyJobserverClient) -
 
         Ok(())
     })
-}
-
-/// Return (resolvers, cargo_install_fallback)
-fn compute_resolvers(
-    mut strategies: Vec<Strategy>,
-    mut disable_strategies: Vec<Strategy>,
-) -> Result<(Vec<Resolver>, bool), BinstallError> {
-    let dup_strategy_err =
-        BinstallError::InvalidStrategies("--strategies should not contain duplicate strategy");
-
-    if strategies.len() > Strategy::COUNT {
-        // If len of strategies is larger than number of variants of Strategy,
-        // then there must be duplicates by pigeon hole principle.
-        return Err(dup_strategy_err);
-    }
-
-    // Whether specific variant of Strategy is present
-    let mut is_variant_present = [false; Strategy::COUNT];
-
-    for strategy in &strategies {
-        let index = *strategy as u8 as usize;
-        if is_variant_present[index] {
-            return Err(dup_strategy_err);
-        } else {
-            is_variant_present[index] = true;
-        }
-    }
-
-    // Default strategies if empty
-    if strategies.is_empty() {
-        strategies = vec![
-            Strategy::CrateMetaData,
-            Strategy::QuickInstall,
-            Strategy::Compile,
-        ];
-    }
-
-    // Filter out all disabled strategies
-    if !disable_strategies.is_empty() {
-        // Since order doesn't matter, we can sort it and remove all duplicates
-        // to speedup checking.
-        disable_strategies.sort_unstable();
-        disable_strategies.dedup();
-
-        // disable_strategies.len() <= Strategy::COUNT, of which is faster
-        // to just use [T]::contains rather than [T]::binary_search
-        strategies.retain(|strategy| !disable_strategies.contains(strategy));
-
-        if strategies.is_empty() {
-            return Err(BinstallError::InvalidStrategies(
-                "You have disabled all strategies",
-            ));
-        }
-    }
-
-    let cargo_install_fallback = *strategies.last().unwrap() == Strategy::Compile;
-
-    if cargo_install_fallback {
-        strategies.pop().unwrap();
-    }
-
-    let resolvers = strategies
-        .into_iter()
-        .map(|strategy| match strategy {
-            Strategy::CrateMetaData => Ok(GhCrateMeta::new as Resolver),
-            Strategy::QuickInstall => Ok(QuickInstall::new as Resolver),
-            Strategy::Compile => Err(BinstallError::InvalidStrategies(
-                "Compile strategy must be the last one",
-            )),
-        })
-        .collect::<Result<Vec<_>, BinstallError>>()?;
-
-    Ok((resolvers, cargo_install_fallback))
 }
 
 /// Return (install_path, cargo_roots, metadata, temp_dir)

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -18,10 +18,7 @@ fn main() -> MainExit {
     // This must be the very first thing to happen
     let jobserver_client = LazyJobserverClient::new();
 
-    let args = match args::parse() {
-        Ok(args) => args,
-        Err(err) => return MainExit::Error(err),
-    };
+    let args = args::parse();
 
     if args.version {
         println!("{}", env!("CARGO_PKG_VERSION"));

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -282,14 +282,6 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::SourceFilePath))]
     EmptySourceFilePath,
 
-    /// Invalid strategies configured.
-    ///
-    /// - Code: `binstall::strategies`
-    /// - Exit: 93
-    #[error("Invalid strategies configured: {0}")]
-    #[diagnostic(severity(error), code(binstall::strategies))]
-    InvalidStrategies(&'static str),
-
     /// Fallback to `cargo-install` is disabled.
     ///
     /// - Code: `binstall::no_fallback_to_cargo_install`
@@ -329,7 +321,6 @@ impl BinstallError {
             DuplicateSourceFilePath { .. } => 90,
             InvalidSourceFilePath { .. } => 91,
             EmptySourceFilePath => 92,
-            InvalidStrategies(..) => 93,
             NoFallbackToCargoInstall => 94,
             CrateContext(context) => context.err.exit_number(),
         };

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -205,28 +205,6 @@ pub enum BinstallError {
     )]
     SuperfluousVersionOption,
 
-    /// An override option is used when multiple packages are to be installed.
-    ///
-    /// This is raised when more than one package name is provided and any of:
-    ///
-    /// - `--version`
-    /// - `--manifest-path`
-    /// - `--bin-dir`
-    /// - `--pkg-fmt`
-    /// - `--pkg-url`
-    ///
-    /// is provided.
-    ///
-    /// - Code: `binstall::conflict::overrides`
-    /// - Exit: 85
-    #[error("override option used with multi package syntax")]
-    #[diagnostic(
-        severity(error),
-        code(binstall::conflict::overrides),
-        help("You cannot use --{option} and specify multiple packages at the same time. Do one or the other.")
-    )]
-    OverrideOptionUsedWithMultiInstall { option: &'static str },
-
     /// No binaries were found for the crate.
     ///
     /// When installing, either the binaries are specified in the crate's Cargo.toml, or they're
@@ -344,7 +322,6 @@ impl BinstallError {
             VersionParse { .. } => 80,
             VersionMismatch { .. } => 82,
             SuperfluousVersionOption => 84,
-            OverrideOptionUsedWithMultiInstall { .. } => 85,
             UnspecifiedBinaries => 86,
             NoViableTargets => 87,
             BinFileNotFound(_) => 88,


### PR DESCRIPTION
* Fix reporting parsing error from `args::parse`
   Report it in `args::parse` by using `Args::command().error(...).exit()`
   instead of returning `BinstallError`.
* Rm unused variant `BinstallError::OverrideOptionUsedWithMultiInstall`
* Refactor: Move `strategies` validation into `args::parse`
* Rm unused variant `BinstallError::InvalidStrategies`
* Add new unit test `args::test::verify_cli`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>