### PR TITLE
Optimization: Box fut `Remote::get_redirected_final_url` in `GhCrateMeta::find`

### DIFF
--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -86,11 +86,7 @@ impl super::Fetcher for GhCrateMeta {
     fn find(self: Arc<Self>) -> AutoAbortJoinHandle<Result<bool, BinstallError>> {
         AutoAbortJoinHandle::spawn(async move {
             let repo = if let Some(repo) = self.data.repo.as_deref() {
-                Some(
-                    self.client
-                        .get_redirected_final_url(Url::parse(repo)?)
-                        .await?,
-                )
+                Some(Box::pin(self.client.get_redirected_final_url(Url::parse(repo)?)).await?)
             } else {
                 None
             };

--- a/crates/binstalk/src/helpers/signal.rs
+++ b/crates/binstalk/src/helpers/signal.rs
@@ -41,16 +41,12 @@ fn ignore_signals() -> io::Result<()> {
 /// that also returns `Ok(())`.
 async fn wait_on_cancellation_signal() -> Result<(), io::Error> {
     #[cfg(unix)]
-    async fn inner() -> Result<(), io::Error> {
-        unix::wait_on_cancellation_signal_unix().await
-    }
+    unix::wait_on_cancellation_signal_unix().await?;
 
     #[cfg(not(unix))]
-    async fn inner() -> Result<(), io::Error> {
-        signal::ctrl_c().await
-    }
+    signal::ctrl_c().await?;
 
-    inner().await
+    Ok(())
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Since the other await point in `GhCrateMeta::find` only needs `Arc<Self>` and `handles` to be saved, which is much smaller than the future returned by `Remote::get_redirected_final_url`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>