### PR TITLE
Extract GitHub token from file if `--github-token` or env variable `GITHUB_TOKEN` is not present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "embed-resource",
  "file-format",
  "fs-lock",
+ "gh-token",
  "log",
  "miette",
  "mimalloc",
@@ -801,6 +802,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gh-token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc623f67e9004eac91ad251d7d4c0b1fa7ac53646c09d9c8ef6e27a21b2d02fd"
+dependencies = [
+ "home",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -1965,6 +1978,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2566,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -29,6 +29,7 @@ compact_str = "0.7.0"
 dirs = "4.0.0"
 file-format = { version = "0.14.0", default-features = false }
 fs-lock = { version = "0.1.0", path = "../fs-lock" }
+gh-token = "0.1.0"
 log = { version = "0.4.17", features = ["std"] }
 miette = "5.5.0"
 mimalloc = { version = "0.1.34", default-features = false, optional = true }

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -152,7 +152,7 @@ pub struct Args {
     ///
     /// This option can be used to disable that behavior.
     #[clap(help_heading = "Overrides", long)]
-    pub no_extract_github_token_from_config: bool,
+    pub no_scrap_github_token: bool,
 
     /// Disable symlinking / versioned updates.
     ///
@@ -461,7 +461,7 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
             .exit()
     }
 
-    if opts.github_token.is_none() && !opts.no_extract_github_token_from_config {
+    if opts.github_token.is_none() && !opts.no_scrap_github_token {
         if let Some(github_token) = try_extract_from_git_credentials() {
             opts.github_token = Some(github_token);
         } else if let Ok(github_token) = gh_token::get() {

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -145,6 +145,14 @@ pub struct Args {
     #[clap(help_heading = "Overrides", long, value_delimiter(','))]
     pub disable_strategies: Vec<Strategy>,
 
+    /// If `--github-token` or environment variable `GITHUB_TOKEN` is not
+    /// specified, then cargo-binstall will try to extract github token from
+    /// `$HOME/.git-credentials` or `$HOME/.config/gh/hosts.yml` by default.
+    ///
+    /// This option can be used to disable that behavior.
+    #[clap(help_heading = "Overrides", long)]
+    pub no_extract_github_token_from_config: bool,
+
     /// Disable symlinking / versioned updates.
     ///
     /// By default, Binstall will install a binary named `<name>-<version>` in the install path, and

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::OsString,
     fmt, fs, iter,
     num::{NonZeroU64, ParseIntError},
-    path::{Path, PathBuf},
+    path::PathBuf,
     str::FromStr,
 };
 
@@ -152,7 +152,7 @@ pub struct Args {
     ///
     /// This option can be used to disable that behavior.
     #[clap(help_heading = "Overrides", long)]
-    pub no_scrap_github_token: bool,
+    pub no_discover_github_token: bool,
 
     /// Disable symlinking / versioned updates.
     ///
@@ -461,7 +461,7 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
             .exit()
     }
 
-    if opts.github_token.is_none() && !opts.no_scrap_github_token {
+    if opts.github_token.is_none() && !opts.no_discover_github_token {
         if let Some(github_token) = try_extract_from_git_credentials() {
             opts.github_token = Some(github_token);
         } else if let Ok(github_token) = gh_token::get() {


### PR DESCRIPTION
 - Add option `--no-discover-github-token` for disabling this behavior
 - Add new dep gh-token v0.1.0 to crates/bin
 - Extract github-token from git-credentials or gh config if `--github-token` or
    environment variable `GITHUB_TOKEN` is not present.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>