### PR TITLE
Use known-working versions for tests

### DIFF
--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-crates="b3sum cargo-release cargo-binstall cargo-watch miniserve sccache"
+crates="b3sum@1.3.3 cargo-release@0.24.5 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3"
 
 export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
 othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')

--- a/e2e-tests/self-upgrade-no-symlink.sh
+++ b/e2e-tests/self-upgrade-no-symlink.sh
@@ -14,19 +14,19 @@ cp "./$1" "$CARGO_HOME/bin"
 # now we're running the CARGO_HOME/bin/cargo-binstall (via cargo):
 
 # self update replacing no-symlinks with no-symlinks
-cargo binstall --no-confirm --no-symlinks --force cargo-binstall
+cargo binstall --no-confirm --no-symlinks --force cargo-binstall@0.20.1
 
 # self update replacing no-symlinks with symlinks
 cp "./$1" "$CARGO_HOME/bin"
 
-cargo binstall --no-confirm --force cargo-binstall
+cargo binstall --no-confirm --force cargo-binstall@0.20.1
 
 # self update replacing symlinks with symlinks
 ln -snf "$(pwd)/cargo-binstall" "$CARGO_HOME/bin/cargo-binstall"
 
-cargo binstall --no-confirm --force cargo-binstall
+cargo binstall --no-confirm --force cargo-binstall@0.20.1
 
 # self update replacing symlinks with no-symlinks
 ln -snf "$(pwd)/cargo-binstall" "$CARGO_HOME/bin/cargo-binstall"
 
-cargo binstall --no-confirm --force --no-symlinks cargo-binstall
+cargo binstall --no-confirm --force --no-symlinks cargo-binstall@0.20.1

--- a/e2e-tests/strategies.sh
+++ b/e2e-tests/strategies.sh
@@ -8,7 +8,7 @@ export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
 export PATH="$CARGO_HOME/bin:$PATH"
 
 ## Test --disable-strategies
-"./$1" binstall --no-confirm --disable-strategies quick-install,compile cargo-update
+"./$1" binstall --no-confirm --disable-strategies quick-install,compile cargo-update@11.1.2
 exit_code="$?"
 
 if [ "$exit_code" != 94 ]; then
@@ -17,7 +17,7 @@ if [ "$exit_code" != 94 ]; then
 fi
 
 ## Test --strategies
-"./$1" binstall --no-confirm --strategies crate-meta-data cargo-update
+"./$1" binstall --no-confirm --strategies crate-meta-data cargo-update@11.1.2
 exit_code="$?"
 
 if [ "$exit_code" != 94 ]; then
@@ -26,4 +26,4 @@ if [ "$exit_code" != 94 ]; then
 fi
 
 ## Test compile-only strategy
-"./$1" binstall --no-confirm --strategies compile cargo-quickinstall
+"./$1" binstall --no-confirm --strategies compile cargo-quickinstall@0.2.8

--- a/e2e-tests/tls.sh
+++ b/e2e-tests/tls.sh
@@ -11,6 +11,6 @@ export PATH="$CARGO_HOME/bin:$PATH"
     --force \
     --min-tls-version "${2:-1.3}" \
     --no-confirm \
-    cargo-binstall
+    cargo-binstall@0.20.1
 # Test that the installed binaries can be run
 cargo binstall --help >/dev/null

--- a/e2e-tests/uninstall.sh
+++ b/e2e-tests/uninstall.sh
@@ -13,5 +13,5 @@ mkdir -p "$othertmpdir/bin"
 cp "./$1" "$othertmpdir/bin/"
 
 
-cargo binstall --no-confirm cargo-watch
+cargo binstall --no-confirm cargo-watch@8.4.0
 cargo uninstall cargo-watch


### PR DESCRIPTION
This will avoid tests takes half an hour on release because the artifacts aren't there yet, and also free us from spurious failures due to other projects making releases.