### PR TITLE
Improve CI: All in cargo-zigbuild for linux targets

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -19,21 +19,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { o: macos-latest,    t: x86_64-apple-darwin,           r: true          }
-          - { o: macos-latest,    t: aarch64-apple-darwin                            }
-          - { o: ubuntu-20.04,    t: x86_64-unknown-linux-gnu,      r: true, c: true }
-          - { o: ubuntu-20.04,    t: armv7-unknown-linux-gnueabihf,          c: true }
-          - { o: ubuntu-20.04,    t: aarch64-unknown-linux-gnu,              c: true }
-          - { o: ubuntu-latest,   t: x86_64-unknown-linux-musl,     r: true, c: true }
-          - { o: ubuntu-latest,   t: armv7-unknown-linux-musleabihf,         c: true }
-          - { o: ubuntu-latest,   t: aarch64-unknown-linux-musl,             c: true }
-          - { o: windows-latest,  t: x86_64-pc-windows-msvc,        r: true          }
-          - { o: windows-latest,  t: aarch64-pc-windows-msvc                         }
+          - { o: macos-latest,   t: x86_64-apple-darwin,                    r: true          }
+          - { o: macos-latest,   t: aarch64-apple-darwin                                     }
+          - { o: ubuntu-20.04,   t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
+          - { o: ubuntu-20.04,   t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
+          - { o: ubuntu-20.04,   t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
+          - { o: ubuntu-latest,  t: x86_64-unknown-linux-musl,              r: true, c: true }
+          - { o: ubuntu-latest,  t: armv7-unknown-linux-musleabihf,                  c: true }
+          - { o: ubuntu-latest,  t: aarch64-unknown-linux-musl,                      c: true }
+          - { o: windows-latest, t: x86_64-pc-windows-msvc,                 r: true          }
+          - { o: windows-latest, t: aarch64-pc-windows-msvc                                  }
 
     name: ${{ matrix.t }}
     runs-on: ${{ matrix.o }}
     env:
-      CARGO_BUILD_TARGET: ${{ matrix.t }}
+      CARGO_BUILD_TARGET: ${{ matrix.t }}.${{ matrix.g }}
       JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
       JUST_FOR_RELEASE: true
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,9 +21,9 @@ jobs:
         include:
           - { o: macos-latest,   t: x86_64-apple-darwin,                    r: true          }
           - { o: macos-latest,   t: aarch64-apple-darwin                                     }
-          - { o: ubuntu-20.04,   t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
-          - { o: ubuntu-20.04,   t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
-          - { o: ubuntu-20.04,   t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
+          - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
+          - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
+          - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
           - { o: ubuntu-latest,  t: x86_64-unknown-linux-musl,              r: true, c: true }
           - { o: ubuntu-latest,  t: armv7-unknown-linux-musleabihf,                  c: true }
           - { o: ubuntu-latest,  t: aarch64-unknown-linux-musl,                      c: true }

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - { o: macos-latest,    t: x86_64-apple-darwin,           r: true          }
           - { o: macos-latest,    t: aarch64-apple-darwin                            }
-          - { o: ubuntu-20.04,    t: x86_64-unknown-linux-gnu,      r: true          }
+          - { o: ubuntu-20.04,    t: x86_64-unknown-linux-gnu,      r: true, c: true }
           - { o: ubuntu-20.04,    t: armv7-unknown-linux-gnueabihf,          c: true }
           - { o: ubuntu-20.04,    t: aarch64-unknown-linux-gnu,              c: true }
           - { o: ubuntu-latest,   t: x86_64-unknown-linux-musl,     r: true, c: true }

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,9 +21,9 @@ jobs:
         include:
           - { o: macos-latest,   t: x86_64-apple-darwin,                    r: true          }
           - { o: macos-latest,   t: aarch64-apple-darwin                                     }
-          - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
-          - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
-          - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
+          - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: .2.17, r: true, c: true }
+          - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: .2.17,          c: true }
+          - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: .2.17,          c: true }
           - { o: ubuntu-latest,  t: x86_64-unknown-linux-musl,              r: true, c: true }
           - { o: ubuntu-latest,  t: armv7-unknown-linux-musleabihf,                  c: true }
           - { o: ubuntu-latest,  t: aarch64-unknown-linux-musl,                      c: true }
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.t }}
     runs-on: ${{ matrix.o }}
     env:
-      CARGO_BUILD_TARGET: ${{ matrix.t }}.${{ matrix.g }}
+      CARGO_BUILD_TARGET: ${{ matrix.t }}${{ matrix.g }}
       JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
       JUST_FOR_RELEASE: true
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,9 +21,9 @@ jobs:
         include:
           - { o: macos-latest,   t: x86_64-apple-darwin,                    r: true          }
           - { o: macos-latest,   t: aarch64-apple-darwin                                     }
-          - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: .2.17, r: true, c: true }
-          - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: .2.17,          c: true }
-          - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: .2.17,          c: true }
+          - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
+          - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
+          - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
           - { o: ubuntu-latest,  t: x86_64-unknown-linux-musl,              r: true, c: true }
           - { o: ubuntu-latest,  t: armv7-unknown-linux-musleabihf,                  c: true }
           - { o: ubuntu-latest,  t: aarch64-unknown-linux-musl,                      c: true }
@@ -33,7 +33,8 @@ jobs:
     name: ${{ matrix.t }}
     runs-on: ${{ matrix.o }}
     env:
-      CARGO_BUILD_TARGET: ${{ matrix.t }}${{ matrix.g }}
+      CARGO_BUILD_TARGET: ${{ matrix.t }}
+      GLIBC_VERSION: ${{ matrix.g }}
       JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
       JUST_FOR_RELEASE: true
 

--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ rust-lld := if target-os != "windows" { " -Z gcc-ld=lld" } else { "" }
 # rust-lld.
 rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
 
-target-glibc-ver-postfix = if glibc-version != "" {
+target-glibc-ver-postfix := if glibc-version != "" {
     if use-cargo-zigbuild != "" {
         "." + glibc-version
     } else {
@@ -110,7 +110,7 @@ target-glibc-ver-postfix = if glibc-version != "" {
     ""
 }
 
-need-target = if target != target-host {
+need-target := if target != target-host {
     "need"
 } else if cargo-buildstd != "" {
     "need"

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ extra-build-args := env_var_or_default("JUST_EXTRA_BUILD_ARGS", "")
 extra-features := env_var_or_default("JUST_EXTRA_FEATURES", "")
 default-features := env_var_or_default("JUST_DEFAULT_FEATURES", "")
 override-features := env_var_or_default("JUST_OVERRIDE_FEATURES", "")
+glibc-version := env_var_or_default("GLIBC_VERSION", "")
 
 export BINSTALL_LOG_LEVEL := if env_var_or_default("RUNNER_DEBUG", "0") == "1" { "debug" } else { "info" }
 
@@ -99,7 +100,33 @@ rust-lld := if target-os != "windows" { " -Z gcc-ld=lld" } else { "" }
 # rust-lld.
 rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
 
-cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (if target != target-host { " --target " + target } else if cargo-buildstd != "" { " --target " + target } else { "" }) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
+target-glibc-ver-postfix = if glibc-version != "" {
+    if use-cargo-zigbuild != "" {
+        "." + glibc-version
+    } else {
+        ""
+    }
+} else {
+    ""
+}
+
+need-target = if target != target-host {
+    "need"
+} else if cargo-buildstd != "" {
+    "need"
+} else if target-glibc-ver-postfix != "" {
+    "need"
+} else {
+    ""
+}
+
+target-args := if need-target != "" {
+    "--target " + target + target-glibc-ver-postfix
+} else {
+    ""
+}
+
+cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (target-args) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
 export RUSTFLAGS := "-Z share-generics " + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
 
 

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ need-target := if target != target-host {
 }
 
 target-args := if need-target != "" {
-    "--target " + target + target-glibc-ver-postfix
+    " --target " + target + target-glibc-ver-postfix
 } else {
     ""
 }

--- a/justfile
+++ b/justfile
@@ -110,23 +110,7 @@ target-glibc-ver-postfix := if glibc-version != "" {
     ""
 }
 
-need-target := if target != target-host {
-    "need"
-} else if cargo-buildstd != "" {
-    "need"
-} else if target-glibc-ver-postfix != "" {
-    "need"
-} else {
-    ""
-}
-
-target-args := if need-target != "" {
-    " --target " + target + target-glibc-ver-postfix
-} else {
-    ""
-}
-
-cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (target-args) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
+cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (" --target ") + (target) + (target-glibc-ver-postfix) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
 export RUSTFLAGS := "-Z share-generics " + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
 
 


### PR DESCRIPTION
 - Build `x86_64-unknown-linux-gnu` using `cargo-zigbuild`
 - Build all `*-gnu` targets on glibc 2.17 for backwards compatibility
 - Use ubuntu-latest image everywhere

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>