### PR TITLE
ci: Verify before publishing

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install cargo-release
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-release
+          tool: cargo-release,cargo-semver-checks
 
       - uses: cargo-bins/release-pr@v2
         with:
@@ -51,3 +51,4 @@ jobs:
           pr-label: release
           pr-release-notes: ${{ inputs.crate == 'bin' }}
           pr-template-file: .github/scripts/release-pr-template.ejs
+          check-semver: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         tag_prefix: v
     - name: Publish to crates.io
       run: |
-        cargo publish --no-verify -p '${{ needs.info.outputs.crate }}'
+        cargo publish -p '${{ needs.info.outputs.crate }}'
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
Run `cargo-publish` without `--no-verify` to verify the publish is valid and does not depend on unpublished crates in job tag of workflow `release.yml`, which could be caused by incorrect merge order.

Also, install `cargo-semver-checks` using `taiki-e/install-action@v2` in job make-release-pr of workflow `release-pr.yml`, since `cargo-bins/release-pr@v2` would try to use `cargo-binstall` for installing `cargo-semver-checks`, but we did not explicitly require `taiki-e/install-actions@v2` to install `cargo-binstall`, so `release-pr` could fallback to `cargo-install` which is just too slow.