### PR TITLE
speedup git shallow cloning: Enable `gix/max-performance`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1307,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
+ "sha1",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -3096,6 +3106,27 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563d4f7100bc3fce234e5f37bbf63dc2752558964505ba6ac3f7204bdc59eaac"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -52,6 +52,7 @@ embed-resource = "2.1.1"
 default = ["static", "rustls", "trust-dns", "fancy-no-backtrace", "zstd-thin", "git"]
 
 git = ["binstalk/git"]
+git-max-perf = ["binstalk/git-max-perf"]
 
 mimalloc = ["dep:mimalloc"]
 

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -52,6 +52,7 @@ windows = { version = "0.48.0", features = ["Win32_Storage_FileSystem", "Win32_F
 default = ["static", "rustls", "git"]
 
 git = ["dep:gix"]
+git-max-perf = ["gix?/max-performance"]
 
 static = ["binstalk-downloader/static"]
 pkg-config = ["binstalk-downloader/pkg-config"]

--- a/justfile
+++ b/justfile
@@ -73,9 +73,32 @@ support-pkg-config := if target == target-host {
     if target-os == "linux" { "true" } else { "" }
 } else { "" }
 
+enable-git-max-perf-feature := if target == "x86_64-apple-darwin" {
+    "true"
+} else if target == "aarch64-apple-darwin" {
+    "true"
+} else if target == "x86_64-unknown-linux-gnu" {
+    "true"
+} else if target == "x86_64-unknown-linux-musl" {
+    "true"
+} else {
+    "false"
+}
+git-max-perf-feature := if enable-git-max-perf-feature == "true" {
+    ",git-max-perf"
+} else if target-os == "windows" {
+    ",zlib-ng"
+} else if target == "aarch64-unknown-linux-gnu" {
+    ",zlib-ng"
+} else if target == "aarch64-unknown-linux-musl" {
+    ",zlib-ng"
+} else {
+    ""
+}
+
 cargo-features := trim_end_match(if override-features != "" { override-features
-    } else if (cargo-profile / ci-or-no) == "dev/ci" { "git,rustls,fancy-with-backtrace,zstd-thin,log_max_level_debug" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "git,static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto" + extra-features
+    } else if (cargo-profile / ci-or-no) == "dev/ci" { "git,rustls,fancy-with-backtrace,zstd-thin,log_max_level_debug" + git-max-perf-feature + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "git,static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto"  + git-max-perf-feature + extra-features
     } else { extra-features
 }, ",")
 


### PR DESCRIPTION

for targets:
 - x86_64-apple-darwin
 - aarch64-apple-darwin
 - x86_64-unknown-linux-gnu
 - x86_64-unknown-linux-musl

which will use `zlib-ng` to speedup decompression and use assembly
version for sha1 checksum calculation on supported CPU.

Also enable feature `zlib-ng` on windows and
 - aarch64-unknown-linux-gnu
 - aarch64-unknown-linux-musl

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

## Motivation

#1184 adds e2e test that shallow clones the crates.io git index, which takes 11m just to clone the index in CI.