### PR TITLE
Fix download link for armv7 release in readme (#980

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend using the pre-compiled ones because we optimize those more than a s
 | OS      | Arch    | URL                                                          |
 | ------- | ------- | ------------------------------------------------------------ |
 | linux   | x86\_64 | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz |
-| linux   | armv7   | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz |
+| linux   | armv7   | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-armv7-unknown-linux-musleabihf.tgz |
 | linux   | arm64   | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-aarch64-unknown-linux-musl.tgz |
 | macos   | x86\_64 | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-apple-darwin.zip |
 | macos   | m1      | https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-aarch64-apple-darwin.zip |


### PR DESCRIPTION
The Armv7 download link was pointing at the x86 release 