### PR TITLE
Speedup `ci.yml`: Do not run tests on x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,12 @@ jobs:
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            c: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 
     runs-on: ${{ matrix.os }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
-      JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
 
     steps:
     - uses: actions/checkout@v3
@@ -71,6 +67,7 @@ jobs:
         - armv7-unknown-linux-gnueabihf
         - aarch64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
+        - x86_64-unknown-linux-musl
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Since we already run test on x86_64-unknown-linux-musl in `release-build.yml` and x86_64-unknown-linux-musl is almost identical to x86_64-unknown-linux-gnu except for the libc, there's no need to run the tests in `ci.yml`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>