### PR TITLE
Add release metadata in PR (from release-pr v2)

### DIFF
--- a/.github/scripts/release-pr-template.ejs
+++ b/.github/scripts/release-pr-template.ejs
@@ -1,3 +1,7 @@
+<% if (pr.metaComment) { %>
+<!-- <%- JSON.stringify({ "release-pr": { v2: { crates, version } } }) %> -->
+<% } %>
+
 This is a release PR for **<%= crate.name %>** version **<%= version.actual %>**<%
     if (version.actual != version.desired) {
 %> (performing a <%= version.desired %> bump).<%
@@ -6,17 +10,7 @@ This is a release PR for **<%= crate.name %>** version **<%= version.actual %>**
     }
 %>
 
-<% if (pr.mergeStrategy == "merge") { %>
-**Use a merge commit.**
-<% } else if (pr.mergeStrategy == "rebase") { %>
-**Use rebase merge.**
-<% } else if (pr.mergeStrategy == "squash") { %>
 **Use squash merge.**
-<% } else if (pr.mergeStrategy == "bors") { %>
-**Merge by commenting:**
-| bors r+ |
-|:-:|
-<% } %>
 
 <% if (crate.name == "cargo-binstall") { %>
 Upon merging, this will automatically create the tag `v<%= version.actual %>`, build the CLI, and create a GitHub release with the release notes below.


### PR DESCRIPTION
We do nothing with it yet but eventually that will let us move away from parsing commit messages for releases.