### PR TITLE
Fix bin names in `.crates.toml` on win

### DIFF
--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -4,7 +4,7 @@ use std::{
     path::{self, Component, Path, PathBuf},
 };
 
-use compact_str::CompactString;
+use compact_str::{format_compact, CompactString};
 use normalize_path::NormalizePath;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
@@ -141,7 +141,7 @@ impl BinFile {
         };
 
         Ok(Self {
-            base_name: CompactString::from(base_name),
+            base_name: format_compact!("{base_name}{binary_ext}"),
             source,
             dest,
             link,

--- a/e2e-tests/uninstall.sh
+++ b/e2e-tests/uninstall.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+unset CARGO_INSTALL_ROOT
+
+export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')
+export PATH="$CARGO_HOME/bin:$othertmpdir/bin:$PATH"
+
+mkdir -p "$othertmpdir/bin"
+# Copy it to bin to test use of env var `CARGO`
+cp "./$1" "$othertmpdir/bin/"
+
+
+cargo binstall --no-confirm cargo-watch
+cargo uninstall cargo-watch

--- a/justfile
+++ b/justfile
@@ -132,6 +132,7 @@ e2e-test-strategies: (e2e-test "strategies")
 e2e-test-version-syntax: (e2e-test "version-syntax")
 e2e-test-upgrade: (e2e-test "upgrade")
 e2e-test-self-upgrade-no-symlink: (e2e-test "self-upgrade-no-symlink")
+e2e-test-uninstall: (e2e-test "uninstall")
 
 # WinTLS (Windows in CI) does not have TLS 1.3 support
 [windows]
@@ -140,7 +141,7 @@ e2e-test-tls: (e2e-test "tls" "1.2")
 [macos]
 e2e-test-tls: (e2e-test "tls" "1.2") (e2e-test "tls" "1.3")
 
-e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink
+e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall
 
 unit-tests:
     {{cargo-bin}} test {{cargo-build-args}}


### PR DESCRIPTION
`bins::BinFile::new` does not include `binary_ext` in the `BinFile::base_name`.

Also add regression e2e-test.

Fixed #801