### PR TITLE
Optimize `profile.dev`: Set `codege-units` to 32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ debug = true
 lto = false
 debug-assertions = true
 overflow-checks = true
-codegen-units = 1024
+codegen-units = 32
 
 # Set the default for dependencies on debug.
 [profile.dev.package."*"]


### PR DESCRIPTION
Splitting too many codege-units would actually takes longer to compile due to overhead of parallelism in backend.

Also, our CI does not have that many CPU cores to take advantages of.