### PR TITLE
Fix `QuickInstall` report bug for target `universal2-apple-darwin`

### DIFF
--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -20,6 +20,10 @@ use super::{Data, TargetData};
 const BASE_URL: &str = "https://github.com/cargo-bins/cargo-quickinstall/releases/download";
 const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
 
+fn is_universal_macos(target: &str) -> bool {
+    ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)
+}
+
 pub struct QuickInstall {
     client: Client,
     gh_api_client: GhApiClient,
@@ -63,7 +67,7 @@ impl super::Fetcher for QuickInstall {
 
     fn find(self: Arc<Self>) -> AutoAbortJoinHandle<Result<bool, BinstallError>> {
         AutoAbortJoinHandle::spawn(async move {
-            if self.target_data.target == "universal-apple-darwin" {
+            if is_universal_macos(&self.target_data.target) {
                 return Ok(false);
             }
 
@@ -79,12 +83,12 @@ impl super::Fetcher for QuickInstall {
     fn report_to_upstream(self: Arc<Self>) {
         if cfg!(debug_assertions) {
             debug!("Not sending quickinstall report in debug mode");
-        } else if self.target_data.target == "universal-apple-darwin" {
+        } else if is_universal_macos(&self.target_data.target) {
             debug!(
                 r#"Not sending quickinstall report for universal-apple-darwin
-quickinstall does not support our homebrew target
-universal-apple-darwin, it only supports targets supported by
-rust officially."#,
+and universal2-apple-darwin.
+Quickinstall does not support these targets, it only supports targets supported
+by rust officially."#,
             );
         } else {
             tokio::spawn(async move {


### PR DESCRIPTION
This bug was reintroduced by #919 and it was fixed by #918

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>