### PR TITLE
Set opt-level for `{binstall, tokio}-tar` to `"z"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ strip = "symbols"
 [profile.release.build-override]
 inherits = "dev.build-override"
 
+[profile.release.package."tokio-tar"]
+opt-level = "z"
+
+[profile.release.package."binstall-tar"]
+opt-level = "z"
+
 [profile.dev]
 opt-level = 0
 debug = true
@@ -34,6 +40,12 @@ codegen-units = 1024
 # Set the default for dependencies on debug.
 [profile.dev.package."*"]
 opt-level = 3
+
+[profile.dev.package."tokio-tar"]
+opt-level = "z"
+
+[profile.dev.package."binstall-tar"]
+opt-level = "z"
 
 [profile.dev.build-override]
 inherits = "dev"


### PR DESCRIPTION
Trying to fix #1196