### PR TITLE
Speedup CI

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -47,9 +47,11 @@ runs:
 
   - name: Install rust toolchains
     run: just toolchain
+    shell: bash
 
   - name: rustc version
     run: rustc -vV | tee /tmp/rustc-version
+    shell: bash
 
   - if: inputs.build-cache
     name: Configure build cache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -4,8 +4,13 @@ inputs:
     description: Extra tools
     required: false
     default: ""
-  cache:
-    description: Enable caches
+  index-cache:
+    description: Enable index cache
+    required: true
+    default: true
+    type: boolean
+  build-cache:
+    description: Enable build cache
     required: true
     default: true
     type: boolean
@@ -27,7 +32,7 @@ runs:
     with:
       tool: just,${{ inputs.tools }}
 
-  - if: inputs.cache
+  - if: inputs.index-cache
     name: Configure index cache
     uses: actions/cache@v3
     with:
@@ -46,7 +51,7 @@ runs:
   - name: rustc version
     run: rustc -vV | tee /tmp/rustc-version
 
-  - if: inputs.cache
+  - if: inputs.build-cache
     name: Configure build cache
     uses: actions/cache@v3
     with:

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -40,10 +40,16 @@ runs:
         ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
         ${{ runner.os }}-cargo-index-
 
+  - name: Install rust toolchains
+    run: just toolchain
+
+  - name: rustc version
+    run: rustc -vV | tee /tmp/rustc-version
+
   - if: inputs.cache
     name: Configure build cache
     uses: actions/cache@v3
     with:
       path: |
         target/
-      key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+      key: ${{ runner.os }}-cargo-build-${{ hashFiles('/tmp/rustc-version') }}-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
 
     - run: just ci-install-deps
     - run: just test
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
 
     - run: just ci-install-deps
     - run: just check
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
 
     - run: just check
 
@@ -112,7 +112,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ matrix.target }}-debug
+        cache-suffix: ${{ matrix.target }}
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
-    - run: just toolchain
     - run: just ci-install-deps
     - run: just test
       env:
@@ -80,7 +79,6 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
-    - run: just toolchain
     - run: just ci-install-deps
     - run: just check
 
@@ -95,7 +93,6 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
-    - run: just toolchain
     - run: just check
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        build-cache: false
+        cache-suffix: lint
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
+      with:
+        cache: false
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
     - run: just toolchain
     - run: just ci-install-deps
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
     - run: just toolchain
     - run: just ci-install-deps
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}-debug
 
     - run: just toolchain
     - run: just check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache: false
+        build-cache: false
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: lint
+        cache-suffix: ${{ matrix.target }}-debug
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        tools: cross
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
 
     - run: just toolchain

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: ${{ matrix.t }}-release
+        cache-suffix: release-${{ matrix.t }}
 
     - run: just toolchain rust-src
     - run: just ci-install-deps

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: release-${{ matrix.t }}-release
+        cache-suffix: ${{ matrix.t }}-release
 
     - run: just toolchain rust-src
     - run: just ci-install-deps

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,7 +42,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        tools: cross
         cache-suffix: release-${{ matrix.t }}
 
     - run: just toolchain rust-src

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: release-${{ matrix.t }}
+        cache-suffix: release-${{ matrix.t }}-release
 
     - run: just toolchain rust-src
     - run: just ci-install-deps

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -86,7 +86,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache: false
+        index-cache: false
+        build-cache: false
 
     - uses: actions/download-artifact@v3
       with:

--- a/justfile
+++ b/justfile
@@ -151,7 +151,7 @@ ci-apt-deps := if target == "x86_64-unknown-linux-gnu" { "liblzma-dev libzip-dev
 [linux]
 ci-install-deps:
     if [ -n "{{ci-apt-deps}}" ]; then sudo apt update && sudo apt install -y --no-install-recommends {{ci-apt-deps}}; fi
-    pip3 install cargo-zigbuild
+    if [ -n "{{use-cargo-zigbuild}}" ]; then pip3 install cargo-zigbuild; fi
 
 [macos]
 [windows]


### PR DESCRIPTION
 - Remove `tools: cross` input to `actions/just-setup`
    since we use `cargo-zigbuild` for cross compiling instead of `cross-rs`
    now.
 - Only install `cargo-zigbuild` in `just ci-install-deps` if `JUST_USE_CARGO_ZIGBUILD` is enabled
 - Include hash of `rustc -vV` in `build-cache`
    Switching between different versions of `rustc` will cause all crates to be
    rebuilt using new `rustc`.
 - Replace input `cache` with `index-cache` and `build-cache` in `actions/just-setup`
    for better control of caching behavior
 -  Reuse workflow `test`'s `build-cache` in workflow `lint`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>