### PR TITLE
Improve `GhCrateMeta`: Detect cases where pkg-fmt is not specified

### DIFF
--- a/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
@@ -57,6 +57,38 @@ impl PkgFmt {
             PkgFmt::Zip => &[".zip"],
         }
     }
+
+    /// The pkg-url template
+    pub fn guess_pkg_format(pkg_url: &str) -> Option<Self> {
+        let mut it = pkg_url.rsplitn(3, '.');
+
+        let guess = match it.next()? {
+            "tar" => Some(PkgFmt::Tar),
+
+            "tbz2" => Some(PkgFmt::Tbz2),
+            "bz2" if it.next() == Some("tar") => Some(PkgFmt::Tbz2),
+
+            "tgz" => Some(PkgFmt::Tgz),
+            "gz" if it.next() == Some("tar") => Some(PkgFmt::Tgz),
+
+            "txz" => Some(PkgFmt::Txz),
+            "xz" if it.next() == Some("tar") => Some(PkgFmt::Txz),
+
+            "tzstd" | "tzst" => Some(PkgFmt::Tzstd),
+            "zst" if it.next() == Some("tar") => Some(PkgFmt::Tzstd),
+
+            "exe" | "bin" => Some(PkgFmt::Bin),
+            "zip" => Some(PkgFmt::Zip),
+
+            _ => None,
+        };
+
+        if it.next().is_some() {
+            guess
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
@@ -58,7 +58,7 @@ impl PkgFmt {
         }
     }
 
-    /// The pkg-url template
+    /// Given the pkg-url template, guess the possible pkg-fmt.
     pub fn guess_pkg_format(pkg_url: &str) -> Option<Self> {
         let mut it = pkg_url.rsplitn(3, '.');
 

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -44,11 +44,11 @@ pub struct CrateContextError {
 #[derive(Debug, Error)]
 #[error("Invalid pkg-url {pkg_url} for {crate_name}@{version} on {target}: {reason}")]
 pub struct InvalidPkgFmtError {
-    crate_name: CompactString,
-    version: CompactString,
-    target: String,
-    pkg_url: String,
-    reason: &'static str,
+    pub crate_name: CompactString,
+    pub version: CompactString,
+    pub target: String,
+    pub pkg_url: String,
+    pub reason: &'static str,
 }
 
 /// Error kinds emitted by cargo-binstall.

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -41,6 +41,16 @@ pub struct CrateContextError {
     err: BinstallError,
 }
 
+#[derive(Debug, Error)]
+#[error("Invalid pkg-url {pkg_url} for {crate_name}@{version} on {target}: {reason}")]
+pub struct InvalidPkgFmtError {
+    crate_name: CompactString,
+    version: CompactString,
+    target: String,
+    pkg_url: String,
+    reason: &'static str,
+}
+
 /// Error kinds emitted by cargo-binstall.
 #[derive(Error, Diagnostic, Debug)]
 #[non_exhaustive]
@@ -291,6 +301,14 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::no_fallback_to_cargo_install))]
     NoFallbackToCargoInstall,
 
+    /// Fallback to `cargo-install` is disabled.
+    ///
+    /// - Code: `binstall::invalid_pkg_fmt`
+    /// - Exit: 95
+    #[error(transparent)]
+    #[diagnostic(severity(error), code(binstall::invalid_pkg_fmt))]
+    InvalidPkgFmt(Box<InvalidPkgFmtError>),
+
     /// A wrapped error providing the context of which crate the error is about.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -324,6 +342,7 @@ impl BinstallError {
             InvalidSourceFilePath { .. } => 91,
             EmptySourceFilePath => 92,
             NoFallbackToCargoInstall => 94,
+            InvalidPkgFmt(..) => 95,
             CrateContext(context) => context.err.exit_number(),
         };
 
@@ -426,5 +445,11 @@ impl From<TinyTemplateError> for BinstallError {
 impl From<CargoTomlError> for BinstallError {
     fn from(e: CargoTomlError) -> Self {
         BinstallError::CargoManifest(Box::new(e))
+    }
+}
+
+impl From<InvalidPkgFmtError> for BinstallError {
+    fn from(e: InvalidPkgFmtError) -> Self {
+        BinstallError::InvalidPkgFmt(Box::new(e))
     }
 }

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -108,23 +108,23 @@ impl super::Fetcher for GhCrateMeta {
                     Either::Right(pkg_urls.map(Cow::Owned))
                 } else {
                     warn!(
-                    concat!(
-                        "Unknown repository {}, cargo-binstall cannot provide default pkg_url for it.\n",
-                        "Please ask the upstream to provide it for target {}."
-                    ),
-                    repo, self.target_data.target
-                );
+                        concat!(
+                            "Unknown repository {}, cargo-binstall cannot provide default pkg_url for it.\n",
+                            "Please ask the upstream to provide it for target {}."
+                        ),
+                        repo, self.target_data.target
+                    );
 
                     return Ok(false);
                 }
             } else {
                 warn!(
-                concat!(
-                    "Package does not specify repository, cargo-binstall cannot provide default pkg_url for it.\n",
-                    "Please ask the upstream to provide it for target {}."
-                ),
-                self.target_data.target
-            );
+                    concat!(
+                        "Package does not specify repository, cargo-binstall cannot provide default pkg_url for it.\n",
+                        "Please ask the upstream to provide it for target {}."
+                    ),
+                    self.target_data.target
+                );
 
                 return Ok(false);
             };


### PR DESCRIPTION
but `pkg-url` also does not contain format, archive-format or
archive-suffix which is required for automatically deducing the pkg-fmt.

In these cases, we would call `PkgFmt::guess_pkg_format` to try out best
to figure out the pkg-fmt, otherwise we just return an error.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

## Auto-merge commit message

* Fix fmt of mod `<GhCrateMeta as Fetcher>::find`
* Add new variant `BinstallError::InvalidPkgFmt`
* Impl new fn `PkgFmt::guess_pkg_format`
* Improve `GhCrateMeta`: Detect cases where `pkg-fmt` is not specified
  
  but `pkg-url` also does not contain format, archive-format or
  archive-suffix which is required for automatically deducing the pkg-fmt.
  
  In these cases, we would call `PkgFmt::guess_pkg_format` to try out best
  to figure out the pkg-fmt, otherwise we just return an error.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>