### PR TITLE
Revert "Bump async_zip from 0.0.9 to 0.0.10"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,14 +91,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_zip"
-version = "0.0.10"
+name = "async_io_utilities"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5282f208287c58b7df1f7965531a49192eb4a22558fa1421d26d1a7c6118613"
+checksum = "9b20cffc5590f4bf33f05f97a3ea587feba9c50d20325b401daa096b92ff7da0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a36d43bdefc7215b2b3a97edd03b1553b7969ad76551025eedd3b913c645f6e"
 dependencies = [
  "async-compression",
+ "async_io_utilities",
+ "chrono",
  "crc32fast",
- "pin-project",
  "thiserror",
  "tokio",
 ]
@@ -392,9 +411,14 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -441,6 +465,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -518,6 +552,50 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -829,7 +907,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1007,6 +1085,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,7 +1435,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1912,6 +2023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2337,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2622,6 +2750,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0"
 [dependencies]
 async-trait = "0.1.61"
 async-compression = { version = "0.3.15", features = ["gzip", "zstd", "xz", "bzip2", "tokio"] }
-async_zip = { version = "0.0.10", features = ["deflate", "bzip2", "lzma", "zstd", "xz"] }
+async_zip = { version = "0.0.9", features = ["deflate", "bzip2", "lzma", "zstd", "xz"] }
 binstalk-types = { version = "0.2.0", path = "../binstalk-types" }
 bytes = "1.3.0"
 bzip2 = "0.4.4"

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -48,10 +48,8 @@ where
     let mut zip = ZipFileReader::new(reader);
     let mut buf = BytesMut::with_capacity(4 * 4096);
 
-    while let Some(mut zip_reader) = zip.next_entry().await.map_err(ZipError::from_inner)? {
-        extract_zip_entry(&mut zip_reader, path, &mut buf).await?;
-
-        zip = zip_reader.done().await.map_err(ZipError::from_inner)?;
+    while let Some(entry) = zip.entry_reader().await.map_err(ZipError::from_inner)? {
+        extract_zip_entry(entry, path, &mut buf).await?;
     }
 
     Ok(())

--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -3,15 +3,12 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use async_zip::read::{
-    seek::ZipEntryReader,
-    stream::{Reading, ZipFileReader},
-};
+use async_zip::{read::ZipEntryReader, ZipEntryExt};
 use bytes::{Bytes, BytesMut};
 use futures_util::future::{try_join, TryFutureExt};
 use thiserror::Error as ThisError;
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, Take},
+    io::{AsyncRead, AsyncReadExt},
     sync::mpsc,
 };
 
@@ -37,7 +34,7 @@ impl ZipError {
 }
 
 pub(super) async fn extract_zip_entry<R>(
-    zip_reader: &mut ZipFileReader<Reading<'_, Take<R>>>,
+    entry: ZipEntryReader<'_, R>,
     path: &Path,
     buf: &mut BytesMut,
 ) -> Result<(), DownloadError>
@@ -45,7 +42,7 @@ where
     R: AsyncRead + Unpin + Send + Sync,
 {
     // Sanitize filename
-    let raw_filename = zip_reader.entry().filename();
+    let raw_filename = entry.entry().filename();
     let filename = check_filename_and_normalize(raw_filename)
         .ok_or_else(|| ZipError(ZipErrorInner::InvalidFilePath(raw_filename.into())))?;
 
@@ -59,7 +56,7 @@ where
     {
         use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
-        if let Some(mode) = zip_reader.entry().unix_permissions() {
+        if let Some(mode) = entry.entry().unix_permissions() {
             let mode: u16 = mode;
             perms = Some(Permissions::from_mode(mode as u32));
         }
@@ -101,7 +98,7 @@ where
                 Ok(())
             })
             .err_into(),
-            copy_file_to_mpsc(zip_reader.reader(), tx, buf)
+            copy_file_to_mpsc(entry, tx, buf)
                 .map_err(ZipError::from_inner)
                 .map_err(DownloadError::from),
         )
@@ -112,7 +109,7 @@ where
 }
 
 async fn copy_file_to_mpsc<R>(
-    entry_reader: &mut ZipEntryReader<'_, R>,
+    mut entry: ZipEntryReader<'_, R>,
     tx: mpsc::Sender<Bytes>,
     buf: &mut BytesMut,
 ) -> Result<(), async_zip::error::ZipError>
@@ -121,7 +118,7 @@ where
 {
     // Since BytesMut does not have a max cap, if AsyncReadExt::read_buf returns
     // 0 then it means Eof.
-    while entry_reader.read_buf(buf).await? != 0 {
+    while entry.read_buf(buf).await? != 0 {
         // Ensure AsyncReadExt::read_buf can read at least 4096B to avoid
         // frequent expensive read syscalls.
         //
@@ -146,17 +143,11 @@ where
         }
     }
 
-    // With async_zip 0.0.10, ZipEntryReader::compare_crc is removed.
-    // Hopefully it will restored later.
-
-    /*
-    if entry_reader.compare_crc() {
+    if entry.compare_crc() {
         Ok(())
     } else {
         Err(async_zip::error::ZipError::CRC32CheckError)
-    }*/
-
-    Ok(())
+    }
 }
 
 /// Ensure the file path is safe to use as a [`Path`].


### PR DESCRIPTION
Reverts cargo-bins/cargo-binstall#709

Unless async_zip does a 0.0.11 release before we merge this, let's get the breakage out