### PR TITLE
`GhApiClient` misc improvements

### DIFF
--- a/crates/binstalk-downloader/src/gh_api_client.rs
+++ b/crates/binstalk-downloader/src/gh_api_client.rs
@@ -21,7 +21,7 @@ mod request;
 pub use request::{GhApiContextError, GhApiError, GhGraphQLErrors};
 
 /// default retry duration if x-ratelimit-reset is not found in response header
-const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(3);
+const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(5 * 60);
 
 fn percent_encode_http_url_path(path: &str) -> PercentEncode<'_> {
     /// https://url.spec.whatwg.org/#fragment-percent-encode-set
@@ -42,7 +42,12 @@ fn percent_encode_http_url_path(path: &str) -> PercentEncode<'_> {
 }
 
 fn percent_decode_http_url_path(input: &str) -> CompactString {
-    percent_decode_str(input).decode_utf8_lossy().into()
+    if input.contains('%') {
+        percent_decode_str(input).decode_utf8_lossy().into()
+    } else {
+        // No '%', no need to decode.
+        CompactString::new(input)
+    }
 }
 
 /// The keys required to identify a github release.


### PR DESCRIPTION
 - Increase `DEFAULT_RETRY_DURATION` to 5 minutes, since GitHub enforces rate limit on an hourly basis.
 - Refactor `check_for_status` & `fetch_release_artifacts_restful_api`
 - Optimize `percent_decode_http_url_path`: Avoid `percent_decode_str` if there is no `%` in the `input`.