### PR TITLE
Enable cross-lang-fat-lto on Linux

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -62,6 +62,7 @@ native-tls = ["binstalk/native-tls"]
 trust-dns = ["binstalk/trust-dns"]
 
 zstd-thin = ["binstalk/zstd-thin"]
+cross-lang-fat-lto = ["binstalk/cross-lang-fat-lto"]
 
 fancy-no-backtrace = ["miette/fancy-no-backtrace"]
 fancy-with-backtrace = ["fancy-no-backtrace", "miette/fancy"]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -69,3 +69,5 @@ native-tls = ["reqwest/native-tls", "trust-dns-resolver?/dns-over-native-tls"]
 trust-dns = ["trust-dns-resolver", "reqwest/trust-dns"]
 
 zstd-thin = ["zstd/thin"]
+
+cross-lang-fat-lto = ["zstd/fat-lto"]

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -55,3 +55,4 @@ native-tls = ["binstalk-downloader/native-tls"]
 trust-dns = ["binstalk-downloader/trust-dns"]
 
 zstd-thin = ["binstalk-downloader/zstd-thin"]
+cross-lang-fat-lto = ["binstalk-downloader/cross-lang-fat-lto"]

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
 
 # Only enable linker-plugin-lto for release
 # Also disable this on windows since it uses msvc.
-linker-plugin-lto = if for-release == "" {
+linker-plugin-lto := if for-release == "" {
     ""
 } else if target-os != "windows" {
     "-C linker-plugin-lto "

--- a/justfile
+++ b/justfile
@@ -92,7 +92,13 @@ rustc-miropt := if for-release != "" { " -Z mir-opt-level=4" } else { "" }
 # TODO: There is ongoing effort to stabilise this and we will need to update
 # this once it is merged.
 # https://github.com/rust-lang/compiler-team/issues/510
-rust-lld := if target-os != "windows" { " -Z gcc-ld=lld" } else { "" }
+rust-lld := if use-cargo-zigbuild != "" {
+    # If cargo-zigbuild is used, then it will provide the lld linker.
+    ""
+} else if target-os != "windows" {
+    # This option is not supported on windows
+    " -Z gcc-ld=lld"
+} else { "" }
 
 # ICF: link-time identical code folding
 #

--- a/justfile
+++ b/justfile
@@ -92,11 +92,12 @@ rustc-miropt := if for-release != "" { " -Z mir-opt-level=4" } else { "" }
 # TODO: There is ongoing effort to stabilise this and we will need to update
 # this once it is merged.
 # https://github.com/rust-lang/compiler-team/issues/510
+#
+# If cargo-zigbuild is used, then it will provide the lld linker
+# and this option is not supported on windows, so it will be disabled.
 rust-lld := if use-cargo-zigbuild != "" {
-    # If cargo-zigbuild is used, then it will provide the lld linker.
     ""
 } else if target-os != "windows" {
-    # This option is not supported on windows
     " -Z gcc-ld=lld"
 } else { "" }
 

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ support-pkg-config := if target == target-host {
 
 cargo-features := trim_end_match(if override-features != "" { override-features
     } else if (cargo-profile / ci-or-no) == "dev/ci" { "rustls,fancy-with-backtrace,zstd-thin,log_release_max_level_debug" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug" + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto" + extra-features
     } else { extra-features
 }, ",")
 

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ support-pkg-config := if target == target-host {
 
 cargo-features := trim_end_match(if override-features != "" { override-features
     } else if (cargo-profile / ci-or-no) == "dev/ci" { "rustls,fancy-with-backtrace,zstd-thin,log_release_max_level_debug" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto" + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug" + (if target-os == "macos" { ",cross-lang-fat-lto" } else { "" }) + extra-features
     } else { extra-features
 }, ",")
 

--- a/justfile
+++ b/justfile
@@ -107,6 +107,14 @@ rust-lld := if use-cargo-zigbuild != "" {
 # rust-lld.
 rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
 
+# Only enable linker-plugin-lto for release
+# Also disable this on windows since it uses msvc.
+linker-plugin-lto = if for-release == "" {
+    ""
+} else if target-os != "windows" {
+    "-C linker-plugin-lto "
+} else { "" }
+
 target-glibc-ver-postfix := if glibc-version != "" {
     if use-cargo-zigbuild != "" {
         "." + glibc-version
@@ -118,7 +126,7 @@ target-glibc-ver-postfix := if glibc-version != "" {
 }
 
 cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (" --target ") + (target) + (target-glibc-ver-postfix) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
-export RUSTFLAGS := "-Z share-generics " + (if target-os != "windows" { "-C linker-plugin-lto " } else { "" }) + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
+export RUSTFLAGS := "-Z share-generics " + (linker-plugin-lto) + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
 
 
 # libblocksruntime-dev provides compiler-rt

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ target-glibc-ver-postfix := if glibc-version != "" {
 }
 
 cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (" --target ") + (target) + (target-glibc-ver-postfix) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
-export RUSTFLAGS := "-Z share-generics -C linker-plugin-lto " + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
+export RUSTFLAGS := "-Z share-generics " + (if target-os != "windows" { "-C linker-plugin-lto " } else { "" }) + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
 
 
 # libblocksruntime-dev provides compiler-rt

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ support-pkg-config := if target == target-host {
 
 cargo-features := trim_end_match(if override-features != "" { override-features
     } else if (cargo-profile / ci-or-no) == "dev/ci" { "rustls,fancy-with-backtrace,zstd-thin,log_release_max_level_debug" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug" + (if target-os == "macos" { ",cross-lang-fat-lto" } else { "" }) + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug" + (if target-os != "macos" { ",cross-lang-fat-lto" } else { "" }) + extra-features
     } else { extra-features
 }, ",")
 

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ target-glibc-ver-postfix := if glibc-version != "" {
 }
 
 cargo-build-args := (if for-release != "" { " --release" } else { "" }) + (" --target ") + (target) + (target-glibc-ver-postfix) + (cargo-buildstd) + (if extra-build-args != "" { " " + extra-build-args } else { "" }) + (cargo-no-default-features) + (cargo-split-debuginfo) + (if cargo-features != "" { " --features " + cargo-features } else { "" }) + (win-arm64-ring16)
-export RUSTFLAGS := "-Z share-generics " + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
+export RUSTFLAGS := "-Z share-generics -C linker-plugin-lto " + (rustc-gcclibs) + (rustc-miropt) + (rust-lld) + (rustc-icf)
 
 
 # libblocksruntime-dev provides compiler-rt

--- a/justfile
+++ b/justfile
@@ -93,13 +93,15 @@ rustc-miropt := if for-release != "" { " -Z mir-opt-level=4" } else { "" }
 # this once it is merged.
 # https://github.com/rust-lang/compiler-team/issues/510
 #
-# If cargo-zigbuild is used, then it will provide the lld linker
-# and this option is not supported on windows, so it will be disabled.
+# If cargo-zigbuild is used, then it will provide the lld linker.
+# This option is disabled on windows since it not supported.
 rust-lld := if use-cargo-zigbuild != "" {
     ""
 } else if target-os != "windows" {
     " -Z gcc-ld=lld"
-} else { "" }
+} else {
+    ""
+}
 
 # ICF: link-time identical code folding
 #
@@ -113,7 +115,9 @@ linker-plugin-lto = if for-release == "" {
     ""
 } else if target-os != "windows" {
     "-C linker-plugin-lto "
-} else { "" }
+} else {
+    ""
+}
 
 target-glibc-ver-postfix := if glibc-version != "" {
     if use-cargo-zigbuild != "" {

--- a/justfile
+++ b/justfile
@@ -113,7 +113,7 @@ rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
 # Also disable this on windows since it uses msvc.
 linker-plugin-lto := if for-release == "" {
     ""
-} else if target-os != "windows" {
+} else if target-os == "linux" {
     "-C linker-plugin-lto "
 } else {
     ""


### PR DESCRIPTION
Fixed #806

 - Add new feature flag `cross-lang-fat-lto` and enable it on release for linux
 - Enable `-C linker-plugin-lto` for linux
 - Only use `-Z gcc-ld=lld` on non-windows targets when `cargo-zigbuild` is not enabled

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>