### PR TITLE
feat: Support `--verbose --version`/`-vV`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +499,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "vergen",
 ]
 
 [[package]]
@@ -3827,6 +3834,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { version = "0.3.17", features = ["fmt", "json", "ansi"], d
 
 [build-dependencies]
 embed-resource = "2.1.1"
+vergen = { version = "8.2.4", features = ["build", "cargo", "git", "gitcl", "rustc"] }
 
 [features]
 default = ["static", "rustls", "trust-dns", "fancy-no-backtrace", "zstd-thin", "git"]

--- a/crates/bin/build.rs
+++ b/crates/bin/build.rs
@@ -1,7 +1,44 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=manifest.rc");
-    println!("cargo:rerun-if-changed=windows.manifest");
+use std::{
+    io,
+    path::Path,
+    process::{Child, Command},
+    thread,
+};
 
-    embed_resource::compile("manifest.rc", embed_resource::NONE);
+fn succeeds(res: io::Result<Child>) -> bool {
+    res.and_then(|mut child| child.wait())
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn main() {
+    let handle = thread::spawn(|| {
+        println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-changed=manifest.rc");
+        println!("cargo:rerun-if-changed=windows.manifest");
+
+        embed_resource::compile("manifest.rc", embed_resource::NONE);
+    });
+
+    let git = Command::new("git").arg("--version").spawn();
+
+    // .git is usually a dir, but it also can be a file containing
+    // path to another .git if it is a submodule.
+    //
+    // If build.rs is run on a git repository, then ../../.git
+    // should exists.
+    let is_git_repo = Path::new("../../.git").exists();
+
+    let mut builder = vergen::EmitBuilder::builder();
+    builder.all_build().all_cargo().all_rustc();
+
+    if is_git_repo && succeeds(git) {
+        builder.all_git();
+    } else {
+        builder.disable_git();
+    }
+
+    builder.emit().unwrap();
+
+    handle.join().unwrap();
 }

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -318,6 +318,10 @@ pub struct Args {
     #[clap(help_heading = "Meta", long, value_name = "LEVEL")]
     pub log_level: Option<LevelFilter>,
 
+    /// Used with `--version` to print out verbose information.
+    #[clap(help_heading = "Meta", short, long, default_value_t = false)]
+    pub verbose: bool,
+
     /// Equivalent to setting `log_level` to `off`.
     ///
     /// This would override the `log_level`.

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use binstalk::helpers::jobserver_client::LazyJobserverClient;
+use binstalk::{helpers::jobserver_client::LazyJobserverClient, TARGET};
 use log::LevelFilter;
 use tracing::debug;
 
@@ -22,7 +22,33 @@ fn main() -> MainExit {
     let args = args::parse();
 
     if args.version {
-        println!("{}", env!("CARGO_PKG_VERSION"));
+        let cargo_binstall_version = env!("CARGO_PKG_VERSION");
+        if args.verbose {
+            let build_date = env!("VERGEN_BUILD_DATE");
+
+            let features = env!("VERGEN_CARGO_FEATURES");
+
+            let git_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("UNKNOWN");
+            let git_commit_date = option_env!("VERGEN_GIT_COMMIT_DATE").unwrap_or("UNKNOWN");
+
+            let rustc_semver = env!("VERGEN_RUSTC_SEMVER");
+            let rustc_commit_hash = env!("VERGEN_RUSTC_COMMIT_HASH");
+            let rustc_llvm_version = env!("VERGEN_RUSTC_LLVM_VERSION");
+
+            println!(
+                r#"cargo-binstall: {cargo_binstall_version}
+build-date: {build_date}
+build-target: {TARGET}
+build-features: {features}
+build-commit-hash: {git_sha}
+build-commit-date: {git_commit_date}
+rustc-version: {rustc_semver}
+rustc-commit-hash: {rustc_commit_hash}
+rustc-llvm-version: {rustc_llvm_version}"#
+            );
+        } else {
+            println!("{cargo_binstall_version}");
+        }
         MainExit::Success(None)
     } else {
         logging(

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -9,5 +9,5 @@ pub mod helpers;
 pub mod ops;
 
 pub use binstalk_types as manifests;
-pub use detect_targets::{get_desired_targets, DesiredTargets};
+pub use detect_targets::{get_desired_targets, DesiredTargets, TARGET};
 pub use home;


### PR DESCRIPTION
that provides more information:

```
cargo-binstall: 1.0.0
build-date: 2023-07-18
build-target: aarch64-apple-darwin
build-features: default,fancy_no_backtrace,git,rustls,static,trust_dns,zstd_thin
build-commit-hash: https://github.com/cargo-bins/cargo-binstall/commit/39d8cfc07f2253080ce997e620406c2994dced25
build-commit-date: 2023-07-18
rustc-version: 1.71.0
rustc-commit-hash: 8ede3aae28fe6e4d52b38157d7bfe0d3bceef225
rustc-llvm-version: 16.0
```

Fixed #627