### PR TITLE
Switch from toml back to toml_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 0.6.0",
+ "toml_edit",
  "url",
 ]
 
@@ -385,7 +385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1204fe51a1e56042b8ec31d6407547ecd18f596b66f470dadb9abd9be9c843"
 dependencies = [
  "serde",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ checksum = "e62abb876c07e4754fae5c14cafa77937841f01740637e17d78dc04352f32a5e"
 dependencies = [
  "cc",
  "rustc_version",
- "toml 0.5.11",
+ "toml",
  "vswhom",
  "winreg",
 ]
@@ -2500,18 +2500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
 ]
 
 [[package]]

--- a/crates/binstalk-manifests/Cargo.toml
+++ b/crates/binstalk-manifests/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde-tuple-vec-map = "1.0.1"
 serde_json = "1.0.91"
 thiserror = "1.0.38"
-toml = "0.6.0"
+toml_edit = { version = "0.18.0", features = ["serde"] }
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Since now toml simply uses toml_edit, there is no reason to continue using it as it merely increase compilation time and bloat.

Instead, we switch to toml_edit v0.18.0 with feature serde enabled.

This also remove the `CratesTomlParseError::TomlParseNonUtf8` variant intorduced in #736.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>