### PR TITLE
Replace dep `futures-util` with `futures-lite` in binstalk-downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "compact_str",
  "digest",
  "flate2",
- "futures-util",
+ "futures-lite",
  "generic-array",
  "httpdate",
  "reqwest",
@@ -846,6 +846,16 @@ name = "futures-io"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -19,7 +19,7 @@ bzip2 = "0.4.4"
 compact_str = "0.6.1"
 digest = "0.10.6"
 flate2 = { version = "1.0.25", default-features = false }
-futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
+futures-lite = { version = "1.12.0", default-features = false }
 generic-array = "0.14.6"
 httpdate = "1.0.2"
 reqwest = { version = "0.11.14", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, io, marker::PhantomData, path::Path};
 
 use binstalk_types::cargo_toml_binstall::PkgFmtDecomposed;
 use digest::{Digest, FixedOutput, HashMarker, Output, OutputSizeUser, Update};
-use futures_util::stream::StreamExt;
+use futures_lite::stream::StreamExt;
 use thiserror::Error as ThisError;
 use tracing::{debug, instrument};
 

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -7,8 +7,8 @@ use std::{
 
 use async_zip::read::stream::ZipFileReader;
 use bytes::{Bytes, BytesMut};
-use futures_util::{
-    future::try_join,
+use futures_lite::{
+    future::try_zip as try_join,
     stream::{Stream, StreamExt},
 };
 use tokio::sync::mpsc;

--- a/crates/binstalk-downloader/src/download/async_tar_visitor.rs
+++ b/crates/binstalk-downloader/src/download/async_tar_visitor.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Debug, io, path::Path, pin::Pin};
 
 use async_compression::tokio::bufread;
 use bytes::Bytes;
-use futures_util::stream::{Stream, StreamExt};
+use futures_lite::stream::{Stream, StreamExt};
 use tokio::io::{copy, sink, AsyncRead};
 use tokio_tar::{Archive, Entry, EntryType};
 use tokio_util::io::StreamReader;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_util::stream::{Stream, StreamExt};
+use futures_lite::stream::{Stream, StreamExt};
 use httpdate::parse_http_date;
 use reqwest::{
     header::{HeaderMap, RETRY_AFTER},


### PR DESCRIPTION
`futures-util` has too many dependencies and it contains a lot of code of which we only use a tiny bit of them.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>