### PR TITLE
Build -gnu targets on ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             debug_features: [ rustls, pkg-config ]
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -49,7 +49,7 @@ jobs:
             os: ubuntu-latest
             use-cross: true
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             use-cross: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
In a dockerfile I have `rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') && curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$rust_target.tgz`; it broke with the most recent release because the `rust:1.65` image has glibc 2.31 and the 0.18.0 release built on ubuntu-22.04 ([build log](https://github.com/cargo-bins/cargo-binstall/actions/runs/3676457750/jobs/6217128087)), which has a more recent version (2.35?). This commit pins it to 20.04, so the glibc version required by the release binaries remains lower. (If possible, a 0.18.1 release to fix this would be really nice, or otherwise I can use a workaround for now)
