### PR TITLE
Run CI on auto-merge enable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - auto_merge_enabled
   push:
     branches:
       - main


### PR DESCRIPTION
Little trick from the watchexec repo: instead of closing/opening the release PRs, this makes it such that enabling auto-merge triggers CI