### PR TITLE
Fix "Too many "Too Many Requests" log"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "httpdate",
+ "itertools",
  "pin-project",
  "reqwest",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,6 @@ dependencies = [
  "generic-array",
  "httpdate",
  "itertools",
- "pin-project",
  "reqwest",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,6 @@ dependencies = [
  "futures-util",
  "generic-array",
  "httpdate",
- "itertools",
  "reqwest",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "binstall-tar",
  "bytes",
  "bzip2",
+ "compact_str",
  "digest",
  "flate2",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "httpdate",
+ "pin-project",
  "reqwest",
  "tempfile",
  "thiserror",

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -23,7 +23,6 @@ futures-util = { version = "0.3.26", default-features = false, features = ["std"
 generic-array = "0.14.6"
 httpdate = "1.0.2"
 itertools = "0.10.5"
-pin-project = "1.0.12"
 reqwest = { version = "0.11.14", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 # Use a fork here since we need PAX support, but the upstream
 # does not hav the PR merged yet.

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -22,6 +22,7 @@ flate2 = { version = "1.0.25", default-features = false }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 generic-array = "0.14.6"
 httpdate = "1.0.2"
+itertools = "0.10.5"
 pin-project = "1.0.12"
 reqwest = { version = "0.11.14", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 # Use a fork here since we need PAX support, but the upstream

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -22,7 +22,6 @@ flate2 = { version = "1.0.25", default-features = false }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 generic-array = "0.14.6"
 httpdate = "1.0.2"
-itertools = "0.10.5"
 reqwest = { version = "0.11.14", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 # Use a fork here since we need PAX support, but the upstream
 # does not hav the PR merged yet.

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -21,6 +21,7 @@ flate2 = { version = "1.0.25", default-features = false }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 generic-array = "0.14.6"
 httpdate = "1.0.2"
+pin-project = "1.0.12"
 reqwest = { version = "0.11.14", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 # Use a fork here since we need PAX support, but the upstream
 # does not hav the PR merged yet.

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -16,6 +16,7 @@ async_zip = { version = "0.0.9", features = ["deflate", "bzip2", "lzma", "zstd",
 binstalk-types = { version = "0.2.0", path = "../binstalk-types" }
 bytes = "1.4.0"
 bzip2 = "0.4.4"
+compact_str = "0.6.1"
 digest = "0.10.6"
 flate2 = { version = "1.0.25", default-features = false }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -19,6 +19,8 @@ use tracing::{debug, info};
 pub use reqwest::{tls, Error as ReqwestError, Method};
 pub use url::Url;
 
+mod delay_request;
+
 const MAX_RETRY_DURATION: Duration = Duration::from_secs(120);
 const MAX_RETRY_COUNT: u8 = 3;
 const DEFAULT_MIN_TLS: tls::Version = tls::Version::TLS_1_2;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -127,9 +127,9 @@ impl Client {
                 (
                     // 503                            429
                     StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS,
-                    Some(mut duration),
+                    Some(duration),
                 ) => {
-                    duration = duration.min(MAX_RETRY_DURATION);
+                    let duration = duration.min(MAX_RETRY_DURATION);
 
                     info!("Receiver status code {status}, will wait for {duration:#?} and retry");
 

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -127,8 +127,10 @@ impl Client {
                 (
                     // 503                            429
                     StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS,
-                    Some(duration),
-                ) if duration <= MAX_RETRY_DURATION && count < MAX_RETRY_COUNT => {
+                    Some(mut duration),
+                ) if count < MAX_RETRY_COUNT => {
+                    duration = duration.min(MAX_RETRY_DURATION);
+
                     info!("Receiver status code {status}, will wait for {duration:#?} and retry");
 
                     let deadline = Instant::now() + duration;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -128,7 +128,7 @@ impl Client {
                     // 503                            429
                     StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS,
                     Some(mut duration),
-                ) if count < MAX_RETRY_COUNT => {
+                ) => {
                     duration = duration.min(MAX_RETRY_DURATION);
 
                     info!("Receiver status code {status}, will wait for {duration:#?} and retry");
@@ -140,6 +140,10 @@ impl Client {
                         .lock()
                         .await
                         .add_urls_to_delay([url, response.url()].into_iter().dedup(), deadline);
+
+                    if count >= MAX_RETRY_COUNT {
+                        break Ok(response);
+                    }
                 }
                 _ => break Ok(response),
             }

--- a/crates/binstalk-downloader/src/remote/delay_request.rs
+++ b/crates/binstalk-downloader/src/remote/delay_request.rs
@@ -1,0 +1,100 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use compact_str::{CompactString, ToCompactString};
+use pin_project::pin_project;
+use reqwest::Request;
+use tokio::time::{sleep_until, Instant, Sleep};
+use tower::Service;
+
+pub(super) struct DelayRequest<S> {
+    inner: S,
+    hosts_to_delay: HashMap<CompactString, Instant>,
+}
+
+impl<S> DelayRequest<S> {
+    pub(super) fn new(inner: S) -> Self {
+        Self {
+            inner,
+            hosts_to_delay: Default::default(),
+        }
+    }
+
+    pub(super) fn add_host_to_delay(&mut self, host: &str, deadline: Instant) {
+        self.hosts_to_delay
+            .entry(host.to_compact_string())
+            .and_modify(|old_dl| {
+                *old_dl = deadline.max(*old_dl);
+            })
+            .or_insert(deadline);
+    }
+}
+
+impl<S> Service<Request> for DelayRequest<S>
+where
+    S: Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = DelayRequestFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let sleep = req
+            .url()
+            .host_str()
+            .and_then(|host| {
+                self.hosts_to_delay
+                    .get(host)
+                    .map(|deadline| (*deadline, host))
+            })
+            .and_then(|(deadline, host)| {
+                if deadline.elapsed().is_zero() {
+                    Some(Box::pin(sleep_until(deadline)))
+                } else {
+                    // We have already gone past the deadline,
+                    // so we should remove it instead.
+                    self.hosts_to_delay.remove(host);
+                    None
+                }
+            });
+
+        DelayRequestFuture {
+            sleep,
+            inner: self.inner.call(req),
+        }
+    }
+}
+
+#[pin_project]
+pub(super) struct DelayRequestFuture<F> {
+    sleep: Option<Pin<Box<Sleep>>>,
+
+    #[pin]
+    inner: F,
+}
+
+impl<F> Future for DelayRequestFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        if let Some(sleep) = this.sleep.as_mut() {
+            ready!(sleep.as_mut().poll(cx));
+            *this.sleep = None;
+        }
+
+        this.inner.poll(cx)
+    }
+}


### PR DESCRIPTION
Fixed #747

 - Add dep compact_str v0.6.1 to binstalk-downloader
 - Impl new type `DelayRequest`
 - Handle 503/429 with wait duration > `MAX_RETRY_DURATION` by simply taking the min
 - Fix `Client::send_request_inner`: Ensure 503/429 get propagated to other requests
   
   even if the current requests reach its maximum retry and decides to
   simply return an error.
