### PR TITLE
feat: Add more variables for template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "semver",
  "serde",
  "strum",
+ "target-lexicon",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2236,6 +2237,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "tempfile"

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -30,6 +30,7 @@ once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
 strum = "0.25.0"
+target-lexicon = { version = "0.12.7", features = ["std"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 # parking_lot for `tokio::sync::OnceCell::const_new`

--- a/crates/binstalk/src/bins.rs
+++ b/crates/binstalk/src/bins.rs
@@ -15,7 +15,7 @@ use crate::{
         atomic_install, atomic_install_noclobber, atomic_symlink_file,
         atomic_symlink_file_noclobber,
     },
-    helpers::download::ExtractedFiles,
+    helpers::{download::ExtractedFiles, target_triple::TargetTriple},
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
 
@@ -98,6 +98,8 @@ impl BinFile {
             version: data.version,
             bin: base_name,
             binary_ext,
+
+            triple: data.triple,
         };
 
         let (source, archive_source_path) = if data.meta.pkg_fmt == Some(PkgFmt::Bin) {
@@ -271,6 +273,7 @@ pub struct Data<'a> {
     pub meta: PkgMeta,
     pub bin_path: &'a Path,
     pub install_path: &'a Path,
+    pub triple: &'a TargetTriple,
 }
 
 #[derive(Clone, Debug)]
@@ -283,6 +286,8 @@ struct Context<'c> {
 
     /// Filename extension on the binary, i.e. .exe on Windows, nothing otherwise
     pub binary_ext: &'c str,
+
+    pub triple: &'c TargetTriple,
 }
 
 impl leon::Values for Context<'_> {
@@ -296,7 +301,8 @@ impl leon::Values for Context<'_> {
             "binary-ext" => Some(Cow::Borrowed(self.binary_ext)),
             // Soft-deprecated alias for binary-ext
             "format" => Some(Cow::Borrowed(self.binary_ext)),
-            _ => None,
+
+            key => self.triple.get_value(key),
         }
     }
 }

--- a/crates/binstalk/src/fetchers.rs
+++ b/crates/binstalk/src/fetchers.rs
@@ -11,7 +11,7 @@ use crate::{
     errors::BinstallError,
     helpers::{
         download::ExtractedFiles, gh_api_client::GhApiClient, remote::Client,
-        tasks::AutoAbortJoinHandle,
+        target_triple::TargetTriple, tasks::AutoAbortJoinHandle,
     },
     manifests::cargo_toml_binstall::{PkgFmt, PkgMeta},
 };
@@ -72,6 +72,8 @@ pub trait Fetcher: Send + Sync {
 
     /// Return the target for this fetcher
     fn target(&self) -> &str;
+
+    fn target_data(&self) -> &Arc<TargetData>;
 }
 
 #[derive(Clone, Debug)]
@@ -186,6 +188,7 @@ impl RepoInfo {
 #[derive(Clone, Debug)]
 pub struct TargetData {
     pub target: String,
+    pub triple: TargetTriple,
     pub meta: PkgMeta,
 }
 

--- a/crates/binstalk/src/fetchers/quickinstall.rs
+++ b/crates/binstalk/src/fetchers/quickinstall.rs
@@ -9,6 +9,7 @@ use crate::{
     helpers::{
         download::{Download, ExtractedFiles},
         gh_api_client::GhApiClient,
+        is_universal_macos,
         remote::{does_url_exist, Client, Method},
         tasks::AutoAbortJoinHandle,
     },
@@ -19,10 +20,6 @@ use super::{Data, TargetData};
 
 const BASE_URL: &str = "https://github.com/cargo-bins/cargo-quickinstall/releases/download";
 const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
-
-fn is_universal_macos(target: &str) -> bool {
-    ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)
-}
 
 pub struct QuickInstall {
     client: Client,
@@ -135,6 +132,10 @@ by rust officially."#,
 
     fn target(&self) -> &str {
         &self.target_data.target
+    }
+
+    fn target_data(&self) -> &Arc<TargetData> {
+        &self.target_data
     }
 }
 

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -2,6 +2,11 @@ pub mod futures_resolver;
 pub mod jobserver_client;
 pub mod remote;
 pub mod signal;
+pub mod target_triple;
 pub mod tasks;
 
 pub use binstalk_downloader::{download, gh_api_client};
+
+pub fn is_universal_macos(target: &str) -> bool {
+    ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)
+}

--- a/crates/binstalk/src/helpers/target_triple.rs
+++ b/crates/binstalk/src/helpers/target_triple.rs
@@ -1,0 +1,54 @@
+use std::{borrow::Cow, str::FromStr};
+
+use compact_str::{CompactString, ToCompactString};
+use target_lexicon::Triple;
+
+use crate::{errors::BinstallError, helpers::is_universal_macos};
+
+#[derive(Clone, Debug)]
+pub struct TargetTriple {
+    // TODO: Once https://github.com/bytecodealliance/target-lexicon/pull/90
+    // lands, consider replacing use of CompactString with `Cow<'_, str>`.
+    pub target_family: CompactString,
+    pub target_arch: CompactString,
+    pub target_libc: CompactString,
+    pub target_vendor: CompactString,
+}
+
+impl FromStr for TargetTriple {
+    type Err = BinstallError;
+
+    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        let is_universal_macos = is_universal_macos(s);
+
+        if is_universal_macos {
+            s = "x86_64-apple-darwin";
+        }
+
+        let triple = Triple::from_str(s)?;
+
+        Ok(Self {
+            target_family: triple.operating_system.to_compact_string(),
+            target_arch: if is_universal_macos {
+                "universal".to_compact_string()
+            } else {
+                triple.architecture.to_compact_string()
+            },
+            target_libc: triple.environment.to_compact_string(),
+            target_vendor: triple.vendor.to_compact_string(),
+        })
+    }
+}
+
+impl leon::Values for TargetTriple {
+    fn get_value<'s>(&'s self, key: &str) -> Option<Cow<'s, str>> {
+        match key {
+            "target-family" => Some(Cow::Borrowed(&self.target_family)),
+            "target-arch" => Some(Cow::Borrowed(&self.target_arch)),
+            "target-libc" => Some(Cow::Borrowed(&self.target_libc)),
+            "target-vendor" => Some(Cow::Borrowed(&self.target_vendor)),
+
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Fixed https://github.com/cargo-bins/cargo-binstall/issues/775

 - Add dep target-lexicon v0.12.7
 - Add `target-{family, arch, libc, vendor}` to
   `package.metadata.binstall`.

For `{universal, universal2}-apple-darwin`, the `target-arch` is set to
`universal`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>