### PR TITLE
Fix clippy warning in `binstalk_downloader`

### DIFF
--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -83,7 +83,7 @@ impl Download {
         Self {
             client,
             url,
-            _digest: PhantomData::default(),
+            _digest: PhantomData,
             _checksum: Vec::new(),
         }
     }
@@ -158,7 +158,7 @@ impl<D: Digest> Download<D> {
         Self {
             client,
             url,
-            _digest: PhantomData::default(),
+            _digest: PhantomData,
             _checksum: checksum,
         }
     }


### PR DESCRIPTION
Replace use of `PhantomData::default()` in `src/download.rs` with `PhantomData` since it is a unit struct.