### PR TITLE
Make disabling static and rustls features possible

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -22,7 +22,7 @@ pkg-fmt = "zip"
 pkg-fmt = "zip"
 
 [dependencies]
-binstalk = { path = "../binstalk", version = "0.7.1" }
+binstalk = { path = "../binstalk", version = "0.7.1", default-features = false }
 binstalk-manifests = { path = "../binstalk-manifests", version = "0.2.0" }
 clap = { version = "4.1.4", features = ["derive"] }
 crates_io_api = { version = "0.8.1", default-features = false }

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0"
 
 [dependencies]
 async-trait = "0.1.64"
-binstalk-downloader = { version = "0.3.2", path = "../binstalk-downloader" }
+binstalk-downloader = { version = "0.3.2", path = "../binstalk-downloader", default-features = false }
 binstalk-types = { version = "0.2.0", path = "../binstalk-types" }
 cargo_toml = "0.15.1"
 command-group = { version = "2.0.1", features = ["with-tokio"] }


### PR DESCRIPTION
Default features were turned on for binstalk and the `static` and `pkg-config` features of cargo-binstall didn't do anything