### PR TITLE
Avoid checking dev-deps for jobs `*-check` and `lint` in workflow `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: just ci-install-deps
+    - run: just avoid-dev-deps
     - run: just check
 
   apple-m1-check:
@@ -105,6 +106,7 @@ jobs:
         # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - run: just avoid-dev-deps
     - run: just check
 
   windows-aarch64-check:
@@ -122,6 +124,7 @@ jobs:
         # which works better when we provide it with GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - run: just avoid-dev-deps
     - run: just check
 
   lint:
@@ -145,6 +148,7 @@ jobs:
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps
+    - run: just avoid-dev-deps
     - run: just lint
 
   # Dummy job to have a stable name for the "all tests pass" requirement

--- a/justfile
+++ b/justfile
@@ -220,6 +220,14 @@ fmt-check: fmt
 
 lint: clippy fmt-check
 
+# Some dev-dependencies require a newer version of Rust, but it doesn't matter for MSRV check
+# This is a workaround for the cargo nightly option `-Z avoid-dev-deps`
+avoid-dev-deps:
+    for crate in ./crates/*; do \
+        sed 's/\[dev-dependencies\]/[workaround-avoid-dev-deps]/g' "$crate/Cargo.toml" >"$crate/Cargo.toml.tmp"; \
+        mv "$crate/Cargo.toml.tmp" "$crate/Cargo.toml" \
+    ; done
+
 package-dir:
     rm -rf packages/prep
     mkdir -p packages/prep


### PR DESCRIPTION
We just want to make sure cargo-binstall can compile for the target, we don't want to pull in the extra dependencies.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>