### PR TITLE
Fix `detect_targrets_linux`: Use `guess_host_triple` to determine arch/libc

### DIFF
--- a/crates/detect-targets/Cargo.toml
+++ b/crates/detect-targets/Cargo.toml
@@ -13,8 +13,6 @@ license = "Apache-2.0 OR MIT"
 tokio = { version = "1.23.0", features = ["rt", "process", "sync"], default-features = false }
 cfg-if = "1.0.0"
 beef = "0.5.2"
-
-[target.'cfg(not(target_os = "linux"))'.dependencies]
 guess_host_triple = "0.1.3"
 
 [dev-dependencies]

--- a/crates/detect-targets/src/detect.rs
+++ b/crates/detect-targets/src/detect.rs
@@ -42,6 +42,8 @@ pub async fn detect_targets() -> Vec<CowStr> {
 
             if targets[0].contains("gnu") {
                 targets.push(CowStr::owned(targets[0].replace("gnu", "musl")));
+            } else if targets[0].contains("android") {
+                targets.push(CowStr::owned(targets[0].replace("android", "musl")));
             }
 
             targets


### PR DESCRIPTION
 - Enable `guess_host_triple` on all targets
 - Fix `detect_targets_linux`: Detect runtime arch/libc using `guess_host_triple` instead of using the one specified in `TARGET`.
 - Add support for android in detect_targets

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>