### PR TITLE
Fix use of `StreamReadable`: Ensure no empty `Bytes`

### DIFF
--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -96,6 +96,10 @@ where
         try_join(
             async move {
                 while let Some(bytes) = stream.next().await.transpose()? {
+                    if bytes.is_empty() {
+                        continue;
+                    }
+
                     if tx.send(bytes).await.is_err() {
                         // The extract tar returns, which could be that:
                         //  - Extraction fails with an error


### PR DESCRIPTION
which would cause the `StreamReadable` to return eof even if the underlying stream is still open and has not sent EOF yet.

Fixed #777

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>