### PR TITLE
Disable `--icf=safe` on MacOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -106,9 +106,17 @@ rust-lld := "" #if use-cargo-zigbuild != "" {
 
 # ICF: link-time identical code folding
 #
-# On windows it works out of the box and on other targets it uses
+# On windows it works out of the box and on linux it uses
 # rust-lld.
-rustc-icf := if for-release != "" { " -C link-arg=-Wl,--icf=safe" } else { "" }
+rustc-icf := if for-release != "" {
+    if target-os != "macos" {
+        " -C link-arg=-Wl,--icf=safe"
+    } else {
+        ""
+    }
+} else {
+    ""
+}
 
 # Only enable linker-plugin-lto for release
 # Also disable this on windows since it uses msvc.

--- a/justfile
+++ b/justfile
@@ -109,9 +109,11 @@ rust-lld := "" #if use-cargo-zigbuild != "" {
 # On windows it works out of the box and on linux it uses
 # rust-lld.
 rustc-icf := if for-release != "" {
-    if target-os != "macos" {
+    if target-os == "windows" {
         " -C link-arg=-Wl,--icf=safe"
-    } else {
+     } else if target-os == "linux" {
+        " -C link-arg=-Wl,--icf=safe"
+     } else {
         ""
     }
 } else {


### PR DESCRIPTION
Without `-Zgcc-ld=lld` using `--icf=safe` will fail on MacOS.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>