### PR TITLE
Support subcrate in repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     - run: just test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RUNNER_DEBUG: 1
 
   linux-cross-check:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
     - run: just test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RUNNER_DEBUG: 1
 
   linux-cross-check:
     strategy:

--- a/crates/binstalk-downloader/src/gh_api_client.rs
+++ b/crates/binstalk-downloader/src/gh_api_client.rs
@@ -7,7 +7,7 @@ use std::{
 
 use compact_str::{CompactString, ToCompactString};
 use tokio::sync::OnceCell;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::remote;
 
@@ -106,6 +106,7 @@ impl GhApiClient {
     pub fn new(client: remote::Client, auth_token: Option<CompactString>) -> Self {
         let auth_token = auth_token.and_then(|auth_token| {
             if gh_prefixed(&auth_token) {
+                debug!("Using gh api token");
                 Some(auth_token)
             } else {
                 warn!("Invalid auth_token, expected 'gh*_' or `github_*`, fallback to unauthorized mode");

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -128,8 +128,8 @@ impl Data {
 }
 
 impl RepoInfo {
-    /// If `repo` contains a subcrate, then extracts that and return it as
-    /// `{subcrate}%2F` and removes that subcrate path from `repo` to match
+    /// If `repo` contains a subcrate, then extracts and returns it.
+    /// It will also remove that subcrate path from `repo` to match
     /// `scheme:/{repo_owner}/{repo_name}`
     fn detect_subcrate(repo: &mut Url, repository_host: RepositoryHost) -> Option<String> {
         match repository_host {

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -4,8 +4,8 @@ use compact_str::CompactString;
 pub use gh_crate_meta::*;
 pub use quickinstall::*;
 use tokio::sync::OnceCell;
+use tracing::instrument;
 use url::Url;
-using tracing::instrument;
 
 use crate::{
     errors::BinstallError,
@@ -102,7 +102,6 @@ impl Data {
 
     #[instrument(level = "debug")]
     async fn get_repo_info(&self, client: &Client) -> Result<&Option<RepoInfo>, BinstallError> {
-
         self.repo_info
             .get_or_try_init(move || {
                 Box::pin(async move {

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -4,7 +4,7 @@ use compact_str::CompactString;
 pub use gh_crate_meta::*;
 pub use quickinstall::*;
 use tokio::sync::OnceCell;
-use tracing::instrument;
+use tracing::{debug, instrument};
 use url::Url;
 
 use crate::{
@@ -109,14 +109,18 @@ impl Data {
                         let mut repo = client.get_redirected_final_url(Url::parse(repo)?).await?;
                         let repository_host = RepositoryHost::guess_git_hosting_services(&repo);
 
-                        Ok(Some(RepoInfo {
+                        let repo_info = RepoInfo {
                             subcrate_prefix: RepoInfo::detect_subcrate_prefix(
                                 &mut repo,
                                 repository_host,
                             ),
                             repo,
                             repository_host,
-                        }))
+                        };
+
+                        debug!("Resolved repo_info = {repo_info:#?}");
+
+                        Ok(Some(repo_info))
                     } else {
                         Ok(None)
                     }

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -5,6 +5,7 @@ pub use gh_crate_meta::*;
 pub use quickinstall::*;
 use tokio::sync::OnceCell;
 use url::Url;
+using tracing::instrument;
 
 use crate::{
     errors::BinstallError,
@@ -99,7 +100,9 @@ impl Data {
         }
     }
 
+    #[instrument(level = "debug")]
     async fn get_repo_info(&self, client: &Client) -> Result<&Option<RepoInfo>, BinstallError> {
+
         self.repo_info
             .get_or_try_init(move || {
                 Box::pin(async move {

--- a/crates/binstalk/src/fetchers/gh_crate_meta.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta.rs
@@ -330,7 +330,7 @@ impl leon::Values for Context<'_> {
 
             "binary-ext" => Some(Cow::Borrowed(self.binary_ext)),
 
-            "subcrate_prefix" => self.subcrate_prefix.map(Cow::Borrowed),
+            "subcrate_prefix" => Some(Cow::Borrowed(self.subcrate_prefix.unwrap_or(""))),
 
             _ => None,
         }

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -50,15 +50,15 @@ const SOURCEFORGE_RELEASE_PATHS: &[Template<'_>] = &[
 ];
 
 impl RepositoryHost {
-    pub fn guess_git_hosting_services(repo: &Url) -> Result<Self, BinstallError> {
+    pub fn guess_git_hosting_services(repo: &Url) -> Self {
         use RepositoryHost::*;
 
         match repo.domain() {
-            Some(domain) if domain.starts_with("github") => Ok(GitHub),
-            Some(domain) if domain.starts_with("gitlab") => Ok(GitLab),
-            Some(domain) if domain == "bitbucket.org" => Ok(BitBucket),
-            Some(domain) if domain == "sourceforge.net" => Ok(SourceForge),
-            _ => Ok(Unknown),
+            Some(domain) if domain.starts_with("github") => GitHub,
+            Some(domain) if domain.starts_with("gitlab") => GitLab,
+            Some(domain) if domain == "bitbucket.org" => BitBucket,
+            Some(domain) if domain == "sourceforge.net" => SourceForge,
+            _ => Unknown,
         }
     }
 

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -3,7 +3,7 @@ use leon::{Item, Template};
 use leon_macros::template;
 use url::Url;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RepositoryHost {
     GitHub,
     GitLab,

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -3,8 +3,6 @@ use leon::{Item, Template};
 use leon_macros::template;
 use url::Url;
 
-use crate::errors::BinstallError;
-
 #[derive(Copy, Clone, Debug)]
 pub enum RepositoryHost {
     GitHub,

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -31,20 +31,20 @@ pub const NOVERSION_FILENAMES: &[Template<'_>] = &[
 ];
 
 const GITHUB_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/releases/download/{ version }"),
-    template!("{ repo }/releases/download/v{ version }"),
+    template!("{ repo }/releases/download/{ subcrate_prefix }{ version }"),
+    template!("{ repo }/releases/download/{ subcrate_prefix }v{ version }"),
 ];
 
 const GITLAB_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/-/releases/{ version }/downloads/binaries"),
-    template!("{ repo }/-/releases/v{ version }/downloads/binaries"),
+    template!("{ repo }/-/releases/{ subcrate_prefix }{ version }/downloads/binaries"),
+    template!("{ repo }/-/releases/{ subcrate_prefix }v{ version }/downloads/binaries"),
 ];
 
 const BITBUCKET_RELEASE_PATHS: &[Template<'_>] = &[template!("{ repo }/downloads")];
 
 const SOURCEFORGE_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/files/binaries/{  version }"),
-    template!("{ repo }/files/binaries/v{ version }"),
+    template!("{ repo }/files/binaries/{ subcrate_prefix }{  version }"),
+    template!("{ repo }/files/binaries/{ subcrate_prefix }v{ version }"),
 ];
 
 impl RepositoryHost {

--- a/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
+++ b/crates/binstalk/src/fetchers/gh_crate_meta/hosting.rs
@@ -31,20 +31,29 @@ pub const NOVERSION_FILENAMES: &[Template<'_>] = &[
 ];
 
 const GITHUB_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/releases/download/{ subcrate_prefix }{ version }"),
-    template!("{ repo }/releases/download/{ subcrate_prefix }v{ version }"),
+    template!("{ repo }/releases/download/{ version }"),
+    template!("{ repo }/releases/download/v{ version }"),
+    // %2F is escaped form of '/'
+    template!("{ repo }/releases/download/{ subcrate }%2F{ version }"),
+    template!("{ repo }/releases/download/{ subcrate }%2Fv{ version }"),
 ];
 
 const GITLAB_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/-/releases/{ subcrate_prefix }{ version }/downloads/binaries"),
-    template!("{ repo }/-/releases/{ subcrate_prefix }v{ version }/downloads/binaries"),
+    template!("{ repo }/-/releases/{ version }/downloads/binaries"),
+    template!("{ repo }/-/releases/v{ version }/downloads/binaries"),
+    // %2F is escaped form of '/'
+    template!("{ repo }/-/releases/{ subcrate }%2F{ version }/downloads/binaries"),
+    template!("{ repo }/-/releases/{ subcrate }%2Fv{ version }/downloads/binaries"),
 ];
 
 const BITBUCKET_RELEASE_PATHS: &[Template<'_>] = &[template!("{ repo }/downloads")];
 
 const SOURCEFORGE_RELEASE_PATHS: &[Template<'_>] = &[
-    template!("{ repo }/files/binaries/{ subcrate_prefix }{  version }"),
-    template!("{ repo }/files/binaries/{ subcrate_prefix }v{ version }"),
+    template!("{ repo }/files/binaries/{  version }"),
+    template!("{ repo }/files/binaries/v{ version }"),
+    // %2F is escaped form of '/'
+    template!("{ repo }/files/binaries/{ subcrate }%2F{  version }"),
+    template!("{ repo }/files/binaries/{ subcrate }%2Fv{ version }"),
 ];
 
 impl RepositoryHost {

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-crates="b3sum@1.3.3 cargo-release@0.24.5 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3"
+crates="b3sum@1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3"
 
 export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
 othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -30,3 +30,5 @@ miniserve -V
 
 # Test subcrate support
 cargo binstall --no-confirm cargo-audit@0.17.5 --strategies crate-meta-data
+
+cargo audit --version

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -27,8 +27,3 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
-
-# Test subcrate support
-cargo binstall --no-confirm cargo-audit@0.17.5 --strategies crate-meta-data
-
-cargo audit --version

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -6,7 +6,8 @@ unset CARGO_INSTALL_ROOT
 
 crates="b3sum@1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3"
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')
 export PATH="$CARGO_HOME/bin:$othertmpdir/bin:$PATH"
 

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -27,3 +27,6 @@ cargo-binstall --help >/dev/null
 cargo binstall --help >/dev/null
 cargo watch -V
 miniserve -V
+
+# Test subcrate support
+cargo binstall --no-confirm cargo-audit@0.17.5 --strategies crate-meta-data

--- a/e2e-tests/manifest-path.sh
+++ b/e2e-tests/manifest-path.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 # Install binaries using `--manifest-path`

--- a/e2e-tests/other-repos.sh
+++ b/e2e-tests/other-repos.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 # Test default GitLab pkg-url templates

--- a/e2e-tests/self-upgrade-no-symlink.sh
+++ b/e2e-tests/self-upgrade-no-symlink.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 # first boostrap-install into the CARGO_HOME

--- a/e2e-tests/strategies.sh
+++ b/e2e-tests/strategies.sh
@@ -4,7 +4,8 @@ set -uxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 ## Test --disable-strategies

--- a/e2e-tests/subcrate.sh
+++ b/e2e-tests/subcrate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+unset CARGO_INSTALL_ROOT
+
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
+othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')
+export PATH="$CARGO_HOME/bin:$othertmpdir/bin:$PATH"
+
+mkdir -p "$othertmpdir/bin"
+# Copy it to bin to test use of env var `CARGO`
+cp "./$1" "$othertmpdir/bin/"
+
+cargo binstall --no-confirm cargo-audit@0.17.5 --strategies crate-meta-data
+
+cargo audit --version

--- a/e2e-tests/tls.sh
+++ b/e2e-tests/tls.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 "./$1" binstall \

--- a/e2e-tests/uninstall.sh
+++ b/e2e-tests/uninstall.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 othertmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-test')
 export PATH="$CARGO_HOME/bin:$othertmpdir/bin:$PATH"
 

--- a/e2e-tests/upgrade.sh
+++ b/e2e-tests/upgrade.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 # Test skip when installed

--- a/e2e-tests/version-syntax.sh
+++ b/e2e-tests/version-syntax.sh
@@ -4,7 +4,8 @@ set -euxo pipefail
 
 unset CARGO_INSTALL_ROOT
 
-export CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
 export PATH="$CARGO_HOME/bin:$PATH"
 
 # Test --version

--- a/justfile
+++ b/justfile
@@ -188,6 +188,7 @@ e2e-test file *arguments: (get-binary "e2e-tests")
     cd e2e-tests && env -u RUSTFLAGS bash {{file}}.sh {{output-filename}} {{arguments}}
 
 e2e-test-live: (e2e-test "live")
+e2e-test-subcrate: (e2e-test "subcrate")
 e2e-test-manifest-path: (e2e-test "manifest-path")
 e2e-test-other-repos: (e2e-test "other-repos")
 e2e-test-strategies: (e2e-test "strategies")
@@ -203,7 +204,7 @@ e2e-test-tls: (e2e-test "tls" "1.2")
 [macos]
 e2e-test-tls: (e2e-test "tls" "1.2") (e2e-test "tls" "1.3")
 
-e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall
+e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall e2e-test-subcrate
 
 unit-tests: print-env
     {{cargo-bin}} test {{cargo-build-args}}


### PR DESCRIPTION
Fixed #838

 - Add new key `subcrate` for rendering `pkg-url`
 - Add new release paths in GitHub, GitLab & SourceForge using key `subcrate` for auto-detection
 - Add subcrate detection for GitHub and GitLab
 - Add `debug!` when using gh api token in `GhApiClient::new`
 - Add subcrate testing to `e2e-tests/subcrate.sh`
 - Bump cargo-release to 0.24.9 in e2e-tests/live.sh
   to fix test failure on MacOS without libssl installed in `/usr/local/`.
 - Optimize GhCrateMeta: Detect subcrate and repo-host in `Data::get_repo_info`
    to cache the result and avoid duplicate works, this also makes the code
    more ergonomic by removing the need to some `unwrap()` plus making it
    more efficient since we don't need to clone the url just to modify it.
 - Add instrument to `Data::get_repo_info`
 - Fix `shellcheck` err in `e2e-tests/*.sh`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>