### PR TITLE
Run unit tests in `release-build.yml`

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -58,6 +58,12 @@ jobs:
     - if: runner.os != 'Windows'
       run: ls -shal packages/
 
+    - name: Run unit tests in release build
+      if: "matrix.r"
+      run: just unit-tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Ensure release binary is runnable
       if: "matrix.r"
       run: just e2e-tests


### PR DESCRIPTION
Since release build enables a lot of optimization, disable debug assert and possibly change the code to be run, it's better to run the tests again.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>