### PR TITLE
Optimize `extract_zip`: Use `async_zip::read::stream::ZipFileReader` to avoid temporary file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_io_utilities"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b20cffc5590f4bf33f05f97a3ea587feba9c50d20325b401daa096b92ff7da0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a36d43bdefc7215b2b3a97edd03b1553b7969ad76551025eedd3b913c645f6e"
+dependencies = [
+ "async-compression",
+ "async_io_utilities",
+ "chrono",
+ "crc32fast",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -156,6 +188,7 @@ version = "0.1.0"
 dependencies = [
  "async-compression",
  "async-trait",
+ "async_zip",
  "binstalk-types",
  "binstall-tar",
  "bytes",
@@ -366,9 +399,14 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -415,6 +453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -499,6 +547,50 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -810,7 +902,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -988,6 +1080,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1430,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -1882,6 +2007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,6 +2305,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2598,6 +2740,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,6 @@ dependencies = [
  "trust-dns-resolver",
  "url",
  "xz2",
- "zip",
  "zstd 0.12.0+zstd.1.5.2",
 ]
 
@@ -526,15 +525,6 @@ name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422f23e724af1240ec469ea1e834d87a4b59ce2efe2c6a96256b0c47e2fd86aa"
 dependencies = [
  "cfg-if",
 ]
@@ -3010,20 +3000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -40,14 +40,6 @@ url = "2.3.1"
 
 xz2 = "0.1.7"
 
-# Disable all features of zip except for features of compression algorithms:
-# Disabled features include:
-#  - aes-crypto: Enables decryption of files which were encrypted with AES, absolutely zero use for
-#    this crate.
-#  - time: Enables features using the [time](https://github.com/time-rs/time) crate,
-#    which is not used by this crate.
-zip = { version = "0.6.3", default-features = false, features = ["deflate", "bzip2", "zstd"] }
-
 # zstd is also depended by zip.
 # Since zip 0.6.3 depends on zstd 0.11, we can use 0.12.0 here
 # because it uses the same zstd-sys version.

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -12,6 +12,7 @@ license = "GPL-3.0"
 [dependencies]
 async-trait = "0.1.59"
 async-compression = { version = "0.3.15", features = ["gzip", "zstd", "xz", "bzip2", "tokio"] }
+async_zip = { version = "0.0.9", features = ["deflate", "bzip2", "lzma", "zstd", "xz"] }
 binstalk-types = { version = "0.1.0", path = "../binstalk-types" }
 bytes = "1.3.0"
 bzip2 = "0.4.3"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -30,7 +30,7 @@ scopeguard = "1.1.0"
 tar = { package = "binstall-tar", version = "0.4.39" }
 tempfile = "3.3.0"
 thiserror = "1.0.37"
-tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread", "sync", "time"], default-features = false }
+tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs"], default-features = false }
 tokio-tar = "0.3.0"
 tokio-util = { version = "0.7.4", features = ["io"] }
 tower = { version = "0.4.13", features = ["limit", "util"] }

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -19,11 +19,10 @@ pub use async_tar_visitor::*;
 mod extracter;
 mod stream_readable;
 
-pub type CancellationFuture = Option<Pin<Box<dyn Future<Output = Result<(), io::Error>> + Send>>>;
+mod zip_extraction;
+pub use zip_extraction::ZipError;
 
-#[derive(Debug, ThisError)]
-#[error(transparent)]
-pub struct ZipError(zip::result::ZipError);
+pub type CancellationFuture = Option<Pin<Box<dyn Future<Output = Result<(), io::Error>> + Send>>>;
 
 #[derive(Debug, ThisError)]
 pub enum DownloadError {

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -7,7 +7,6 @@ use thiserror::Error as ThisError;
 use tracing::{debug, instrument};
 
 pub use binstalk_types::cargo_toml_binstall::PkgFmt;
-pub use zip::result::ZipError;
 
 use crate::remote::{Client, Error as RemoteError, Url};
 
@@ -21,6 +20,10 @@ mod extracter;
 mod stream_readable;
 
 pub type CancellationFuture = Option<Pin<Box<dyn Future<Output = Result<(), io::Error>> + Send>>>;
+
+#[derive(Debug, ThisError)]
+#[error(transparent)]
+pub struct ZipError(zip::result::ZipError);
 
 #[derive(Debug, ThisError)]
 pub enum DownloadError {

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -145,7 +145,11 @@ impl Download {
             path: &Path,
             cancellation_future: CancellationFuture,
         ) -> Result<(), DownloadError> {
-            let stream = this.client.get_stream(this.url).await?;
+            let stream = this
+                .client
+                .get_stream(this.url)
+                .await?
+                .map(|res| res.map_err(DownloadError::from));
 
             debug!("Downloading and extracting to: '{}'", path.display());
 

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -118,10 +118,12 @@ impl Download {
         debug!("Downloading and extracting then in-memory processing");
 
         let ret = tokio::select! {
-            res = extract_tar_based_stream_and_visit(stream, fmt, visitor) => res?,
+            biased;
+
             res = await_on_option(cancellation_future) => {
                 Err(res.err().unwrap_or_else(|| io::Error::from(DownloadError::UserAbort)))?
             }
+            res = extract_tar_based_stream_and_visit(stream, fmt, visitor) => res?,
         };
 
         debug!("Download, extraction and in-memory procession OK");

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -50,7 +50,7 @@ where
     S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + 'static,
 {
     let mut reader = StreamReadable::new(stream, cancellation_future).await;
-    block_in_place(move || {
+    block_in_place(move || -> Result<(), DownloadError> {
         fs::create_dir_all(path.parent().unwrap())?;
 
         let mut file = tempfile()?;
@@ -60,7 +60,7 @@ where
         // rewind it so that we can pass it to unzip
         file.rewind()?;
 
-        unzip(file, path)
+        unzip(file, path).map_err(DownloadError::from)
     })
 }
 

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -65,10 +65,12 @@ where
     });
 
     tokio::select! {
-        res = extract_future => res,
+        biased;
+
         res = await_on_option(cancellation_future) => {
             Err(res.err().map(DownloadError::from).unwrap_or(DownloadError::UserAbort))
         }
+        res = extract_future => res,
     }
 }
 

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -11,14 +11,13 @@ use super::{
     extracter::*, stream_readable::StreamReadable, CancellationFuture, DownloadError, TarBasedFmt,
 };
 
-pub async fn extract_bin<S, E>(
+pub async fn extract_bin<S>(
     stream: S,
     path: &Path,
     cancellation_future: CancellationFuture,
 ) -> Result<(), DownloadError>
 where
-    S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
-    DownloadError: From<E>,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + 'static,
 {
     let mut reader = StreamReadable::new(stream, cancellation_future).await;
     block_in_place(move || {
@@ -42,14 +41,13 @@ where
     })
 }
 
-pub async fn extract_zip<S, E>(
+pub async fn extract_zip<S>(
     stream: S,
     path: &Path,
     cancellation_future: CancellationFuture,
 ) -> Result<(), DownloadError>
 where
-    S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
-    DownloadError: From<E>,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + 'static,
 {
     let mut reader = StreamReadable::new(stream, cancellation_future).await;
     block_in_place(move || {
@@ -66,15 +64,14 @@ where
     })
 }
 
-pub async fn extract_tar_based_stream<S, E>(
+pub async fn extract_tar_based_stream<S>(
     stream: S,
     path: &Path,
     fmt: TarBasedFmt,
     cancellation_future: CancellationFuture,
 ) -> Result<(), DownloadError>
 where
-    S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
-    DownloadError: From<E>,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + 'static,
 {
     let reader = StreamReadable::new(stream, cancellation_future).await;
     block_in_place(move || {

--- a/crates/binstalk-downloader/src/download/extracter.rs
+++ b/crates/binstalk-downloader/src/download/extracter.rs
@@ -1,18 +1,12 @@
-use std::{
-    fs::File,
-    io::{self, BufRead, Read},
-    path::Path,
-};
+use std::io::{self, BufRead, Read};
 
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
 use tar::Archive;
-use tracing::debug;
 use xz2::bufread::XzDecoder;
-use zip::read::ZipArchive;
 use zstd::stream::Decoder as ZstdDecoder;
 
-use super::{TarBasedFmt, ZipError};
+use super::TarBasedFmt;
 
 pub fn create_tar_decoder(
     dat: impl BufRead + 'static,
@@ -34,17 +28,4 @@ pub fn create_tar_decoder(
     };
 
     Ok(Archive::new(r))
-}
-
-pub fn unzip(dat: File, dst: &Path) -> Result<(), ZipError> {
-    debug!("Decompressing from zip archive to `{dst:?}`");
-
-    let inner = move || {
-        let mut zip = ZipArchive::new(dat)?;
-        zip.extract(dst)?;
-
-        Ok(())
-    };
-
-    inner().map_err(ZipError)
 }

--- a/crates/binstalk-downloader/src/download/utils.rs
+++ b/crates/binstalk-downloader/src/download/utils.rs
@@ -1,0 +1,16 @@
+use std::future::{pending, Future};
+
+/// Await on `future` if it is not `None`, or call [`pending`]
+/// so that this branch would never get selected again.
+///
+/// Designed to use with [`tokio::select`].
+pub(super) async fn await_on_option<Fut, R>(future: Option<Fut>) -> R
+where
+    Fut: Future<Output = R>,
+{
+    if let Some(future) = future {
+        future.await
+    } else {
+        pending().await
+    }
+}

--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -57,8 +57,8 @@ where
     }
 
     if raw_filename.ends_with('/') {
+        // This entry is a dir.
         asyncify(move || {
-            // This entry is a dir.
             std::fs::create_dir_all(&outpath)?;
             if let Some(perms) = perms {
                 std::fs::set_permissions(&outpath, perms)?;

--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -1,0 +1,149 @@
+use std::{
+    io,
+    path::{Component, Path, PathBuf},
+};
+
+use async_zip::{read::ZipEntryReader, ZipEntryExt};
+use thiserror::Error as ThisError;
+use tokio::{fs, io::AsyncRead, task::spawn_blocking};
+
+use super::DownloadError;
+
+#[derive(Debug, ThisError)]
+enum ZipErrorInner {
+    #[error(transparent)]
+    Inner(#[from] async_zip::error::ZipError),
+
+    #[error("Invalid file path: {0}")]
+    InvalidFilePath(Box<str>),
+}
+
+#[derive(Debug, ThisError)]
+#[error(transparent)]
+pub struct ZipError(#[from] ZipErrorInner);
+
+impl ZipError {
+    pub(super) fn from_inner(err: async_zip::error::ZipError) -> Self {
+        Self(ZipErrorInner::Inner(err))
+    }
+}
+
+pub(super) async fn extract_zip_entry<R>(
+    entry: ZipEntryReader<'_, R>,
+    path: &Path,
+) -> Result<(), DownloadError>
+where
+    R: AsyncRead + Unpin + Send + Sync,
+{
+    // Sanitize filename
+    let raw_filename = entry.entry().filename();
+    let filename = check_filename_and_normalize(raw_filename)
+        .ok_or_else(|| ZipError(ZipErrorInner::InvalidFilePath(raw_filename.into())))?;
+
+    // Calculates the outpath
+    let outpath = path.join(filename);
+
+    // Get permissions
+    let mut perms = None;
+
+    #[cfg(unix)]
+    {
+        use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+
+        if let Some(mode) = entry.entry().unix_permissions() {
+            let mode: u16 = mode;
+            perms = Some(Permissions::from_mode(mode as u32));
+        }
+    }
+
+    if raw_filename.ends_with('/') {
+        asyncify(move || {
+            // This entry is a dir.
+            std::fs::create_dir_all(&outpath)?;
+            if let Some(perms) = perms {
+                std::fs::set_permissions(&outpath, perms)?;
+            }
+
+            Ok(())
+        })
+        .await?;
+    } else {
+        // This entry is a file.
+        let mut outfile = asyncify(move || {
+            if let Some(p) = outpath.parent() {
+                std::fs::create_dir_all(p)?;
+            }
+            let outfile = std::fs::File::create(&outpath)?;
+
+            if let Some(perms) = perms {
+                outfile.set_permissions(perms)?;
+            }
+
+            Ok(outfile)
+        })
+        .await
+        .map(fs::File::from_std)?;
+
+        entry
+            .copy_to_end_crc(&mut outfile, 64 * 1024)
+            .await
+            .map_err(ZipError::from_inner)?;
+    }
+
+    Ok(())
+}
+
+/// Ensure the file path is safe to use as a [`Path`].
+///
+/// - It can't contain NULL bytes
+/// - It can't resolve to a path outside the current directory
+///   > `foo/../bar` is fine, `foo/../../bar` is not.
+/// - It can't be an absolute path
+///
+/// It will then return a normalized path.
+///
+/// This will read well-formed ZIP files correctly, and is resistant
+/// to path-based exploits.
+///
+/// This function is adapted from `zip::ZipFile::enclosed_name`.
+fn check_filename_and_normalize(filename: &str) -> Option<PathBuf> {
+    if filename.contains('\0') {
+        return None;
+    }
+
+    let mut path = PathBuf::new();
+
+    // The following loop is adapted from
+    // `normalize_path::NormalizePath::normalize`.
+    for component in Path::new(filename).components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => return None,
+            Component::CurDir => (),
+            Component::ParentDir => {
+                if !path.pop() {
+                    // `PathBuf::pop` returns false if there is no parent.
+                    // which means the path is invalid.
+                    return None;
+                }
+            }
+            Component::Normal(c) => path.push(c),
+        }
+    }
+
+    Some(path)
+}
+
+/// Copied from tokio https://docs.rs/tokio/latest/src/tokio/fs/mod.rs.html#132
+async fn asyncify<F, T>(f: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match spawn_blocking(f).await {
+        Ok(res) => res,
+        Err(_) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "background task failed",
+        )),
+    }
+}


### PR DESCRIPTION
* Add new dep async_zip v0.0.9 to binstalk-downloader
   with features "gzip", "zstd", "xz", "bzip2", "tokio".
* Refactor: Simplify `async_extracter::extract_*` API
* Refactor: Create newtype wrapper of `ZipError`
   so that the zip can be upgraded without affecting API of this crate.
* Enable feature fs of dep tokio in binstalk-downloader
* Rewrite `extract_zip` to use `async_zip::read::stream::ZipFileReader`
   which avoids writing the zip file to a temporary file and then read it
   back into memory.
* Refactor: Impl new fn `await_on_option` and use it
* Optimize `tokio::select!`: Make them biased and check for cancellation first
  to make cancellation takes effect ASAP.
* Rm unused dep zip from binstalk-downloader

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>