### PR TITLE
feat: Read `--rate-limit` from env `BINSTALL_RATE_LIMIT` as a fallback

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -144,7 +144,7 @@ pub struct Args {
     ///    allows 2 requests per 6ms.
     ///
     /// Both duration and request count must not be 0.
-    #[clap(help_heading = "Overrides", long, default_value_t = RateLimit::default())]
+    #[clap(help_heading = "Overrides", long, default_value_t = RateLimit::default(), env = "BINSTALL_RATE_LIMIT")]
     pub rate_limit: RateLimit,
 
     /// Specify the strategies to be used,

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ use-auditable := env_var_or_default("JUST_USE_AUDITABLE", "")
 timings := env_var_or_default("JUST_TIMINGS", "")
 
 export BINSTALL_LOG_LEVEL := if env_var_or_default("RUNNER_DEBUG", "0") == "1" { "debug" } else { "info" }
+export BINSTALL_RATE_LIMIT := "100/1"
 
 cargo := if use-cargo-zigbuild != "" { "cargo-zigbuild" } else if use-cross != "" { "cross" } else { "cargo" }
 export CARGO := cargo


### PR DESCRIPTION
and set `BINSTALL_RATE_LIMIT` to `100/1` on CI.

Fixed #1196