### PR TITLE
Enable only feature `cross-lang-fat-lto` on MacOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ support-pkg-config := if target == target-host {
 
 cargo-features := trim_end_match(if override-features != "" { override-features
     } else if (cargo-profile / ci-or-no) == "dev/ci" { "rustls,fancy-with-backtrace,zstd-thin,log_release_max_level_debug" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug" + (if target-os != "macos" { ",cross-lang-fat-lto" } else { "" }) + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto" + extra-features
     } else { extra-features
 }, ",")
 


### PR DESCRIPTION
while we cannot enable cross-lang-fat-lto on MacOS due to linker error described [here], it turns out that enabling the feature `cross-lang-fat-lto` does not break the build.

[here]: https://github.com/cargo-bins/cargo-binstall/issues/806#issuecomment-1454989522

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>