### PR TITLE
Support `--registry` and more options from `.cargo/config.toml`

### DIFF
--- a/e2e-tests/registries.sh
+++ b/e2e-tests/registries.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+test_cargo_binstall_install() {
+  # Test that the installed binaries can be run
+  cargo binstall --help >/dev/null
+
+  cargo_binstall_version="$(cargo binstall -V)"
+  echo "$cargo_binstall_version"
+
+  [ "$cargo_binstall_version" = "cargo-binstall 0.12.0" ]
+}
+
+unset CARGO_INSTALL_ROOT
+
+CARGO_HOME="$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')"
+export CARGO_HOME
+export PATH="$CARGO_HOME/bin:$PATH"
+
+# Testing conflicts of `--index` and `--registry`
+set +e
+
+"./$1" binstall --index 'sparse+https://index.crates.io/' --registry t1 cargo-binstall
+exit_code="$?"
+
+set -e
+
+if [ "$exit_code" != 2 ]; then
+    echo "Expected exit code 2, but actual exit code $exit_code"
+    exit 1
+fi
+
+cat >"$CARGO_HOME/config.toml" << EOF
+[registries]
+t1 = { index = "https://github.com/rust-lang/crates.io-index" }
+t2 = { index = "sparse+https://index.crates.io/" }
+
+[registry]
+default = "t1"
+EOF
+
+# Install binaries using default registry in config
+"./$1" binstall --force -y cargo-binstall@0.12.0
+
+test_cargo_binstall_install
+
+# Install binaries using registry t2 in config
+"./$1" binstall --force --registry t2 -y cargo-binstall@0.12.0
+
+test_cargo_binstall_install
+
+# Install binaries using registry t3 in env
+CARGO_REGISTRIES_t3_INDEX='sparse+https://index.crates.io/' "./$1" binstall --force --registry t3 -y cargo-binstall@0.12.0
+
+test_cargo_binstall_install
+
+
+# Install binaries using index directly
+"./$1" binstall --force --index 'sparse+https://index.crates.io/' -y cargo-binstall@0.12.0
+
+test_cargo_binstall_install

--- a/justfile
+++ b/justfile
@@ -212,6 +212,7 @@ e2e-test-self-upgrade-no-symlink: (e2e-test "self-upgrade-no-symlink")
 e2e-test-uninstall: (e2e-test "uninstall")
 e2e-test-no-track: (e2e-test "no-track")
 e2e-test-git: (e2e-test "git")
+e2e-test-registries: (e2e-test "registries")
 
 # WinTLS (Windows in CI) does not have TLS 1.3 support
 [windows]
@@ -220,7 +221,7 @@ e2e-test-tls: (e2e-test "tls" "1.2")
 [macos]
 e2e-test-tls: (e2e-test "tls" "1.2") (e2e-test "tls" "1.3")
 
-e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-git e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall e2e-test-subcrate e2e-test-no-track
+e2e-tests: e2e-test-live e2e-test-manifest-path e2e-test-git e2e-test-other-repos e2e-test-strategies e2e-test-version-syntax e2e-test-upgrade e2e-test-tls e2e-test-self-upgrade-no-symlink e2e-test-uninstall e2e-test-subcrate e2e-test-no-track e2e-test-registries
 
 unit-tests: print-env
     {{cargo-bin}} test {{cargo-build-args}}


### PR DESCRIPTION
Fixed #885

Now we can take advantage of new argument `--registry` and env overrides:
 - `CARGO_REGISTRIES_DEFAULT` if `--registry` is not specified
 - `CARGO_REGISTRIES_{registry_name}_INDEX` for the registry index url

We can also read from `.cargo/config.toml` for:
 - default registry and registries configurations
 - additional CA bundle `http.cainfo`