### PR TITLE
ci: Switch to `Swatinem/rust-cache@v2`

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -14,21 +14,12 @@ inputs:
     required: true
     default: true
     type: boolean
-  cache-suffix:
-    description: Suffix for cache key
-    required: false
-    default: ""
 
 runs:
   using: composite
   steps:
   - name: Add just to tools to install
     run: echo "tools=just" >>$GITHUB_ENV
-    shell: bash
-
-  - if: inputs.buildcache
-    name: Add sccache to tools to install
-    run: echo "tools=$tools,sccache" >>$GITHUB_ENV
     shell: bash
 
   - name: Add inputs.tools to tools to install
@@ -43,44 +34,26 @@ runs:
     with:
       tool: ${{ env.tools }}
 
-  - if: inputs.indexcache
-    name: Configure index cache
-    uses: actions/cache@v3
-    with:
-      path: |
-        ~/.cargo/registry/index/
-        ~/.cargo/registry/cache/
-        ~/.cargo/git/db/
-      key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
-      restore-keys: |
-        ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
-        ${{ runner.os }}-cargo-index-
-
   - name: Install rust toolchains
     run: just toolchain
     shell: bash
 
   - name: rustc version
-    run: rustc -vV | tee rustc-version
+    run: rustc -vV
     shell: bash
 
-  - if: inputs.buildcache
-    name: Configure sccache
-    uses: actions/github-script@v6
-    with:
-      script: |
-        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-  - if: inputs.buildcache
-    name: Export env for sccache to work
-    shell: bash
+  - name: Retrieve RUSTFLAGS for caching
+    if: inputs.indexcache || inputs.buildcache
+    id: retrieve-rustflags
     run: |
-      echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-      echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+      if [ -n "${{ inputs.buildcache }}" ]; then
+          echo RUSTFLAGS="$(just print-rustflags)" >> "$GITHUB_OUTPUT"
+      else
+          echo RUSTFLAGS= >> "$GITHUB_OUTPUT"
+      fi
+    shell: bash
 
-  - uses: webiny/action-post-run@3.0.0
-    id: post-run-command
-    with:
-      run: sccache --show-stats
+  - if: inputs.indexcache || inputs.buildcache
+    uses: Swatinem/rust-cache@v2
+    env:
+      RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
         # just-setup use binstall to install sccache,
         # which works better when we provide it with GITHUB_TOKEN.
@@ -78,8 +76,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
         # just-setup use binstall to install sccache,
         # which works better when we provide it with GITHUB_TOKEN.
@@ -97,8 +93,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
         # just-setup use binstall to install sccache,
         # which works better when we provide it with GITHUB_TOKEN.
@@ -115,8 +109,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        cache-suffix: ${{ env.CARGO_BUILD_TARGET }}
       env:
         # just-setup use binstall to install sccache,
         # which works better when we provide it with GITHUB_TOKEN.
@@ -141,8 +133,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        cache-suffix: ${{ matrix.target }}
 
     - run: just toolchain rustfmt,clippy
     - run: just ci-install-deps

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,7 +52,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
       with:
-        cache-suffix: release-${{ matrix.t }}
         tools: cargo-auditable
       env:
         # just-setup use binstall to install sccache and cargo-auditable,

--- a/justfile
+++ b/justfile
@@ -128,10 +128,12 @@ rustc-icf := if for-release != "" {
 
 # Only enable linker-plugin-lto for release
 # Also disable this on windows since it uses msvc.
+#
+# Temporarily disable this on linux due to mismatch llvm version
+# } else if target-os == "linux" {
+#     "-C linker-plugin-lto "
 linker-plugin-lto := if for-release == "" {
     ""
-} else if target-os == "linux" {
-    "-C linker-plugin-lto "
 } else {
     ""
 }
@@ -169,7 +171,10 @@ toolchain components="":
     {{ if target != "" { "rustup target add " + target } else { "" } }}
 
 print-env:
-    echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
+    @echo "env RUSTFLAGS='$RUSTFLAGS', CARGO='$CARGO'"
+
+print-rustflags:
+    @echo "$RUSTFLAGS"
 
 build: print-env
     {{cargo-bin}} build {{cargo-build-args}}


### PR DESCRIPTION
Fixed #1038

sccache is not very effective at caching dependencies, the external C/C++ is recompiled in every ci and it takes a lot of time.

Compilation of other Rust dependencies also takes quite some time and sccache is not helping at all, so I decided to switch to `Swatinem/rust-cache@v2`.

The downside of the new caching method is that a new cache conntaining part of the `.cargo/` and `target/` will be created whenver `Cargo.lock`/`Cargo.toml` changes, but it can still reuse the old cache to create new caching.

This is acceptable given that `sccache` often fails to reuse cache due to rate limiting from GHA, since it is not designed for use like a s3 object pool, and `sccache` will create a lot of new cache artifacts for a given branch that cannot be reused in main and would have to cleanup via a cronjob.