### PR TITLE
Use `uname -s` for install script compatibility with outdated macOS GNU utils

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -6,12 +6,12 @@ cd "$(mktemp -d)"
 
 base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
 
-os="$(uname -o)"
+os="$(uname -s)"
 if [ "$os" == "Darwin" ]; then
     url="${base_url}universal-apple-darwin.zip"
     curl -LO --proto '=https' --tlsv1.2 -sSf "$url"
     unzip cargo-binstall-universal-apple-darwin.zip
-elif [ "$os" == "GNU/Linux" ]; then
+elif [ "$os" == "Linux" ]; then
     machine="$(uname -m)"
     target="${machine}-unknown-linux-musl"
     if [ "$machine" == "armv7" ]; then


### PR DESCRIPTION
Closes https://github.com/cargo-bins/cargo-binstall/issues/1122

Confirmed locally on macOS 12.5.1.