### PR TITLE
Enable `--no-symlinks` by default and fix `sccache` installation

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -161,7 +161,7 @@ pub struct Args {
     /// possible to have multiple versions of the same binary, for example for testing or rollback.
     ///
     /// Pass this flag to disable this behavior.
-    #[clap(help_heading = "Options", long)]
+    #[clap(help_heading = "Options", long, default_value_t = true)]
     pub no_symlinks: bool,
 
     /// Dry run, fetch and show changes without installing binaries.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -154,13 +154,9 @@ pub struct Args {
     #[clap(help_heading = "Overrides", long)]
     pub no_discover_github_token: bool,
 
-    /// Disable symlinking / versioned updates.
+    /// This flag is now enabled by default thus a no-op.
     ///
-    /// By default, Binstall will install a binary named `<name>-<version>` in the install path, and
-    /// either symlink or copy it to (depending on platform) the plain binary name. This makes it
-    /// possible to have multiple versions of the same binary, for example for testing or rollback.
-    ///
-    /// Pass this flag to disable this behavior.
+    /// By default, Binstall will install a binary as-is in the install path.
     #[clap(help_heading = "Options", long, default_value_t = true)]
     pub no_symlinks: bool,
 


### PR DESCRIPTION
Partially resolve #731

Using symlinks not only add unnecessary bloat to users' `$CARGO_HOME/bin` directory, but it actually breaks `sccache`, which inspects its binary name and decides how to act on.

For `sccache` to function, it must be invoked directly or use a hard link.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>