### PR TITLE
Use `cargo-auditable` for release build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,6 +37,7 @@ jobs:
       GLIBC_VERSION: ${{ matrix.g }}
       JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
       JUST_FOR_RELEASE: true
+      JUST_USE_AUDITABLE: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -43,6 +43,7 @@ jobs:
     - uses: ./.github/actions/just-setup
       with:
         cache-suffix: release-${{ matrix.t }}
+        tools: cargo-auditable
 
     - run: just toolchain rust-src
     - run: just ci-install-deps

--- a/justfile
+++ b/justfile
@@ -10,6 +10,7 @@ override-features := env_var_or_default("JUST_OVERRIDE_FEATURES", "")
 glibc-version := env_var_or_default("GLIBC_VERSION", "")
 
 export BINSTALL_LOG_LEVEL := if env_var_or_default("RUNNER_DEBUG", "0") == "1" { "debug" } else { "info" }
+export CARGO := if use-cargo-zigbuild != "" { "cargo-zigbuild" } else if use-cross != "" { "cross" } else { "cargo" }
 
 # target information
 target-host := `rustc -vV | grep host: | cut -d ' ' -f 2`
@@ -35,7 +36,15 @@ output-folder := "target" / target / output-profile-folder
 output-path := output-folder / output-filename
 
 # which tool to use for compiling
-cargo-bin := if use-cargo-zigbuild != "" { "cargo-zigbuild" } else if use-cross != "" { "cross" } else { "cargo" }
+cargo-bin := if for-release != "" {
+    "cargo-auditable auditable"
+} else if use-cargo-zigbuild != "" {
+    "cargo-zigbuild"
+} else if use-cross != "" {
+    "cross"
+} else {
+    "cargo"
+}
 
 # cargo compile options
 cargo-profile := if for-release != "" { "release" } else { "dev" }
@@ -161,11 +170,11 @@ toolchain components="":
 
 
 build:
-    echo "env RUSTFLAGS=$RUSTFLAGS"
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     {{cargo-bin}} build {{cargo-build-args}}
 
 check:
-    echo "env RUSTFLAGS=$RUSTFLAGS"
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     {{cargo-bin}} check {{cargo-build-args}}
 
 get-output file outdir=".":

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ extra-features := env_var_or_default("JUST_EXTRA_FEATURES", "")
 default-features := env_var_or_default("JUST_DEFAULT_FEATURES", "")
 override-features := env_var_or_default("JUST_OVERRIDE_FEATURES", "")
 glibc-version := env_var_or_default("GLIBC_VERSION", "")
+use-auditable := env_var_or_default("JUST_USE_AUDITABLE", "")
 
 export BINSTALL_LOG_LEVEL := if env_var_or_default("RUNNER_DEBUG", "0") == "1" { "debug" } else { "info" }
 export CARGO := if use-cargo-zigbuild != "" { "cargo-zigbuild" } else if use-cross != "" { "cross" } else { "cargo" }
@@ -36,7 +37,7 @@ output-folder := "target" / target / output-profile-folder
 output-path := output-folder / output-filename
 
 # which tool to use for compiling
-cargo-bin := if for-release != "" {
+cargo-bin := if use-auditable != "" {
     "cargo-auditable auditable"
 } else if use-cargo-zigbuild != "" {
     "cargo-zigbuild"
@@ -207,17 +208,21 @@ e2e-test-tls: (e2e-test "tls" "1.2") (e2e-test "tls" "1.3")
 e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall
 
 unit-tests:
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     {{cargo-bin}} test {{cargo-build-args}}
 
 test: unit-tests build e2e-tests
 
 clippy:
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     {{cargo-bin}} clippy --no-deps -- -D clippy::all
 
 fmt:
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     cargo fmt --all -- --check
 
 fmt-check:
+    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
     cargo fmt --all -- --check
 
 lint: clippy fmt-check


### PR DESCRIPTION
to make the pre-built artifacts auditable by `cargo-audit` and other tools.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>