### PR TITLE
Use Quickinstall new release schema

### DIFF
--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -9,7 +9,7 @@ use crate::{
     helpers::{
         download::{Download, ExtractedFiles},
         gh_api_client::GhApiClient,
-        remote::{does_url_exist, Client},
+        remote::{does_url_exist, Client, Method},
         tasks::AutoAbortJoinHandle,
     },
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
@@ -127,7 +127,7 @@ impl QuickInstall {
         let url = self.stats_url.clone();
         debug!("Sending installation report to quickinstall ({url})");
 
-        self.client.remote_gettable(url).await?;
+        self.client.request(Method::HEAD, url).send(true).await?;
 
         Ok(())
     }

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -1,6 +1,7 @@
 pub mod futures_resolver;
 pub mod jobserver_client;
+pub mod remote;
 pub mod signal;
 pub mod tasks;
 
-pub use binstalk_downloader::{download, gh_api_client, remote};
+pub use binstalk_downloader::{download, gh_api_client};

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -1,0 +1,37 @@
+pub use binstalk_downloader::remote::*;
+
+use binstalk_downloader::gh_api_client::{GhApiClient, GhReleaseArtifact, HasReleaseArtifact};
+use tracing::{debug, warn};
+
+use crate::errors::BinstallError;
+
+/// This function returns a future where its size should be at most size of
+/// 2 pointers.
+pub async fn does_url_exist(
+    client: Client,
+    gh_api_client: GhApiClient,
+    url: &Url,
+) -> Result<bool, BinstallError> {
+    debug!("Checking for package at: '{url}'");
+
+    if let Some(artifact) = GhReleaseArtifact::try_extract_from_url(url) {
+        debug!("Using GitHub Restful API to check for existence of artifact, which will also cache the API response");
+
+        // The future returned has the same size as a pointer
+        match gh_api_client.has_release_artifact(artifact).await? {
+            HasReleaseArtifact::Yes => return Ok(true),
+            HasReleaseArtifact::No | HasReleaseArtifact::NoSuchRelease => return Ok(false),
+
+            HasReleaseArtifact::RateLimit { retry_after } => {
+                warn!("Your GitHub API token (if any) has reached its rate limit and cannot be used again until {retry_after:?}, so we will fallback to HEAD/GET on the url.");
+                warn!("If you did not supply the github token, consider supply one since GitHub by default limit the number of requests for unauthoized user to 60 requests per hour per origin IP address.");
+            }
+            HasReleaseArtifact::Unauthorized => {
+                warn!("GitHub API somehow requires a token for the API access, so we will fallback to HEAD/GET on the url.");
+                warn!("Please consider supplying a token to cargo-binstall to speedup resolution.");
+            }
+        }
+    }
+
+    Ok(Box::pin(client.remote_gettable(url.clone())).await?)
+}

--- a/crates/binstalk/src/helpers/remote.rs
+++ b/crates/binstalk/src/helpers/remote.rs
@@ -24,7 +24,7 @@ pub async fn does_url_exist(
 
             HasReleaseArtifact::RateLimit { retry_after } => {
                 warn!("Your GitHub API token (if any) has reached its rate limit and cannot be used again until {retry_after:?}, so we will fallback to HEAD/GET on the url.");
-                warn!("If you did not supply the github token, consider supply one since GitHub by default limit the number of requests for unauthoized user to 60 requests per hour per origin IP address.");
+                warn!("If you did not supply a github token, consider doing so: GitHub limits unauthorized users to 60 requests per hour per origin IP address.");
             }
             HasReleaseArtifact::Unauthorized => {
                 warn!("GitHub API somehow requires a token for the API access, so we will fallback to HEAD/GET on the url.");

--- a/e2e-tests/upgrade.sh
+++ b/e2e-tests/upgrade.sh
@@ -11,8 +11,6 @@ export PATH="$CARGO_HOME/bin:$PATH"
 "./$1" binstall --no-confirm --force cargo-binstall@0.11.1
 "./$1" binstall --log-level=info --no-confirm cargo-binstall@0.11.1 | grep -q 'cargo-binstall v0.11.1 is already installed'
 
-"./$1" binstall --log-level=info --no-confirm cargo-binstall@0.10.0 | grep -q -v 'cargo-binstall v0.10.0 is already installed'
-
 ## Test When 0.11.0 is installed but can be upgraded.
 "./$1" binstall --no-confirm cargo-binstall@0.12.0
 "./$1" binstall --log-level=info --no-confirm cargo-binstall@0.12.0 | grep -q 'cargo-binstall v0.12.0 is already installed'


### PR DESCRIPTION
 - Refactor: Extract new fn `binstalk::helpers::remote::does_url_exist`
 - Use new quickinstall release schema in `binstalk::fetchers::QuickInstall`
 - Optimize `fetchers::QuickInstall`: Generate url once in `Fetcher::new`
    Avoid repeated string allocation plus `Url` parsing.
    This also makes changing package_url and stats_url easier.
 - Optimize `QuickInstall::report`: Use HEAD instead of GET

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>