### PR TITLE
Fix `fetcher::QuickInstall`stats report sending

### DIFF
--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -44,6 +44,10 @@ pub trait Fetcher: Send + Sync {
     /// fatal conditions only.
     fn find(self: Arc<Self>) -> AutoAbortJoinHandle<Result<bool, BinstallError>>;
 
+    /// Report to upstream that cargo-binstall tries to use this fetcher.
+    /// Currently it is only overriden by [`quickinstall::QuickInstall`].
+    fn report_to_upstream(self: Arc<Self>) {}
+
     /// Return the package format
     fn pkg_fmt(&self) -> PkgFmt;
 

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -79,10 +79,14 @@ impl super::Fetcher for QuickInstall {
     fn report_to_upstream(self: Arc<Self>) {
         if cfg!(debug_assertions) {
             debug!("Not sending quickinstall report in debug mode");
-        } else if self.target_data.target != "universal-apple-darwin" {
-            // quickinstall does not support our homebrew target
-            // universal-apple-darwin, it only supports targets supported by
-            // rust officially.
+        } else if self.target_data.target == "universal-apple-darwin" {
+            debug!(
+                r#"Not sending quickinstall report for universal-apple-darwin
+quickinstall does not support our homebrew target
+universal-apple-darwin, it only supports targets supported by
+rust officially."#,
+            );
+        } else {
             tokio::spawn(async move {
                 if let Err(err) = self.report().await {
                     warn!(

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -63,6 +63,10 @@ impl super::Fetcher for QuickInstall {
 
     fn find(self: Arc<Self>) -> AutoAbortJoinHandle<Result<bool, BinstallError>> {
         AutoAbortJoinHandle::spawn(async move {
+            if self.target_data.target == "universal-apple-darwin" {
+                return Ok(false);
+            }
+
             if cfg!(debug_assertions) {
                 debug!("Not sending quickinstall report in debug mode");
             } else {

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -118,6 +118,7 @@ async fn resolve_inner(
     );
 
     for (fetcher, handle) in handles {
+        fetcher.clone().report_to_upstream();
         match handle.flattened_join().await {
             Ok(true) => {
                 // Generate temporary binary path


### PR DESCRIPTION
Fixed https://github.com/cargo-bins/cargo-quickinstall/issues/195

 - Fix `fetchers::QuickInstall`: Stop sending stats for `universal-apple-darwin`
   since quickinstall only supports targets officially supports by rust.
 - Only send stats report to quickinstall if the `Fetcher::find` is `.await`ed on
   
   This prevents stats report to be sent for cases where the `QuickInstall` fetcher
   is actually unused, e.g. resolved to `GhCrateMeta` or other `QuickInstall` fetcher
   with different target.
   
   This also reduces amount of http requests created in background.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>