### PR TITLE
Feature: Better retry policy in `binstalk-downloader`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
+      CARGO_BINSTALL_LOG_LEVEL: debug
 
     steps:
     - uses: actions/checkout@v3

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -193,8 +193,11 @@ pub fn logging(log_level: LevelFilter, json_output: bool) {
     // Calculate log_level
     let log_level = min(log_level, STATIC_MAX_LEVEL);
 
-    let allowed_targets =
-        (log_level != LevelFilter::Trace).then_some(["binstalk", "cargo_binstall"]);
+    let allowed_targets = (log_level != LevelFilter::Trace).then_some([
+        "binstalk",
+        "binstalk_downloader",
+        "cargo_binstall",
+    ]);
 
     // Forward log to tracing
     Logger::init(log_level);

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -116,9 +116,9 @@ impl Client {
             let response = match future.await {
                 Ok(response) => response,
                 Err(err) if err.is_timeout() => {
-                    let deadline = Instant::now() + RETRY_DURATION_FOR_TIMEOUT;
-
-                    self.0.service.add_urls_to_delay([url], deadline);
+                    self.0
+                        .service
+                        .add_urls_to_delay([url], RETRY_DURATION_FOR_TIMEOUT);
                     continue;
                 }
                 Err(err) => return Err(err),
@@ -136,11 +136,9 @@ impl Client {
 
                     info!("Receiver status code {status}, will wait for {duration:#?} and retry");
 
-                    let deadline = Instant::now() + duration;
-
                     self.0
                         .service
-                        .add_urls_to_delay([url, response.url()], deadline);
+                        .add_urls_to_delay([url, response.url()], duration);
 
                     if count >= MAX_RETRY_COUNT {
                         break Ok(response);

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -121,7 +121,6 @@ impl Client {
         let future = (&self.0.service).ready().await?.call(request);
 
         let response = match future.await {
-            Ok(response) => response,
             Err(err) if err.is_timeout() => {
                 // Delay further request on timeout
                 self.0
@@ -130,7 +129,7 @@ impl Client {
 
                 return Ok(ControlFlow::Continue(Err(err)));
             }
-            Err(err) => return Err(err),
+            res => res?,
         };
 
         let status = response.status();

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -148,9 +148,8 @@ impl Client {
             // Delay further request on rate limit
             StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS => {
                 let duration = parse_header_retry_after(response.headers())
-                    .unwrap_or(DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT);
-
-                let duration = duration.min(MAX_RETRY_DURATION);
+                    .unwrap_or(DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT)
+                    .min(MAX_RETRY_DURATION);
 
                 add_delay_and_continue(response, duration)
             }

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -222,13 +222,15 @@ impl Client {
 
         match res {
             Err(Error::Http(http_error))
-                if http_error.err.status() == Some(StatusCode::METHOD_NOT_ALLOWED) =>
+                if http_error
+                    .err
+                    .status()
+                    .map(|status| status.is_client_error())
+                    .unwrap_or(false) =>
             {
                 retry_with_get().await
             }
-            Ok(response) if response.status() == StatusCode::METHOD_NOT_ALLOWED => {
-                retry_with_get().await
-            }
+            Ok(response) if response.status().is_client_error() => retry_with_get().await,
             res => res,
         }
     }

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -24,6 +24,7 @@ use delay_request::DelayRequest;
 
 const MAX_RETRY_DURATION: Duration = Duration::from_secs(120);
 const MAX_RETRY_COUNT: u8 = 3;
+const DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT: Duration = Duration::from_millis(200);
 const RETRY_DURATION_FOR_TIMEOUT: Duration = Duration::from_millis(200);
 const DEFAULT_MIN_TLS: tls::Version = tls::Version::TLS_1_2;
 
@@ -138,9 +139,8 @@ impl Client {
             // 503                            429
             StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS => {
                 // Delay further request on rate limit
-                let Some(duration) = parse_header_retry_after(response.headers()) else {
-                    return Ok(ControlFlow::Break(response));
-                };
+                let duration = parse_header_retry_after(response.headers())
+                    .unwrap_or(DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT);
 
                 let duration = duration.min(MAX_RETRY_DURATION);
 

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -124,7 +124,7 @@ impl Client {
             Err(err) if err.is_timeout() => {
                 let duration = RETRY_DURATION_FOR_TIMEOUT;
 
-                info!("Received timeout erro from reqwest. Delay future request by {duration:#?}");
+                info!("Received timeout error from reqwest. Delay future request by {duration:#?}");
 
                 self.0.service.add_urls_to_delay(&[url], duration);
 

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -231,7 +231,8 @@ impl Client {
             .map(|response| response.status().is_success())
     }
 
-    /// Attempt to get final redirected url.
+    /// Attempt to get final redirected url using `Method::HEAD` or fallback
+    /// to `Method::GET`.
     pub async fn get_redirected_final_url(&self, url: Url) -> Result<Url, Error> {
         self.head_or_fallback_to_get(url)
             .await

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -130,7 +130,7 @@ impl Client {
 
                     self.0
                         .service
-                        .add_urls_to_delay(dedup([url, response.url()]), deadline);
+                        .add_urls_to_delay([url, response.url()], deadline);
 
                     if count >= MAX_RETRY_COUNT {
                         break Ok(response);
@@ -217,13 +217,5 @@ fn parse_header_retry_after(headers: &HeaderMap) -> Option<Duration> {
             // If underflows, returns Duration::ZERO.
             Some(retry_after_unix_timestamp.saturating_sub(curr_time_unix_timestamp))
         }
-    }
-}
-
-fn dedup(urls: [&Url; 2]) -> impl Iterator<Item = &Url> {
-    if urls[0] == urls[1] {
-        Some(urls[0]).into_iter().chain(None)
-    } else {
-        Some(urls[0]).into_iter().chain(Some(urls[1]))
     }
 }

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -125,7 +125,7 @@ impl Client {
                 // Delay further request on timeout
                 self.0
                     .service
-                    .add_urls_to_delay([url], RETRY_DURATION_FOR_TIMEOUT);
+                    .add_urls_to_delay(&[url], RETRY_DURATION_FOR_TIMEOUT);
 
                 return Ok(ControlFlow::Continue(Err(err)));
             }
@@ -148,7 +148,7 @@ impl Client {
 
                 self.0
                     .service
-                    .add_urls_to_delay([url, response.url()], duration);
+                    .add_urls_to_delay(&[url, response.url()], duration);
 
                 Ok(ControlFlow::Continue(Ok(response)))
             }
@@ -161,7 +161,7 @@ impl Client {
 
                 self.0
                     .service
-                    .add_urls_to_delay([url, response.url()], duration);
+                    .add_urls_to_delay(&[url, response.url()], duration);
 
                 Ok(ControlFlow::Continue(Ok(response)))
             }

--- a/crates/binstalk-downloader/src/remote/delay_request.rs
+++ b/crates/binstalk-downloader/src/remote/delay_request.rs
@@ -28,13 +28,20 @@ impl<S> DelayRequest<S> {
         }
     }
 
-    pub(super) fn add_urls_to_delay<'a, Urls>(&self, urls: Urls, deadline: Instant)
-    where
-        Urls: IntoIterator<Item = &'a Url>,
-    {
+    pub(super) fn add_urls_to_delay(&self, urls: [&Url; 2], deadline: Instant) {
+        let mut hosts = [urls[0].host_str(), urls[1].host_str()];
+
+        if hosts[0] == hosts[1] {
+            hosts[1] = None;
+        }
+
+        if hosts.iter().all(Option::is_none) {
+            return;
+        }
+
         let mut hosts_to_delay = self.hosts_to_delay.lock().unwrap();
 
-        urls.into_iter().filter_map(Url::host_str).for_each(|host| {
+        hosts.into_iter().flatten().for_each(|host| {
             hosts_to_delay
                 .entry(host.to_compact_string())
                 .and_modify(|old_dl| {

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -13,9 +13,7 @@ use url::Url;
 use crate::{
     errors::{BinstallError, InvalidPkgFmtError},
     helpers::{
-        download::Download,
-        futures_resolver::FuturesResolver,
-        remote::{Client, Method},
+        download::Download, futures_resolver::FuturesResolver, remote::Client,
         tasks::AutoAbortJoinHandle,
     },
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
@@ -68,8 +66,9 @@ impl GhCrateMeta {
             async move {
                 debug!("Checking for package at: '{url}'");
 
-                Ok((client.remote_exists(url.clone(), Method::HEAD).await?
-                    || client.remote_exists(url.clone(), Method::GET).await?)
+                Ok(client
+                    .remote_gettable(url.clone())
+                    .await?
                     .then_some((url, pkg_fmt)))
             }
         })

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -6,11 +6,7 @@ use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::{
-        download::Download,
-        remote::{Client, Method},
-        tasks::AutoAbortJoinHandle,
-    },
+    helpers::{download::Download, remote::Client, tasks::AutoAbortJoinHandle},
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
 
@@ -60,10 +56,7 @@ impl super::Fetcher for QuickInstall {
 
             let url = self.package_url();
             debug!("Checking for package at: '{url}'");
-            Ok(self
-                .client
-                .remote_exists(Url::parse(&url)?, Method::HEAD)
-                .await?)
+            Ok(self.client.remote_gettable(Url::parse(&url)?).await?)
         })
     }
 
@@ -124,7 +117,7 @@ impl QuickInstall {
         let url = Url::parse(&self.stats_url())?;
         debug!("Sending installation report to quickinstall ({url})");
 
-        self.client.remote_exists(url, Method::HEAD).await?;
+        self.client.remote_gettable(url).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixed #779 #791 

 - Retry request on timeout
 - Retry for `StatusCode::{REQUEST_TIMEOUT, GATEWAY_TIMEOUT}`
 - Add `DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT` for 503/429
   if 503/429 does not give us a header or give us an invalid header on
   when to retry, we would default to
   `DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT`.
 - Fix `Client::get_redirected_final_url`: Retry using `GET` on status code 400..405 + 410
 - Rename remote_exists => remote_gettable & support fallback to GET
   if HEAD fails due to status code 400..405 + 410.
 - Improve `Client::get_stream`: Include url & method in the err of the stream returned

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>