### PR TITLE
Add x86_64 fallback for aarch64 windows in detect-targets

### DIFF
--- a/crates/detect-targets/src/detect/windows.rs
+++ b/crates/detect-targets/src/detect/windows.rs
@@ -1,11 +1,20 @@
 use crate::TARGET;
 use guess_host_triple::guess_host_triple;
 
-pub(super) fn detect_alternative_targets(target: &str) -> Option<String> {
+pub(super) fn detect_alternative_targets(target: &str) -> impl Iterator<Item = String> {
     let (prefix, abi) = target.rsplit_once('-')?;
 
+    // AFAIK only windows 10/11 supports arm and it requires > 4G of ram,
+    // which makes running it on armv7 moot.
+    let is_arm = prefix.starts_with("aarch64");
+
     // detect abi in ["gnu", "gnullvm", ...]
-    (abi != "msvc").then(|| format!("{prefix}-msvc"))
+    let is_gnu_abi = abi != "msvc";
+
+    let msvc_fallback = is_gnu_abi.then(|| format!("{prefix}-msvc"));
+    let x86_64_fallback = is_arm.then(|| "x86_64-pc-windows-mscv".to_string());
+
+    msvc_fallback.into_iter().chain(x86_64_fallback)
 }
 
 pub(super) fn detect_targets_windows() -> Vec<String> {

--- a/crates/detect-targets/src/detect/windows.rs
+++ b/crates/detect-targets/src/detect/windows.rs
@@ -2,7 +2,9 @@ use crate::TARGET;
 use guess_host_triple::guess_host_triple;
 
 pub(super) fn detect_alternative_targets(target: &str) -> impl Iterator<Item = String> {
-    let (prefix, abi) = target.rsplit_once('-')?;
+    // This rsplit will succeed on valid target triple, which we assume
+    // is valid.
+    let (prefix, abi) = target.rsplit_once('-').unwrap();
 
     // AFAIK only windows 10/11 supports arm and it requires > 4G of ram,
     // which makes running it on armv7 moot.


### PR DESCRIPTION
Since aarch64 windows can run unmodified x86(_64) binaries.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>