### PR TITLE
Rm `NOVERSION_FILENAMES` "{ name }{ archive-suffix }"

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -71,7 +71,6 @@ are:
 - `{ name }_{ version }_{ target }{ archive-suffix }`
 - `{ name }_v{ version }_{ target }{ archive-suffix }`
 - `{ name }-{ target }{ archive-suffix }` ("versionless")
-- `{ name }{ archive-suffix }` ("versionless")
 - `{ name }_{ target }{ archive-suffix }` ("versionless")
 
 The paths are:

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -27,7 +27,6 @@ pub const FULL_FILENAMES: &[&str] = &[
 
 pub const NOVERSION_FILENAMES: &[&str] = &[
     "{ name }-{ target }{ archive-suffix }",
-    "{ name }{ archive-suffix }",
     "{ name }_{ target }{ archive-suffix }",
 ];
 


### PR DESCRIPTION
which does not contain `target`, hence it might report the binary being available for any target we specified.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>