### PR TITLE
Only use `GET` in `remote::Client::remote_gettable`

### DIFF
--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -279,7 +279,7 @@ impl Client {
         }
     }
 
-    /// Check if remote exists using `Method::HEAD` or `Method::GET` as fallback.
+    /// Check if remote exists using `Method::GET` as fallback.
     pub async fn remote_gettable(&self, url: Url) -> Result<bool, Error> {
         Ok(self.get(url).send(false).await?.status().is_success())
     }

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -281,9 +281,7 @@ impl Client {
 
     /// Check if remote exists using `Method::HEAD` or `Method::GET` as fallback.
     pub async fn remote_gettable(&self, url: Url) -> Result<bool, Error> {
-        self.head_or_fallback_to_get(url, false)
-            .await
-            .map(|response| response.status().is_success())
+        Ok(self.get(url).send(false).await?.status().is_success())
     }
 
     /// Attempt to get final redirected url using `Method::HEAD` or fallback

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -279,7 +279,7 @@ impl Client {
         }
     }
 
-    /// Check if remote exists using `Method::GET` as fallback.
+    /// Check if remote exists using `Method::GET`.
     pub async fn remote_gettable(&self, url: Url) -> Result<bool, Error> {
         Ok(self.get(url).send(false).await?.status().is_success())
     }


### PR DESCRIPTION
Fixed #835

Using `HEAD` for this would often cause false negative that requires the `Client` to fallback to `GET`, which creates a lot of requests even if the url doesn't exist and then get cargo-binstall rate limited by GitHub/GitLab/etc.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>