### PR TITLE
Upgrade CI to use sccache v0.4.0 for caching

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -81,3 +81,8 @@ runs:
       echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+
+  - uses: webiny/action-post-run@3.0.0
+    id: post-run-command
+    with:
+      run: sccache --show-stats

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -19,12 +19,12 @@ inputs:
     required: false
     default: ""
 runs:
-  using: composite
   env:
     tools: "just"
+  using: composite
   steps:
-  - name: Add sccache to tools to install
-    if: inputs.buildcache
+  - if: inputs.buildcache
+    name: Add sccache to tools to install
     run: echo "tools=$tools,sccache" >>$GITHUB_ENV
     shell: bash
 

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -42,8 +42,6 @@ runs:
     uses: taiki-e/install-action@v2
     with:
       tool: ${{ env.tools }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   - if: inputs.indexcache
     name: Configure index cache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -19,12 +19,11 @@ inputs:
     required: false
     default: ""
 
-env:
-  tools: "just"
-
 runs:
   using: composite
   steps:
+  - name: Add just to tools to install
+    run: echo "tools=just" >>$GITHUB_ENV
   - if: inputs.buildcache
     name: Add sccache to tools to install
     run: echo "tools=$tools,sccache" >>$GITHUB_ENV

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -23,7 +23,12 @@ runs:
   using: composite
   steps:
   - name: Add just to tools to install
-    run: echo "tools=just,cargo-binstall" >>$GITHUB_ENV
+    run: echo "tools=just" >>$GITHUB_ENV
+    shell: bash
+
+  - if: inputs.buildcache
+    name: Add sccache to tools to install
+    run: echo "tools=$tools,sccache" >>$GITHUB_ENV
     shell: bash
 
   - name: Add inputs.tools to tools to install
@@ -37,11 +42,6 @@ runs:
     uses: taiki-e/install-action@v2
     with:
       tool: ${{ env.tools }}
-
-  - if: inputs.buildcache
-    name: Install sccache
-    run: cargo binstall --force --no-symlinks -y sccache
-    shell: bash
 
   - if: inputs.indexcache
     name: Configure index cache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -20,17 +20,25 @@ inputs:
     default: ""
 runs:
   using: composite
+  env:
+    tools: "just"
   steps:
-  - if: inputs.tools == ''
-    name: Install just
+  - name: Add sccache to tools to install
+    if: inputs.buildcache
+    run: echo "tools=$tools,sccache" >>$GITHUB_ENV
+    shell: bash
+
+  - name: Add inputs.tools to tools to install
+    if: inputs.tools != ''
+    env:
+      inputs_tools: ${{ inputs.tools }}
+    run: echo "tools=$tools,$inputs_tools" >>$GITHUB_ENV
+    shell: bash
+
+  - name: Install tools
     uses: taiki-e/install-action@v2
     with:
-      tool: just
-  - if: inputs.tools != ''
-    name: Install just and tools
-    uses: taiki-e/install-action@v2
-    with:
-      tool: just,${{ inputs.tools }}
+      tool: ${{ env.tools }}
 
   - if: inputs.indexcache
     name: Configure index cache
@@ -55,9 +63,11 @@ runs:
 
   - if: inputs.buildcache
     name: Configure sccache
-    uses: mozilla-actions/sccache-action@v0.0.2
+    uses: actions/github-script@v6
     with:
-      version: "v0.4.0-pre.10"
+      script: |
+        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
   - if: inputs.buildcache
     name: Export env for sccache to work

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -42,6 +42,8 @@ runs:
     uses: taiki-e/install-action@v2
     with:
       tool: ${{ env.tools }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   - if: inputs.indexcache
     name: Configure index cache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -24,6 +24,8 @@ runs:
   steps:
   - name: Add just to tools to install
     run: echo "tools=just" >>$GITHUB_ENV
+    shell: bash
+
   - if: inputs.buildcache
     name: Add sccache to tools to install
     run: echo "tools=$tools,sccache" >>$GITHUB_ENV

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -26,11 +26,6 @@ runs:
     run: echo "tools=just" >>$GITHUB_ENV
     shell: bash
 
-  - if: inputs.buildcache
-    name: Add sccache to tools to install
-    run: echo "tools=$tools,sccache" >>$GITHUB_ENV
-    shell: bash
-
   - name: Add inputs.tools to tools to install
     if: inputs.tools != ''
     env:
@@ -42,6 +37,11 @@ runs:
     uses: taiki-e/install-action@v2
     with:
       tool: ${{ env.tools }}
+
+  - if: inputs.buildcache
+    name: Install sccache
+    run: cargo binstall --force --no-symlinks -y sccache
+    shell: bash
 
   - if: inputs.indexcache
     name: Configure index cache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -18,9 +18,11 @@ inputs:
     description: Suffix for cache key
     required: false
     default: ""
+
+env:
+  tools: "just"
+
 runs:
-  env:
-    tools: "just"
   using: composite
   steps:
   - if: inputs.buildcache

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
   - name: Add just to tools to install
-    run: echo "tools=just" >>$GITHUB_ENV
+    run: echo "tools=just,cargo-binstall" >>$GITHUB_ENV
     shell: bash
 
   - name: Add inputs.tools to tools to install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just ci-install-deps
@@ -81,6 +83,8 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just ci-install-deps
@@ -97,6 +101,8 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just check
@@ -112,6 +118,8 @@ jobs:
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     - uses: ./.github/actions/just-setup
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just ci-install-deps
     - run: just test
@@ -78,6 +80,8 @@ jobs:
     - uses: ./.github/actions/just-setup
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just ci-install-deps
     - run: just check
@@ -92,6 +96,8 @@ jobs:
     - uses: ./.github/actions/just-setup
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just check
 
@@ -105,6 +111,8 @@ jobs:
     - uses: ./.github/actions/just-setup
       with:
         cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just check
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -45,6 +45,8 @@ jobs:
       with:
         cache-suffix: release-${{ matrix.t }}
         tools: cargo-auditable
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just toolchain rust-src
     - run: just ci-install-deps

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,6 +46,8 @@ jobs:
         cache-suffix: release-${{ matrix.t }}
         tools: cargo-auditable
       env:
+        # just-setup use binstall to install sccache and cargo-auditable,
+        # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just toolchain rust-src


### PR DESCRIPTION
Remove `mozilla-actions/sccache-action@v0.0.2` and instead use `taiki-ie/install-action` to install `sccache`, since we already use `taiki-e/install-action` for installing crates.

This PR also refactor just-setup.yml and use pass `GITHUB_TOKEN` to `taiki-e/install-action` which uses `cargo-binstall` for installing `cargo-auditable` and `sccache`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>