### PR TITLE
Optimize binstalk-{manifest, types}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "binstalk"
 version = "0.6.0"
 dependencies = [
@@ -216,6 +225,7 @@ dependencies = [
 name = "binstalk-manifests"
 version = "0.1.1"
 dependencies = [
+ "beef",
  "binstalk-types",
  "compact_str",
  "detect-targets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml_edit",
+ "toml",
  "url",
 ]
 
@@ -472,16 +472,6 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -2456,33 +2446,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
-dependencies = [
- "combine",
- "indexmap",
- "itertools",
- "serde",
- "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ name = "binstalk-types"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "maybe-owned",
  "once_cell",
  "semver",
  "serde",
@@ -1340,6 +1341,15 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "memchr"

--- a/crates/binstalk-manifests/Cargo.toml
+++ b/crates/binstalk-manifests/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.151", features = ["derive"] }
 serde-tuple-vec-map = "1.0.1"
 serde_json = "1.0.91"
 thiserror = "1.0.37"
-toml_edit = { version = "0.15.0", features = ["easy"] }
+toml = "0.5.10"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/binstalk-manifests/Cargo.toml
+++ b/crates/binstalk-manifests/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+beef = { version = "0.5.2", features = ["impl_serde"] }
 binstalk-types = { version = "0.1.0", path = "../binstalk-types" }
 compact_str = { version = "0.6.1", features = ["serde"] }
 fs-lock = { version = "0.1.0", path = "../fs-lock" }

--- a/crates/binstalk-manifests/src/cargo_crates_v1.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1.rs
@@ -108,8 +108,15 @@ impl CratesToml {
         };
 
         for metadata in iter {
-            c1.remove(&metadata.name);
-            c1.insert(&CrateVersionSource::from(metadata), metadata.bins.clone());
+            let name = &metadata.name;
+            let version = &metadata.current_version;
+            let source = Source::from(&metadata.source);
+
+            c1.remove(name);
+            c1.v1.push((
+                format!("{name} {version} ({source})"),
+                metadata.bins.clone(),
+            ));
         }
 
         file.rewind()?;

--- a/crates/binstalk-manifests/src/cargo_crates_v1.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1.rs
@@ -49,7 +49,7 @@ impl CratesToml<'_> {
     pub fn load_from_reader<R: io::Read>(mut reader: R) -> Result<Self, CratesTomlParseError> {
         let mut vec = Vec::new();
         reader.read_to_end(&mut vec)?;
-        Ok(toml_edit::easy::from_slice(&vec)?)
+        Ok(toml::from_slice(&vec)?)
     }
 
     pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, CratesTomlParseError> {
@@ -76,7 +76,7 @@ impl CratesToml<'_> {
     }
 
     pub fn write_to_writer<W: io::Write>(&self, mut writer: W) -> Result<(), CratesTomlParseError> {
-        let data = toml_edit::easy::to_vec(&self)?;
+        let data = toml::to_vec(&self)?;
         writer.write_all(&data)?;
         Ok(())
     }
@@ -159,10 +159,10 @@ pub enum CratesTomlParseError {
     Io(#[from] io::Error),
 
     #[error(transparent)]
-    TomlParse(#[from] toml_edit::easy::de::Error),
+    TomlParse(#[from] toml::de::Error),
 
     #[error(transparent)]
-    TomlWrite(Box<toml_edit::easy::ser::Error>),
+    TomlWrite(Box<toml::ser::Error>),
 
     #[error(transparent)]
     CvsParse(Box<CvsParseError>),
@@ -174,8 +174,8 @@ impl From<CvsParseError> for CratesTomlParseError {
     }
 }
 
-impl From<toml_edit::easy::ser::Error> for CratesTomlParseError {
-    fn from(e: toml_edit::easy::ser::Error) -> Self {
+impl From<toml::ser::Error> for CratesTomlParseError {
+    fn from(e: toml::ser::Error) -> Self {
         CratesTomlParseError::TomlWrite(Box::new(e))
     }
 }

--- a/crates/binstalk-manifests/src/cargo_crates_v1/crate_version_source.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1/crate_version_source.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt, str::FromStr};
 
-use binstalk_types::crate_info::cratesio_url;
+use binstalk_types::{crate_info::cratesio_url, maybe_owned::MaybeOwned};
 use compact_str::CompactString;
 use miette::Diagnostic;
 use semver::Version;
@@ -29,14 +29,14 @@ impl From<&CrateInfo> for CrateVersionSource {
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Source {
-    Git(Url),
-    Path(Url),
-    Registry(Url),
+    Git(MaybeOwned<'static, Url>),
+    Path(MaybeOwned<'static, Url>),
+    Registry(MaybeOwned<'static, Url>),
 }
 
 impl Source {
     pub fn cratesio_registry() -> Source {
-        Self::Registry(cratesio_url().clone())
+        Self::Registry(MaybeOwned::Borrowed(cratesio_url()))
     }
 }
 
@@ -65,9 +65,9 @@ impl FromStr for CrateVersionSource {
                     .splitn(2, '+')
                     .collect::<Vec<_>>()[..]
                 {
-                    ["git", url] => Source::Git(Url::parse(url)?),
-                    ["path", url] => Source::Path(Url::parse(url)?),
-                    ["registry", url] => Source::Registry(Url::parse(url)?),
+                    ["git", url] => Source::Git(Url::parse(url)?.into()),
+                    ["path", url] => Source::Path(Url::parse(url)?.into()),
+                    ["registry", url] => Source::Registry(Url::parse(url)?.into()),
                     [kind, arg] => {
                         return Err(CvsParseError::UnknownSourceType {
                             kind: kind.to_string().into_boxed_str(),

--- a/crates/binstalk-types/Cargo.toml
+++ b/crates/binstalk-types/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 compact_str = { version = "0.6.1", features = ["serde"] }
+maybe-owned = { version = "0.3.4", features = ["serde"] }
 once_cell = "1.16.0"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.151", features = ["derive"] }

--- a/crates/binstalk-types/src/crate_info.rs
+++ b/crates/binstalk-types/src/crate_info.rs
@@ -3,6 +3,7 @@
 use std::{borrow, cmp, hash};
 
 use compact_str::CompactString;
+use maybe_owned::MaybeOwned;
 use once_cell::sync::Lazy;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -69,14 +70,14 @@ pub enum SourceType {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CrateSource {
     pub source_type: SourceType,
-    pub url: Url,
+    pub url: MaybeOwned<'static, Url>,
 }
 
 impl CrateSource {
     pub fn cratesio_registry() -> CrateSource {
         Self {
             source_type: SourceType::Registry,
-            url: cratesio_url().clone(),
+            url: MaybeOwned::Borrowed(cratesio_url()),
         }
     }
 }

--- a/crates/binstalk-types/src/lib.rs
+++ b/crates/binstalk-types/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod cargo_toml_binstall;
 pub mod crate_info;
+
+pub use maybe_owned;


### PR DESCRIPTION
* Add new dep maybe-owned v0.3.4 to binstalk-types with features serde
* Re-export maybe_owned in binstalk-types
* Optimize `CrateSource::url`: Use `MaybeOwned<'static, Url>`
   to avoid cloning in `CrateSource::cratesio_registry`
* Optimize `Source`: Use `MaybeOwned<'static, Url>`
   to avoid cloning in `Source::cratesio_registry` and
   `impl From<&CrateSource> for Source`.
* Optimize `Source`: Add lifetime `<'a>` to avoid cloning
   in `impl<'a> From<&'a CrateSource> for Source<'a>`
* Optimize `CratesToml::append_to_path`: Avoid cloning
   caused by `CrateVersionSource::from` by manually `format!` name, version
   and source into string.
* Add new dep beef v0.5.2 to binstalk-manifests with features impl_serde
* Optimize `CratesToml::append_to_path`: Eliminate `metadata.bins.clone()` by using `Cow`
* Replace dep toml_edit with toml v0.5.10 in binstalk-manifests
   to speed up compilation and reduce bloat.
   
   Previously we switch to toml_edit because it is unmaintained, but now
   with it moved into toml-rs/toml as a workspace, it is now under active
   maintenance again, thus we switch back to it.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>