### PR TITLE
feat: Add new cmdline option `--no-track`

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -172,6 +172,21 @@ pub struct Args {
     #[clap(help_heading = "Options", long)]
     pub no_cleanup: bool,
 
+    /// By default, binstall keeps track of the installed packages with metadata files
+    /// stored in the installation root directory.
+    ///
+    /// This flag tells binstall not to use or create that file.
+    ///
+    /// With this flag, binstall will refuse to overwrite any existing files unless the
+    /// `--force` flag is used.
+    ///
+    /// This also disables binstall’s ability to protect against multiple concurrent
+    /// invocations of binstall installing at the same time.
+    ///
+    /// This flag will also be passed to `cargo-install` if it is invoked.
+    #[clap(help_heading = "Options", long)]
+    pub no_track: bool,
+
     /// Install binaries in a custom location.
     ///
     /// By default, binaries are installed to the global location `$CARGO_HOME/bin`, and global

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -25,6 +25,7 @@ pub struct Options {
     pub force: bool,
     pub quiet: bool,
     pub locked: bool,
+    pub no_track: bool,
 
     pub version_req: Option<VersionReq>,
     pub manifest_path: Option<PathBuf>,

--- a/e2e-tests/no-track.sh
+++ b/e2e-tests/no-track.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+unset CARGO_INSTALL_ROOT
+
+CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
+export CARGO_HOME
+export PATH="$CARGO_HOME/bin:$PATH"
+
+"./$1" binstall -y cargo-binstall@0.20.1
+cargo-binstall --help >/dev/null
+
+set +e
+
+"./$1" binstall -y --no-track cargo-binstall@0.20.1
+exit_code="$?"
+
+set -e
+
+if [ "$exit_code" != 74 ]; then
+    echo "Expected exit code 74 Io Error, but actual exit code $exit_code"
+    exit 1
+fi
+
+
+"./$1" binstall -y --no-track --force cargo-binstall@0.20.1
+cargo-binstall --help >/dev/null

--- a/justfile
+++ b/justfile
@@ -202,6 +202,7 @@ e2e-test-version-syntax: (e2e-test "version-syntax")
 e2e-test-upgrade: (e2e-test "upgrade")
 e2e-test-self-upgrade-no-symlink: (e2e-test "self-upgrade-no-symlink")
 e2e-test-uninstall: (e2e-test "uninstall")
+e2e-test-no-track: (e2e-test "no-track")
 
 # WinTLS (Windows in CI) does not have TLS 1.3 support
 [windows]
@@ -210,7 +211,7 @@ e2e-test-tls: (e2e-test "tls" "1.2")
 [macos]
 e2e-test-tls: (e2e-test "tls" "1.2") (e2e-test "tls" "1.3")
 
-e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall e2e-test-subcrate
+e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall e2e-test-subcrate e2e-test-no-track
 
 unit-tests: print-env
     {{cargo-bin}} test {{cargo-build-args}}


### PR DESCRIPTION
Same as `cargo-install`'s `--no-track`.
It is also passed to `cargo-install` if it is invoked.

Also fixed `fs::atomic_symlink_file` which on Windows could fallback to
non-atomic install if symlinking failed.