### PR TITLE
Optimize `TargetTriple`: Use `Cow<'static, str>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,7 +24,9 @@ With the following configuration keys:
 
 
 `pkg-url` and `bin-dir` are templated to support different names for different versions / architectures / etc.
-Template variables use the format `{ VAR }` where `VAR` is the name of the variable, with the following variables available:
+Template variables use the format `{ VAR }` where `VAR` is the name of the variable,
+`\{` for literal `{`, `\}` for literal `}` and `\\` for literal `\`,
+with the following variables available:
 - `name` is the name of the crate/package
 - `version` is the crate version (per `--version` and the crate manifest)
 - `repo` is the repository linked in `Cargo.toml`
@@ -34,6 +36,16 @@ Template variables use the format `{ VAR }` where `VAR` is the name of the varia
 - `archive-format` is the soft-deprecated filename extension of the package archive format that does not include the prefix `.`, e.g. `tgz` for tgz or `exe`/`""` for bin.
 - `binary-ext` is the string `.exe` if the `target` is for Windows, or the empty string otherwise
 - `format` is a soft-deprecated alias for `archive-format` in `pkg-url`, and alias for `binary-ext` in `bin-dir`; in the future, this may warn at install time.
+- `target-family`: Operating system of the target from [`target_lexicon::OperatingSystem`]
+- `target-arch`: Architecture of the target, `universal` on `{universal, universal2}-apple-darwin`,
+  otherwise from [`target_lexicon::Architecture`]
+- `target-libc`: ABI environment of the target from [`target_lexicon::Environment`]
+- `target-vendor`: Vendor of the target from [`target_lexicon::Vendor`]
+
+[`target_lexicon::OperatingSystem`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.OperatingSystem.html
+[`target_lexicon::Architecture`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Architecture.html
+[`target_lexicon::Environment`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Environment.html
+[`target_lexicon::Vendor`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Vendor.html
 
 `pkg-url`, `pkg-fmt` and `bin-dir` can be overridden on a per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip` archives this could be set via:
 

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
 strum = "0.25.0"
-target-lexicon = { version = "0.12.7", features = ["std"] }
+target-lexicon = { version = "0.12.8", features = ["std"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 # parking_lot for `tokio::sync::OnceCell::const_new`

--- a/crates/binstalk/src/helpers/target_triple.rs
+++ b/crates/binstalk/src/helpers/target_triple.rs
@@ -7,11 +7,9 @@ use crate::{errors::BinstallError, helpers::is_universal_macos};
 
 #[derive(Clone, Debug)]
 pub struct TargetTriple {
-    // TODO: Once https://github.com/bytecodealliance/target-lexicon/pull/90
-    // lands, consider replacing use of CompactString with `Cow<'_, str>`.
-    pub target_family: CompactString,
-    pub target_arch: CompactString,
-    pub target_libc: CompactString,
+    pub target_family: Cow<'static, str>,
+    pub target_arch: Cow<'static, str>,
+    pub target_libc: Cow<'static, str>,
     pub target_vendor: CompactString,
 }
 
@@ -28,13 +26,13 @@ impl FromStr for TargetTriple {
         let triple = Triple::from_str(s)?;
 
         Ok(Self {
-            target_family: triple.operating_system.to_compact_string(),
+            target_family: triple.operating_system.into_str(),
             target_arch: if is_universal_macos {
-                "universal".to_compact_string()
+                Cow::Borrowed("universal")
             } else {
-                triple.architecture.to_compact_string()
+                triple.architecture.into_str()
             },
-            target_libc: triple.environment.to_compact_string(),
+            target_libc: triple.environment.into_str(),
             target_vendor: triple.vendor.to_compact_string(),
         })
     }


### PR DESCRIPTION
instead of `CompactString` since `target_lexicon::{OperatingSystem, Architecture, Environment}::into_str()` will return a `&'static str` most of the time.

Also updated `SUPPORT.md`, which I forgot to do in #1160 