### PR TITLE
Speedup prebuilt binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ members = [
 ]
 
 [profile.release]
-opt-level = "z"
+opt-level = 3
 lto = true
 codegen-units = 1
 panic = "abort"
 strip = "symbols"
+
+[profile.release.build-override]
+inherits = "dev.build-override"
 
 [profile.dev]
 opt-level = 0
@@ -28,6 +31,10 @@ debug-assertions = true
 overflow-checks = true
 codegen-units = 1024
 
+# Set the default for dependencies on debug.
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.dev.build-override]
 inherits = "dev"
 debug = false
@@ -35,5 +42,15 @@ debug-assertions = false
 overflow-checks = false
 incremental = false
 
-[profile.release.build-override]
-inherits = "dev.build-override"
+[profile.check-only]
+inherits = "dev"
+debug = false
+debug-assertions = false
+overflow-checks = false
+panic = "abort"
+
+[profile.check-only.build-override]
+inherits = "check-only"
+
+[profile.check-only.package."*"]
+inherits = "check-only"

--- a/justfile
+++ b/justfile
@@ -181,13 +181,14 @@ build: print-env
     {{cargo-bin}} build {{cargo-build-args}}
 
 check: print-env
-    {{cargo-bin}} check {{cargo-build-args}}
-    cargo-hack hack check --feature-powerset -p leon {{cargo-check-args}}
-    {{cargo-bin}} check -p binstalk-downloader --no-default-features
-    {{cargo-bin}} check -p cargo-binstall --no-default-features --features rustls {{cargo-check-args}}
+    {{cargo-bin}} check {{cargo-build-args}} --profile check-only
+    cargo-hack hack check --feature-powerset -p leon {{cargo-check-args}} --profile check-only
+    {{cargo-bin}} check -p binstalk-downloader --no-default-features --profile check-only
+    {{cargo-bin}} check -p cargo-binstall --no-default-features --features rustls {{cargo-check-args}} --profile check-only
     cargo-hack hack check -p binstalk-downloader \
         --feature-powerset \
         --include-features default,json,gh-api-client \
+        --profile check-only \
         {{cargo-check-args}}
 
 get-output file outdir=".":


### PR DESCRIPTION
After the merge of https://github.com/cargo-bins/cargo-binstall/pull/1184, CI now takes 11m just to shallow clone
crates.io git index, which means that our user using alternative git
index would also be quite slow.

This commit speeds it up by building all dependencies with `-O3` in dev
and release build.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>