### PR TITLE
Fix PR CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - auto_merge_enabled
-    paths-ignore:
-      - README.md
-      - SUPPORT.md
   push:
     branches:
       - main


### PR DESCRIPTION
- Remove trigger on "auto merge" enablement, which is just annoying now with the merge queue and was only ever an additional workaround for the release PRs.
- Always run the PR CIs, don't ignore markdown files. That made it impossible to merge PRs that only touched those files (without bypassing requirements).