### PR TITLE
Run cache-cleanup at 3am & 4:30am AEST instead of after every PR

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -4,8 +4,8 @@ on:
   # Run twice every day to remove the cache so that the caches from the closed prs
   # are removed.
   schedule:
-    - cron: "0 3 * * *"
-    - cron: "30 4 * * *"
+    - cron: "0 17 * * *"
+    - cron: "30 18 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,8 +1,12 @@
 name: Cleanup caches for closed PRs
+
 on:
-  pull_request:
-    types:
-      - closed
+  # Run twice every day to remove the cache so that the caches from the closed prs
+  # are removed.
+  schedule:
+    - cron: "0 3 * * *"
+    - cron: "30 4 * * *"
+  workflow_dispatch:
 
 jobs:
   cleanup:
@@ -13,26 +17,12 @@ jobs:
         run: |
           gh extension install actions/gh-actions-cache
 
-          REPO="${{ github.repository }}"
-          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          export REPO="${{ github.repository }}"
 
-          while true; do
-              echo "Fetching list of cache key"
-              cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )"
-
-              if [ -z "$cacheKeysForPR" ]; then
-                  break
-              fi
-
-              ## Setting this to not fail the workflow while deleting cache keys. 
-              set +e
-              echo "Deleting caches..."
-              for cacheKey in $cacheKeysForPR
-              do
-                  echo Removing "$cacheKey"
-                  gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+          gh pr list --state closed -L 20 --json number --jq '.[]|.number' | (
+              while IFS='$\n' read -r closed_pr; do
+                  BRANCH="refs/pull/${closed_pr}/merge" ./cleanup-cache.sh
               done
-          done
-          echo "Done"
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cleanup-cache.sh
+++ b/cleanup-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -uxo pipefail
+
+REPO="${REPO?}"
+BRANCH="${BRANCH?}"
+
+while true; do
+    echo "Fetching list of cache key for $BRANCH"
+    cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )"
+
+    if [ -z "$cacheKeysForPR" ]; then
+        break
+    fi
+
+    ## Setting this to not fail the workflow while deleting cache keys. 
+    set +e
+    echo "Deleting caches..."
+    for cacheKey in $cacheKeysForPR
+    do
+        echo Removing "$cacheKey"
+        gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+    done
+done
+echo "Done cleaning up $BRANCH"


### PR DESCRIPTION
since cache-cleanup will issue a lot of gh api requests, running the workflow right after the PRs would cause the GH API to rate limit all workflows (including our CI for testing and release) that they can no longer upload artifacts and `cargo-binstall` would have to fallback to sending GET requests instead of using GH API, which makes it a lot slower and more likely to fail.

This PR changes it to be run at 3am and 4:30am which nobody would submit any PR at that time and then remove all caches of the top 20 closed prs.

The workflow can also now be triggered manually just in case there are too many caches.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>