### PR TITLE
docs(readme): fix link to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ cargo binstall --no-confirm --no-symlinks cargo-edit cargo-watch cargo-tarpaulin
     watchexec-cli cargo-outdated just fnm broot stylua
 ```
 
-If your favorite package fails to install, you may specify the Cargo.toml metadata entries for `pkg-url`, `bin-dir`, and `pkg-fmt` at the command line, with values [as documented below](#supporting-binary-installation).
+If your favorite package fails to install, you may specify the metadata entries for `pkg-url`, `bin-dir`, and `pkg-fmt` at the command line, with values [as documented here](SUPPORT.md).
 
 For example:
 
 ```shell
 $ binstall \
   --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }" \
-  --pkg-fmt="txz" crate_name
+  --pkg-fmt="txz" \
+  crate_name
 ```
 
 ## Upgrade installed crates

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ cargo binstall --no-confirm --no-symlinks cargo-edit cargo-watch cargo-tarpaulin
     watchexec-cli cargo-outdated just fnm broot stylua
 ```
 
-If your favorite package fails to install, you may specify the metadata entries for `pkg-url`, `bin-dir`, and `pkg-fmt` at the command line, with values [as documented here](SUPPORT.md).
+If your favorite package fails to install, you can instead specify the `pkg-url`, `bin-dir`, and `pkg-fmt` at the command line, with values as documented in [SUPPORT.md](./SUPPORT.md).
 
 For example:
 
 ```shell
-$ binstall \
+$ cargo-binstall \
   --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }" \
   --pkg-fmt="txz" \
   crate_name


### PR DESCRIPTION
The link was dead and the entry was probably removed / moved over to SUPPORT.md?
I changed the wording as its meant for end uses which don't care about Cargo.toml.

Also the example is a bit easier to read with each argument in their own line.