### PR TITLE
Perform startup/init code eagerly in `entry::install_crates`

### DIFF
--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> MainExit {
 
         let start = Instant::now();
 
-        let result = run_tokio_main(entry::install_crates(args, jobserver_client));
+        let result = run_tokio_main(|| entry::install_crates(args, jobserver_client));
 
         let done = start.elapsed();
         debug!("run time: {done:?}");


### PR DESCRIPTION
The startup/init code in `entry::install_crates` performs a lot of blocking operations, from testing if dir exists to reading from files and there is no `.await` in there until after the startup.

There are also a few cases where `block_in_place` should be called (e.g. loading manifests, loading TLS certificates) but is missing.

Most of the `Args` passed to `entry::install_crates` are actually consumed before the first `.await` point, so performing startup/init code eagerly would make the generated future much smaller, reduce codegen and also makes it easier to optimize.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>