### PR TITLE
dep: Bump strum v0.24.1 => v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,21 +2170,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -35,8 +35,8 @@ miette = "5.9.0"
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
 once_cell = "1.18.0"
 semver = "1.0.17"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.0"
 supports-color = "2.0.0"
 tempfile = "3.5.0"
 tokio = { version = "1.28.2", features = ["rt-multi-thread"], default-features = false }

--- a/crates/binstalk-types/Cargo.toml
+++ b/crates/binstalk-types/Cargo.toml
@@ -15,6 +15,6 @@ maybe-owned = { version = "0.3.4", features = ["serde"] }
 once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.0"
 url = { version = "2.3.1", features = ["serde"] }

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -29,7 +29,7 @@ normalize-path = { version = "0.2.0", path = "../normalize-path" }
 once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
-strum = "0.24.1"
+strum = "0.25.0"
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 # parking_lot for `tokio::sync::OnceCell::const_new`


### PR DESCRIPTION
Also bump strum_macros v0.24.3 => v0.25.0

[strum and strum_macros v0.25.0 changelog][1]

[1]: https://github.com/Peternator7/strum/blob/master/CHANGELOG.md