### PR TITLE
Add opt `--root-ceritificates` & env `BINSTALL_HTTPS_ROOT_CERTS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "crates_io_api",
  "dirs",
  "embed-resource",
+ "file-format",
  "fs-lock",
  "log",
  "miette",
@@ -726,6 +727,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "file-format"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d645737d3dda11cbf14905e9b943a1bd578cdcb751709b581a924ea9b9b18b5c"
 
 [[package]]
 name = "filetime"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -24,7 +24,7 @@ pkg-fmt = "zip"
 [dependencies]
 binstalk = { path = "../binstalk", version = "0.8.0", default-features = false }
 binstalk-manifests = { path = "../binstalk-manifests", version = "0.3.0" }
-clap = { version = "4.1.6", features = ["derive"] }
+clap = { version = "4.1.6", features = ["derive", "env"] }
 crates_io_api = { version = "0.8.1", default-features = false }
 dirs = "4.0.0"
 fs-lock = { version = "0.1.0", path = "../fs-lock" }

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -27,6 +27,7 @@ binstalk-manifests = { path = "../binstalk-manifests", version = "0.3.0" }
 clap = { version = "4.1.6", features = ["derive", "env"] }
 crates_io_api = { version = "0.8.1", default-features = false }
 dirs = "4.0.0"
+file-format = { version = "0.14.0", default-features = false }
 fs-lock = { version = "0.1.0", path = "../fs-lock" }
 log = { version = "0.4.17", features = ["std"] }
 miette = "5.5.0"

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -203,6 +203,11 @@ pub struct Args {
     #[clap(help_heading = "Options", long, value_enum, value_name = "VERSION")]
     pub min_tls_version: Option<TLSVersion>,
 
+    /// Specify the root ceritificates to use for https connnections,
+    /// in additional to default system-wide ones.
+    #[clap(help_heading = "Options", long, env = "BINSTALL_HTTPS_ROOT_CERTS")]
+    pub root_certificates: Vec<PathBuf>,
+
     /// Print logs in json format to be parsable.
     #[clap(help_heading = "Options", long)]
     pub json_output: bool,
@@ -313,7 +318,7 @@ pub fn parse() -> Args {
     // Filter extraneous arg when invoked by cargo
     // `cargo run -- --help` gives ["target/debug/cargo-binstall", "--help"]
     // `cargo binstall --help` gives ["/home/ryan/.cargo/bin/cargo-binstall", "binstall", "--help"]
-    let mut args: Vec<OsString> = std::env::args_os().collect();
+    let mut args: Vec<OsString> = env::args_os().collect();
     let args = if args.get(1).map(|arg| arg == "binstall").unwrap_or_default() {
         // Equivalent to
         //

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -203,8 +203,8 @@ pub struct Args {
     #[clap(help_heading = "Options", long, value_enum, value_name = "VERSION")]
     pub min_tls_version: Option<TLSVersion>,
 
-    /// Specify the root ceritificates to use for https connnections,
-    /// in additional to default system-wide ones.
+    /// Specify the root certificates to use for https connnections,
+    /// in addition to default system-wide ones.
     #[clap(help_heading = "Options", long, env = "BINSTALL_HTTPS_ROOT_CERTS")]
     pub root_certificates: Vec<PathBuf>,
 

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -23,7 +23,7 @@ mod delay_request;
 use delay_request::DelayRequest;
 
 mod certificate;
-pub use certificate::{Certificate, OpenCertificateError};
+pub use certificate::Certificate;
 
 const MAX_RETRY_DURATION: Duration = Duration::from_secs(120);
 const MAX_RETRY_COUNT: u8 = 3;

--- a/crates/binstalk-downloader/src/remote/certificate.rs
+++ b/crates/binstalk-downloader/src/remote/certificate.rs
@@ -1,49 +1,11 @@
-use std::{ffi::OsStr, fs, io, path::Path};
-
-use compact_str::CompactString;
 use reqwest::tls;
-use thiserror::Error as ThisError;
 
 use super::ReqwestError;
-
-#[derive(Debug, ThisError)]
-pub enum OpenCertificateError {
-    #[error(transparent)]
-    Reqwest(#[from] ReqwestError),
-
-    #[error(transparent)]
-    Io(#[from] io::Error),
-
-    #[error("Expected extension .pem or .der, but found {0:#?}")]
-    UnknownExtensions(Option<CompactString>),
-}
 
 #[derive(Clone, Debug)]
 pub struct Certificate(pub(super) tls::Certificate);
 
 impl Certificate {
-    /// Open Certificate on disk and automatically detect its format based on
-    /// its extension.
-    pub fn open(path: impl AsRef<Path>) -> Result<Self, OpenCertificateError> {
-        Self::open_inner(path.as_ref())
-    }
-
-    fn open_inner(path: &Path) -> Result<Self, OpenCertificateError> {
-        let ext = path.extension();
-
-        let f = if ext == Some(OsStr::new("pem")) {
-            Self::from_pem
-        } else if ext == Some(OsStr::new("der")) {
-            Self::from_der
-        } else {
-            return Err(OpenCertificateError::UnknownExtensions(
-                ext.map(|os_str| os_str.to_string_lossy().into()),
-            ));
-        };
-
-        Ok(f(fs::read(path)?)?)
-    }
-
     /// Create a Certificate from a binary DER encoded certificate
     pub fn from_der(der: impl AsRef<[u8]>) -> Result<Self, ReqwestError> {
         tls::Certificate::from_der(der.as_ref()).map(Self)

--- a/crates/binstalk-downloader/src/remote/certificate.rs
+++ b/crates/binstalk-downloader/src/remote/certificate.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsStr, fs, io, path::Path};
+use std::{ffi::OsStr, fs, io, path::Path};
 
 use compact_str::CompactString;
 use reqwest::tls;
@@ -22,17 +22,6 @@ pub enum OpenCertificateError {
 pub struct Certificate(pub(super) tls::Certificate);
 
 impl Certificate {
-    /// Open Certificate with path specified by the environment variable `name`
-    pub fn from_env(name: impl AsRef<OsStr>) -> Result<Option<Self>, OpenCertificateError> {
-        Self::from_env_inner(name.as_ref())
-    }
-
-    fn from_env_inner(name: &OsStr) -> Result<Option<Self>, OpenCertificateError> {
-        env::var_os(name)
-            .map(|value| Self::open_inner(Path::new(&value)))
-            .transpose()
-    }
-
     /// Open Certificate on disk and automatically detect its format based on
     /// its extension.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, OpenCertificateError> {


### PR DESCRIPTION
for specifying root ceritificates used for https connnections.

And remove old environment variable `CARGO_HTTP_CAINFO`, `SSL_CERT_FILE`
and `SSL_CERT_PATH` to avoid accidentally setting them, especially in CI
env.

Also:
 - Rm fn `binstalk_downloader::Certificate::from_env`
 - Enable feature `env` of dep `clap` in `crates/bin`
 - Add new dep `file-format` v0.14.0 to `crates/bin`
 - Use `file-format` to determine pem/der file format when loading root certs
 - Rm fn `binstalk_downloader::Certificate::open` and enum `binstalk_downloader::OpenCertificateError`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>