### PR TITLE
Fix #728: fallback to copy when symlinking on windows

### DIFF
--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    fmt, fs,
+    fmt,
     path::{self, Component, Path, PathBuf},
 };
 
@@ -183,7 +183,7 @@ impl BinFile {
         );
 
         #[cfg(unix)]
-        fs::set_permissions(
+        std::fs::set_permissions(
             &self.source,
             std::os::unix::fs::PermissionsExt::from_mode(0o755),
         )?;

--- a/crates/binstalk/src/fs.rs
+++ b/crates/binstalk/src/fs.rs
@@ -63,7 +63,7 @@ pub fn atomic_install(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
+fn symlink_file(original: &Path, link: &Path) -> io::Result<()> {
     #[cfg(target_family = "unix")]
     std::os::unix::fs::symlink(original, link)?;
 

--- a/crates/binstalk/src/fs.rs
+++ b/crates/binstalk/src/fs.rs
@@ -65,11 +65,13 @@ pub fn atomic_install(src: &Path, dst: &Path) -> io::Result<()> {
 
 fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     #[cfg(target_family = "unix")]
-    let f = std::os::unix::fs::symlink;
-    #[cfg(target_family = "windows")]
-    let f = std::os::windows::fs::symlink_file;
+    std::os::unix::fs::symlink(original, link)?;
 
-    f(original, link)
+    // Symlinks on Windows are disabled in some editions, so creating one is unreliable.
+    #[cfg(target_family = "windows")]
+    std::os::windows::fs::symlink_file(original, link)
+        .or_else(|_| std::fs::copy(original, link))?;
+    Ok(())
 }
 
 /// Atomically install symlink "link" to a file "dst".

--- a/crates/binstalk/src/fs.rs
+++ b/crates/binstalk/src/fs.rs
@@ -70,7 +70,7 @@ fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Res
     // Symlinks on Windows are disabled in some editions, so creating one is unreliable.
     #[cfg(target_family = "windows")]
     std::os::windows::fs::symlink_file(original, link)
-        .or_else(|_| std::fs::copy(original, link))?;
+        .or_else(|_| std::fs::copy(original, link).map(drop))?;
     Ok(())
 }
 

--- a/crates/binstalk/src/helpers/signal.rs
+++ b/crates/binstalk/src/helpers/signal.rs
@@ -1,4 +1,4 @@
-use std::{future::pending, io};
+use std::io;
 
 use super::tasks::AutoAbortJoinHandle;
 use crate::errors::BinstallError;
@@ -73,7 +73,7 @@ mod unix {
             Ok(())
         } else {
             // Use pending() here for the same reason as above.
-            pending().await
+            std::future::pending().await
         }
     }
 


### PR DESCRIPTION
Fixes #728

This isn't as good as using reflinks but let's fix the immediate bug for now.