### PR TITLE
Add one-liner for installing `cargo-binstall` on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 And the one-liner for installing a pre-compiled `cargo-binstall` binary from release on Windows (x86_64 and aarch64):
 
 ```
-Set-ExecutionPolicy Unrestricted -Scope Process && iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
+Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 ```
 
 To get started _using_ `cargo-binstall` first install the binary (either via `cargo install cargo-binstall` or by downloading a pre-compiled [release](https://github.com/cargo-bins/cargo-binstall/releases)), then extract it using `tar` or `unzip` and move it into `$HOME/.cargo/bin`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Here are the one-liners for installing pre-compiled `cargo-binstall` binary from
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 ```
 
+And the one-liner for installing a pre-compiled `cargo-binstall` binary from release on Windows (x86_64 and aarch64):
+
+```
+Set-ExecutionPolicy Unrestricted -Scope Process && iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
+```
+
 To get started _using_ `cargo-binstall` first install the binary (either via `cargo install cargo-binstall` or by downloading a pre-compiled [release](https://github.com/cargo-bins/cargo-binstall/releases)), then extract it using `tar` or `unzip` and move it into `$HOME/.cargo/bin`.
 We recommend using the pre-compiled ones because we optimize those more than a standard source build does.
 

--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -1,0 +1,20 @@
+$tmpdir = $Env:TEMP
+$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+$type = (Get-ComputerInfo).CsSystemType.ToLower()
+if ($type.StartsWith("x64")) {
+	$arch = "x86_64"
+} elseif ($type.StartsWith("arm64")) {
+	$arch = "aarch64"
+} else {
+	Write-Host "Unsupported Architecture: $type" -ForegroundColor Red
+	[Environment]::Exit(1)
+}
+$url = "$base_url$arch-pc-windows-msvc.zip"
+Invoke-WebRequest $url -OutFile $tmpdir\cargo-binstall.zip
+Expand-Archive -Force $tmpdir\cargo-binstall.zip $tmpdir\cargo-binstall
+Invoke-Expression "$tmpdir\cargo-binstall\cargo-binstall.exe -y --force cargo-binstall"
+Remove-Item -Force $tmpdir\cargo-binstall.zip
+Remove-Item -Recurse -Force $tmpdir\cargo-binstall
+if ($Env:Path -split ";" -notcontains "$HOME\.cargo\bin") {
+	Write-Host "Your path is missing $HOME\.cargo\bin, you might want to add it." -ForegroundColor Red
+}

--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP
 $base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
 $type = (Get-ComputerInfo).CsSystemType.ToLower()
@@ -12,9 +14,12 @@ if ($type.StartsWith("x64")) {
 $url = "$base_url$arch-pc-windows-msvc.zip"
 Invoke-WebRequest $url -OutFile $tmpdir\cargo-binstall.zip
 Expand-Archive -Force $tmpdir\cargo-binstall.zip $tmpdir\cargo-binstall
+Write-Host ""
 Invoke-Expression "$tmpdir\cargo-binstall\cargo-binstall.exe -y --force cargo-binstall"
 Remove-Item -Force $tmpdir\cargo-binstall.zip
 Remove-Item -Recurse -Force $tmpdir\cargo-binstall
 if ($Env:Path -split ";" -notcontains "$HOME\.cargo\bin") {
+	Write-Host ""
 	Write-Host "Your path is missing $HOME\.cargo\bin, you might want to add it." -ForegroundColor Red
+	Write-Host ""
 }


### PR DESCRIPTION
I saw the one-liner added for Unix systems (in #1073 / #1074) and thought it should be possible for Windows :)

The script should have the same behaviour as the Bash version, and the oneliner temporarily (scoped to the current terminal session) disables Powershell's Execution Policy.

The url used in the script is for after the PR is merged, use the following if you want to test:

```
Set-ExecutionPolicy Unrestricted -Scope Process && iex (iwr "https://raw.githubusercontent.com/supleed2/cargo-binstall/main/install-from-binstall-release.ps1").Content
```