### PR TITLE
Optimize `Download::and_visit_tar`: Use trait object to avoid monomorphization

### DIFF
--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -101,11 +101,11 @@ impl Download {
     /// NOTE that this API does not support gnu extension sparse file unlike
     /// [`Download::and_extract`].
     #[instrument(skip(visitor))]
-    pub async fn and_visit_tar<V: TarEntriesVisitor + Debug + Send + 'static>(
+    pub async fn and_visit_tar(
         self,
         fmt: TarBasedFmt,
-        visitor: V,
-    ) -> Result<V::Target, DownloadError> {
+        visitor: &mut dyn TarEntriesVisitor,
+    ) -> Result<(), DownloadError> {
         let stream = self
             .client
             .get_stream(self.url)
@@ -114,11 +114,11 @@ impl Download {
 
         debug!("Downloading and extracting then in-memory processing");
 
-        let ret = extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
+        extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
 
         debug!("Download, extraction and in-memory procession OK");
 
-        Ok(ret)
+        Ok(())
     }
 
     /// Download a file from the provided URL and extract it to the provided path.

--- a/crates/binstalk/src/drivers/crates_io.rs
+++ b/crates/binstalk/src/drivers/crates_io.rs
@@ -52,7 +52,11 @@ pub async fn fetch_crate_cratesio(
 
     let manifest_dir_path: PathBuf = format!("{name}-{version_name}").into();
 
-    Ok(Download::new(client, Url::parse(&crate_url)?)
-        .and_visit_tar(TarBasedFmt::Tgz, ManifestVisitor::new(manifest_dir_path))
-        .await?)
+    let mut manifest_visitor = ManifestVisitor::new(manifest_dir_path);
+
+    Download::new(client, Url::parse(&crate_url)?)
+        .and_visit_tar(TarBasedFmt::Tgz, &mut manifest_visitor)
+        .await?;
+
+    manifest_visitor.load_manifest()
 }


### PR DESCRIPTION
by removing method `TarEntriesVisitor::finish` and associated type `TarEntriesVisitor::Target`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>