### PR TITLE
ci: Publish to crates.io in `release.yml` after tagging

### DIFF
--- a/.github/scripts/release-pr-template.ejs
+++ b/.github/scripts/release-pr-template.ejs
@@ -13,26 +13,11 @@ This is a release PR for **<%= crate.name %>** version **<%= version.actual %>**
 **Use squash merge.**
 
 <% if (crate.name == "cargo-binstall") { %>
-Upon merging, this will automatically create the tag `v<%= version.actual %>`, build the CLI, and create a GitHub release with the release notes below.
-You will still need to manually publish the cargo crate:
-
-```
-$ git switch main
-$ git pull
-$ git switch --detach v<%= version.actual %>
-$ cargo publish -p <%= crate.name %>
-```
+Upon merging, this will automatically create the tag `v<%= version.actual %>`, build the CLI,
+create a GitHub release with the release notes below
 <% } else { %>
-Upon merging, this will create the tag `<%= crate.name %>-v<%= version.actual %>`.
-You will still need to manually publish the cargo crate:
-
-```
-$ git switch main
-$ git pull
-$ git switch --detach <%= crate.name %>-v<%= version.actual %>
-$ cargo publish -p <%= crate.name %>
-```
-<% } %>
+Upon merging, this will create the tag `<%= crate.name %>-v<%= version.actual %>`
+<% } %>, and CI will publish to crates.io on merge of this PR.
 
 **To trigger builds initially, close and then immediately re-open this PR once.**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
+  workflow_call:
   merge_group:
   pull_request:
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,16 @@ jobs:
         event-data: ${{ toJSON(github.event) }}
         extract-notes-under: '### Release notes'
 
-  tag:
+  test:
     if: needs.info.outputs.is-release == 'true'
     needs: info
+    uses: ./.github/workflows/ci.yml
+
+  tag:
+    if: needs.info.outputs.is-release == 'true'
+    needs:
+    - info
+    - test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -42,6 +49,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ needs.info.outputs.version }}
         tag_prefix: v
+    - name: Publish to crates.io
+      run: |
+        cargo publish --no-verify -p '${{ needs.info.outputs.crate }}'
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   package:
     if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'


### PR DESCRIPTION
Fixed #1046

so that we don't have to manually run `cargo-publish` after the CI is merged.