### PR TITLE
Return a list of files written to disk in `binstalk_downloader::download::Download::and_extract`

### DIFF
--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -215,12 +215,21 @@ mod test {
         assert!(extracted_files.has_file(Path::new("cargo-binstall")));
         assert!(!extracted_files.has_file(Path::new("1234")));
 
+        let files = HashSet::from([OsStr::new("cargo-binstall").into()]);
+        assert_eq!(extracted_files.get_dir(Path::new(".")).unwrap(), &files);
+
         assert_eq!(
             extracted_files.0,
-            HashMap::from([(
-                Path::new("cargo-binstall").into(),
-                ExtractedFilesEntry::File
-            )])
+            HashMap::from([
+                (
+                    Path::new("cargo-binstall").into(),
+                    ExtractedFilesEntry::File
+                ),
+                (
+                    Path::new(".").into(),
+                    ExtractedFilesEntry::Dir(Box::new(files))
+                )
+            ])
         );
 
         let cargo_watch_url = "https://github.com/watchexec/cargo-watch/releases/download/v8.4.0/cargo-watch-v8.4.0-aarch64-unknown-linux-gnu.tar.xz";
@@ -231,6 +240,11 @@ mod test {
             .unwrap();
 
         let dir = Path::new("cargo-watch-v8.4.0-aarch64-unknown-linux-gnu");
+
+        assert_eq!(
+            extracted_files.get_dir(Path::new(".")).unwrap(),
+            &HashSet::from([dir.as_os_str().into()])
+        );
 
         assert_eq!(
             extracted_files.get_dir(dir).unwrap(),

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -19,6 +19,9 @@ pub use async_tar_visitor::{TarEntriesVisitor, TarEntry, TarEntryType};
 
 mod extracter;
 
+mod extracted_files;
+pub use extracted_files::{ExtractedFiles, ExtractedFilesEntry};
+
 mod zip_extraction;
 pub use zip_extraction::ZipError;
 

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -140,8 +140,12 @@ impl Download {
 
             match fmt.decompose() {
                 PkgFmtDecomposed::Tar(fmt) => extract_tar_based_stream(stream, path, fmt).await?,
-                PkgFmtDecomposed::Bin => extract_bin(stream, path).await?,
-                PkgFmtDecomposed::Zip => extract_zip(stream, path).await?,
+                PkgFmtDecomposed::Bin => {
+                    extract_bin(stream, path).await?;
+                }
+                PkgFmtDecomposed::Zip => {
+                    extract_zip(stream, path).await?;
+                }
             }
 
             debug!("Download OK, extracted to: '{}'", path.display());

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fs,
     future::Future,
     io::{self, Write},
@@ -68,28 +69,77 @@ where
 
 pub async fn extract_tar_based_stream<S>(
     stream: S,
-    path: &Path,
+    dst: &Path,
     fmt: TarBasedFmt,
-) -> Result<(), DownloadError>
+) -> Result<ExtractedFiles, DownloadError>
 where
     S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin + 'static,
 {
-    debug!("Extracting from {fmt} archive to {path:#?}");
+    debug!("Extracting from {fmt} archive to {}", dst.display());
 
-    extract_with_blocking_decoder(stream, path, move |rx, path| {
-        create_tar_decoder(StreamReadable::new(rx), fmt)?.unpack(path)
+    extract_with_blocking_decoder(stream, dst, move |rx, dst| {
+        // Adapted from https://docs.rs/tar/latest/src/tar/archive.rs.html#189-219
+
+        if dst.symlink_metadata().is_err() {
+            fs::create_dir_all(dst)?;
+        }
+
+        // Canonicalizing the dst directory will prepend the path with '\\?\'
+        // on windows which will allow windows APIs to treat the path as an
+        // extended-length path with a 32,767 character limit. Otherwise all
+        // unpacked paths over 260 characters will fail on creation with a
+        // NotFound exception.
+        let dst = &dst
+            .canonicalize()
+            .map(Cow::Owned)
+            .unwrap_or(Cow::Borrowed(dst));
+
+        let mut tar = create_tar_decoder(StreamReadable::new(rx), fmt)?;
+        let mut entries = tar.entries()?;
+
+        let mut extracted_files = ExtractedFiles::new();
+
+        // Delay any directory entries until the end (they will be created if needed by
+        // descendants), to ensure that directory permissions do not interfer with descendant
+        // extraction.
+        let mut directories = Vec::new();
+
+        while let Some(mut entry) = entries.next().transpose()? {
+            match entry.header().entry_type() {
+                tar::EntryType::Regular => {
+                    // unpack_in returns false if the path contains ".."
+                    // and is skipped.
+                    if entry.unpack_in(dst)? {
+                        extracted_files.add_file(&entry.path()?);
+                    }
+                }
+                tar::EntryType::Directory => {
+                    directories.push(entry);
+                }
+                _ => (),
+            }
+        }
+
+        for mut dir in directories {
+            if dir.unpack_in(dst)? {
+                extracted_files.add_dir(&dir.path()?, None);
+            }
+        }
+
+        Ok(extracted_files)
     })
     .await
 }
 
-fn extract_with_blocking_decoder<S, F>(
+fn extract_with_blocking_decoder<S, F, T>(
     stream: S,
     path: &Path,
     f: F,
-) -> impl Future<Output = Result<(), DownloadError>>
+) -> impl Future<Output = Result<T, DownloadError>>
 where
     S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin + 'static,
-    F: FnOnce(mpsc::Receiver<Bytes>, &Path) -> io::Result<()> + Send + Sync + 'static,
+    F: FnOnce(mpsc::Receiver<Bytes>, &Path) -> io::Result<T> + Send + Sync + 'static,
+    T: Send + 'static,
 {
     let path = path.to_owned();
 

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -122,7 +122,7 @@ where
 
         for mut dir in directories {
             if dir.unpack_in(dst)? {
-                extracted_files.add_dir(&dir.path()?, None);
+                extracted_files.add_dir(&dir.path()?);
             }
         }
 

--- a/crates/binstalk-downloader/src/download/extracted_files.rs
+++ b/crates/binstalk-downloader/src/download/extracted_files.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub enum ExtractedFilesEntry {
     Dir(Box<HashSet<Box<OsStr>>>),
     File,
@@ -21,7 +22,7 @@ impl ExtractedFilesEntry {
 }
 
 #[derive(Debug)]
-pub struct ExtractedFiles(HashMap<Box<Path>, ExtractedFilesEntry>);
+pub struct ExtractedFiles(pub(super) HashMap<Box<Path>, ExtractedFilesEntry>);
 
 impl ExtractedFiles {
     pub(super) fn new() -> Self {
@@ -38,8 +39,11 @@ impl ExtractedFiles {
     }
 
     fn add_dir_if_has_parent(&mut self, path: &Path) {
-        if let Some(parent) = path.parent() {
-            self.add_dir_inner(parent, path.file_name())
+        match path.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => {
+                self.add_dir_inner(parent, path.file_name())
+            }
+            _ => (),
         }
     }
 

--- a/crates/binstalk-downloader/src/download/extracted_files.rs
+++ b/crates/binstalk-downloader/src/download/extracted_files.rs
@@ -1,0 +1,76 @@
+use std::{
+    collections::{hash_map::Entry as HashMapEntry, HashMap, HashSet},
+    ffi::OsStr,
+    path::Path,
+};
+
+#[derive(Debug)]
+pub enum ExtractedFilesEntry {
+    Dir(Box<HashSet<Box<OsStr>>>),
+    File,
+}
+
+impl ExtractedFilesEntry {
+    fn new_dir(file_name: &OsStr) -> Self {
+        ExtractedFilesEntry::Dir(Box::new(HashSet::from([file_name.into()])))
+    }
+}
+
+#[derive(Debug)]
+pub struct ExtractedFiles(HashMap<Box<Path>, ExtractedFilesEntry>);
+
+impl ExtractedFiles {
+    pub(super) fn new() -> Self {
+        Self(Default::default())
+    }
+
+    /// * `path` - must be canonical and must not be empty
+    ///
+    /// NOTE that if the entry for the `path` is previously set to a dir,
+    /// it would be replaced with a file.
+    pub(super) fn add_file(&mut self, path: &Path) {
+        self.0.insert(path.into(), ExtractedFilesEntry::File);
+        self.add_dir_if_has_parent(path);
+    }
+
+    fn add_dir_if_has_parent(&mut self, path: &Path) {
+        if let Some(parent) = path.parent() {
+            self.add_dir(parent, path.file_name().unwrap())
+        }
+    }
+
+    /// * `path` - must be canonical and must not be empty
+    ///
+    /// NOTE that if the entry for the `path` is previously set to a dir,
+    /// it would be replaced with a Dir entry containing `file_name`.
+    pub(super) fn add_dir(&mut self, path: &Path, file_name: &OsStr) {
+        match self.0.entry(path.into()) {
+            HashMapEntry::Vacant(entry) => {
+                entry.insert(ExtractedFilesEntry::new_dir(file_name));
+            }
+            HashMapEntry::Occupied(entry) => match entry.into_mut() {
+                ExtractedFilesEntry::Dir(hash_set) => {
+                    hash_set.insert(file_name.into());
+                }
+                entry => *entry = ExtractedFilesEntry::new_dir(file_name),
+            },
+        }
+
+        self.add_dir_if_has_parent(path);
+    }
+
+    pub fn get_entry(&self, path: &Path) -> Option<&ExtractedFilesEntry> {
+        self.0.get(path)
+    }
+
+    pub fn get_dir(&self, path: &Path) -> Option<&HashSet<Box<OsStr>>> {
+        match self.get_entry(path)? {
+            ExtractedFilesEntry::Dir(file_names) => Some(file_names),
+            ExtractedFilesEntry::File => None,
+        }
+    }
+
+    pub fn has_file(&self, path: &Path) -> bool {
+        matches!(self.get_entry(path), Some(ExtractedFilesEntry::File))
+    }
+}

--- a/crates/binstalk-downloader/src/download/extracted_files.rs
+++ b/crates/binstalk-downloader/src/download/extracted_files.rs
@@ -15,7 +15,7 @@ impl ExtractedFilesEntry {
         ExtractedFilesEntry::Dir(Box::new(
             file_name
                 .map(|file_name| HashSet::from([file_name.into()]))
-                .unwrap_or_else(|| HashSet::default()),
+                .unwrap_or_else(HashSet::default),
         ))
     }
 }
@@ -39,15 +39,24 @@ impl ExtractedFiles {
 
     fn add_dir_if_has_parent(&mut self, path: &Path) {
         if let Some(parent) = path.parent() {
-            self.add_dir(parent, path.file_name())
+            self.add_dir_inner(parent, path.file_name())
         }
     }
 
     /// * `path` - must be canonical and must not be empty
     ///
     /// NOTE that if the entry for the `path` is previously set to a dir,
-    /// it would be replaced with a Dir entry containing `file_name`.
-    pub(super) fn add_dir(&mut self, path: &Path, file_name: Option<&OsStr>) {
+    /// it would be replaced with an empty Dir entry.
+    pub(super) fn add_dir(&mut self, path: &Path) {
+        self.add_dir_inner(path, None);
+    }
+
+    /// * `path` - must be canonical and must not be empty
+    ///
+    /// NOTE that if the entry for the `path` is previously set to a dir,
+    /// it would be replaced with a Dir entry containing `file_name` if it
+    /// is `Some(..)`, or an empty Dir entry.
+    fn add_dir_inner(&mut self, path: &Path, file_name: Option<&OsStr>) {
         match self.0.entry(path.into()) {
             HashMapEntry::Vacant(entry) => {
                 entry.insert(ExtractedFilesEntry::new_dir(file_name));

--- a/crates/binstalk-downloader/src/download/extracted_files.rs
+++ b/crates/binstalk-downloader/src/download/extracted_files.rs
@@ -11,8 +11,12 @@ pub enum ExtractedFilesEntry {
 }
 
 impl ExtractedFilesEntry {
-    fn new_dir(file_name: &OsStr) -> Self {
-        ExtractedFilesEntry::Dir(Box::new(HashSet::from([file_name.into()])))
+    fn new_dir(file_name: Option<&OsStr>) -> Self {
+        ExtractedFilesEntry::Dir(Box::new(
+            file_name
+                .map(|file_name| HashSet::from([file_name.into()]))
+                .unwrap_or_else(|| HashSet::default()),
+        ))
     }
 }
 
@@ -35,7 +39,7 @@ impl ExtractedFiles {
 
     fn add_dir_if_has_parent(&mut self, path: &Path) {
         if let Some(parent) = path.parent() {
-            self.add_dir(parent, path.file_name().unwrap())
+            self.add_dir(parent, path.file_name())
         }
     }
 
@@ -43,14 +47,16 @@ impl ExtractedFiles {
     ///
     /// NOTE that if the entry for the `path` is previously set to a dir,
     /// it would be replaced with a Dir entry containing `file_name`.
-    pub(super) fn add_dir(&mut self, path: &Path, file_name: &OsStr) {
+    pub(super) fn add_dir(&mut self, path: &Path, file_name: Option<&OsStr>) {
         match self.0.entry(path.into()) {
             HashMapEntry::Vacant(entry) => {
                 entry.insert(ExtractedFilesEntry::new_dir(file_name));
             }
             HashMapEntry::Occupied(entry) => match entry.into_mut() {
                 ExtractedFilesEntry::Dir(hash_set) => {
-                    hash_set.insert(file_name.into());
+                    if let Some(file_name) = file_name {
+                        hash_set.insert(file_name.into());
+                    }
                 }
                 entry => *entry = ExtractedFilesEntry::new_dir(file_name),
             },

--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -65,7 +65,7 @@ where
     }
 
     if raw_filename.ends_with('/') {
-        extracted_files.add_dir(&filename, None);
+        extracted_files.add_dir(&filename);
 
         // This entry is a dir.
         asyncify(move || {

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -8,7 +8,10 @@ use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::{gh_api_client::GhApiClient, remote::Client, tasks::AutoAbortJoinHandle},
+    helpers::{
+        download::ExtractedFiles, gh_api_client::GhApiClient, remote::Client,
+        tasks::AutoAbortJoinHandle,
+    },
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
 
@@ -29,7 +32,7 @@ pub trait Fetcher: Send + Sync {
         Self: Sized;
 
     /// Fetch a package and extract
-    async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError>;
+    async fn fetch_and_extract(&self, dst: &Path) -> Result<ExtractedFiles, BinstallError>;
 
     /// Find the package, if it is available for download
     ///

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::{
     errors::{BinstallError, InvalidPkgFmtError},
     helpers::{
-        download::Download,
+        download::{Download, ExtractedFiles},
         futures_resolver::FuturesResolver,
         gh_api_client::{GhApiClient, GhReleaseArtifact, HasReleaseArtifact},
         remote::Client,
@@ -216,7 +216,7 @@ impl super::Fetcher for GhCrateMeta {
         })
     }
 
-    async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
+    async fn fetch_and_extract(&self, dst: &Path) -> Result<ExtractedFiles, BinstallError> {
         let (url, pkg_fmt) = self.resolution.get().unwrap(); // find() is called first
         debug!("Downloading package from: '{url}' dst:{dst:?} fmt:{pkg_fmt:?}");
         Ok(Download::new(self.client.clone(), url.clone())

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -7,7 +7,10 @@ use url::Url;
 use crate::{
     errors::BinstallError,
     helpers::{
-        download::Download, gh_api_client::GhApiClient, remote::Client, tasks::AutoAbortJoinHandle,
+        download::{Download, ExtractedFiles},
+        gh_api_client::GhApiClient,
+        remote::Client,
+        tasks::AutoAbortJoinHandle,
     },
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
@@ -63,7 +66,7 @@ impl super::Fetcher for QuickInstall {
         })
     }
 
-    async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
+    async fn fetch_and_extract(&self, dst: &Path) -> Result<ExtractedFiles, BinstallError> {
         let url = self.package_url();
         debug!("Downloading package from: '{url}'");
         Ok(Download::new(self.client.clone(), Url::parse(&url)?)

--- a/justfile
+++ b/justfile
@@ -31,10 +31,7 @@ target-libc := if target =~ "gnu" { "gnu"
 output-ext := if target-os == "windows" { ".exe" } else { "" }
 output-filename := "cargo-binstall" + output-ext
 output-profile-folder := if for-release != "" { "release" } else { "debug" }
-output-folder := if target != target-host { "target" / target / output-profile-folder
-    } else if env_var_or_default("CARGO_BUILD_TARGET", "") != "" { "target" / target / output-profile-folder
-    } else if cargo-buildstd != "" { "target" / target / output-profile-folder
-    } else { "target" / output-profile-folder }
+output-folder := "target" / target / output-profile-folder
 output-path := output-folder / output-filename
 
 # which tool to use for compiling


### PR DESCRIPTION
 to avoid collecting extracted files from disk again in resolution stage.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>