### PR TITLE
Speedup `release-build.yml`: Do not run `unit-tests`

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,19 +52,12 @@ jobs:
 
     - run: just toolchain rust-src
     - run: just ci-install-deps
+
     - run: just package
     - if: runner.os == 'Windows'
       run: Get-ChildItem packages/
     - if: runner.os != 'Windows'
       run: ls -shal packages/
-
-    - name: Run unit tests in release build
-      if: "matrix.r"
-      run: |
-        just avoid-benchmark-deps
-        just unit-tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Ensure release binary is runnable
       if: "matrix.r"

--- a/justfile
+++ b/justfile
@@ -232,12 +232,6 @@ avoid-dev-deps:
         mv "$crate/Cargo.toml.tmp" "$crate/Cargo.toml" \
     ; done
 
-# leon dev-dependencies pulls in crates for benchmark but not used in test.
-# This is a workaround for the lack of `benchmark-dependencies`.
-avoid-benchmark-deps:
-    sed 's/\[dev-dependencies\]/[workaround-avoid-dev-deps]/g' ./crates/leon/Cargo.toml >./crates/leon/Cargo.toml.tmp
-    mv ./crates/leon/Cargo.toml.tmp ./crates/leon/Cargo.toml
-
 package-dir:
     rm -rf packages/prep
     mkdir -p packages/prep


### PR DESCRIPTION
`cargo-test` cannot share its artifacts with `cargo-build` and vice
versa, plus running `e2e-tests` in release build is enough to find out
potential miscompilation.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>