### PR TITLE
Minor optimization for bin and binstalk

### DIFF
--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -140,7 +140,7 @@ impl Log for Logger {
 struct ErrorFreeWriter;
 
 fn report_err(err: io::Error) {
-    write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+    writeln!(io::stderr(), "Failed to write to stdout: {err}").ok();
 }
 
 impl io::Write for &ErrorFreeWriter {

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -1,4 +1,8 @@
-use std::{cmp::min, io, iter::repeat};
+use std::{
+    cmp::min,
+    io::{self, Write},
+    iter::repeat,
+};
 
 use log::{LevelFilter, Log, STATIC_MAX_LEVEL};
 use once_cell::sync::Lazy;
@@ -135,10 +139,14 @@ impl Log for Logger {
 
 struct ErrorFreeWriter;
 
+fn report_err(err: io::Error) {
+    write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+}
+
 impl io::Write for &ErrorFreeWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         io::stdout().write(buf).or_else(|err| {
-            write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+            report_err(err);
             // Behave as if writing to /dev/null so that logging system
             // would keep working.
             Ok(buf.len())
@@ -147,7 +155,7 @@ impl io::Write for &ErrorFreeWriter {
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         io::stdout().write_all(buf).or_else(|err| {
-            write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+            report_err(err);
             // Behave as if writing to /dev/null so that logging system
             // would keep working.
             Ok(())
@@ -156,7 +164,7 @@ impl io::Write for &ErrorFreeWriter {
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
         io::stdout().write_vectored(bufs).or_else(|err| {
-            write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+            report_err(err);
             // Behave as if writing to /dev/null so that logging system
             // would keep working.
             Ok(bufs.iter().map(|io_slice| io_slice.len()).sum())
@@ -165,7 +173,7 @@ impl io::Write for &ErrorFreeWriter {
 
     fn flush(&mut self) -> io::Result<()> {
         io::stdout().flush().or_else(|err| {
-            write!(io::stderr(), "Failed to write to stdout: {err}").ok();
+            report_err(err);
             // Behave as if writing to /dev/null so that logging system
             // would keep working.
             Ok(())

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -137,7 +137,7 @@ impl super::Fetcher for GhCrateMeta {
 
             let mut handles = FuturesUnordered::new();
 
-            // Iterate over pkg_urls to avoid String::clone.
+            // Iterate over pkg_urls first to avoid String::clone.
             for pkg_url in pkg_urls {
                 //             Clone iter pkg_fmts to ensure all pkg_fmts is
                 //             iterated over for each pkg_url, which is

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -44,7 +44,9 @@ impl RepositoryHost {
         }
     }
 
-    pub fn get_default_pkg_url_template(self) -> Option<Vec<String>> {
+    pub fn get_default_pkg_url_template(
+        self,
+    ) -> Option<impl Iterator<Item = String> + Clone + 'static> {
         use RepositoryHost::*;
 
         match self {
@@ -82,11 +84,14 @@ impl RepositoryHost {
     }
 }
 
-fn apply_filenames_to_paths(paths: &[&str], filenames: &[&[&str]], suffix: &str) -> Vec<String> {
+fn apply_filenames_to_paths(
+    paths: &'static [&'static str],
+    filenames: &'static [&'static [&'static str]],
+    suffix: &'static str,
+) -> impl Iterator<Item = String> + Clone + 'static {
     filenames
         .iter()
         .flat_map(|fs| fs.iter())
         .cartesian_product(paths.iter())
-        .map(|(filename, path)| format!("{path}/{filename}{suffix}"))
-        .collect()
+        .map(move |(filename, path)| format!("{path}/{filename}{suffix}"))
 }


### PR DESCRIPTION
* Refactor `logging`: Extract `report_err`
* Optimize `get_default_pkg_url_template`: Return iter instead of `Vec`
   to avoid heap allocation.
* Refactor `GhCrateMeta::find`: Rm `launch_baseline_find_tasks`
* Optimize `GhCrateMeta::find`: Avoid cloning `Cow<'_, str>`
* Improve `report_err` output: Print newline after msg

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>