### PR TITLE
Run `release-build.yml` unconditionally for consistency & inc cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,9 @@ jobs:
     # fail if ANY dependency has failed or been skipped or cancelled
     - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')"
       run: exit 1
+    # Wait for 30s before release build to avoid overloading GitHub.
+    - run: sleep 30
 
-  # if everything succeeds and PR is ready for review, test the release/package process
   release-builds:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
     needs: tests-pass
     uses: ./.github/workflows/release-build.yml


### PR DESCRIPTION
Since it is run on PR anyway, we should also run it on main just in case it fails, i.e. merging of PRs without rebasing against main to test out latest changes.

It will now also be run on draft PR so that they can test out the changes and find out bugs before making it ready to review.

This change will also increase cache hits on PR, thus speeding up the CI.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>