### PR TITLE
Use sccache for build cache and disable incremental mode in CI

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -61,6 +61,7 @@ runs:
 
   - if: inputs.buildcache
     name: Export env for sccache to work
+    shell: bash
     run: |
       echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -68,6 +69,5 @@ runs:
   - if: inputs.buildcache
     name: Configure post run for sccache stat
     uses: webiny/action-post-run@3.0.0
-    id: Post run for sccache stat
     with:
       run: ${SCCACHE_PATH} --show-stats

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -54,9 +54,20 @@ runs:
     shell: bash
 
   - if: inputs.buildcache
-    name: Configure build cache
-    uses: actions/cache@v3
+    name: Configure sccache
+    uses: mozilla-actions/sccache-action@v0.0.2
     with:
-      path: |
-        target/
-      key: ${{ runner.os }}-cargo-build-${{ hashFiles('rustc-version') }}-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+      version: "v0.4.0-pre.10"
+
+  - if: inputs.buildcache
+    name: Export env for sccache to work
+    run: |
+      echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+      echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+  - if: inputs.buildcache
+    name: Configure post run for sccache stat
+    uses: webiny/action-post-run@3.0.0
+    id: Post run for sccache stat
+    with:
+      run: ${SCCACHE_PATH} --show-stats

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -65,3 +65,4 @@ runs:
     run: |
       echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -65,9 +65,3 @@ runs:
     run: |
       echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-
-  - if: inputs.buildcache
-    name: Configure post run for sccache stat
-    uses: webiny/action-post-run@3.0.0
-    with:
-      run: ${SCCACHE_PATH} --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 
+[profile.dev]
+incremental = false
+
 [profile.dev.build-override]
 opt-level = 0
 codegen-units = 1024

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 
-[profile.dev]
-incremental = false
-
 [profile.dev.build-override]
 opt-level = 0
 codegen-units = 1024


### PR DESCRIPTION
Fixed #911

sccache cannot cache build artifacts if incremental mode is enabled.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>