### PR TITLE
avoid worktree checkouts

### DIFF
--- a/crates/binstalk/src/drivers/registry/git_registry.rs
+++ b/crates/binstalk/src/drivers/registry/git_registry.rs
@@ -119,7 +119,7 @@ impl GitRegistry {
                 .get_or_try_init(|| GitIndex::new(this.0.url.clone()))?;
 
             let MatchedVersion { version, cksum } =
-                Self::find_crate_matched_ver(&repo, &crate_name, &crate_prefix, &version_req)?;
+                Self::find_crate_matched_ver(repo, &crate_name, &crate_prefix, &version_req)?;
 
             let url = Url::parse(&render_dl_template(
                 dl_template,

--- a/crates/binstalk/src/drivers/registry/git_registry.rs
+++ b/crates/binstalk/src/drivers/registry/git_registry.rs
@@ -33,7 +33,7 @@ impl GitIndex {
     fn new(url: GitUrl) -> Result<Self, BinstallError> {
         let tempdir = TempDir::new()?;
 
-        let repo = Repository::shallow_clone_bare(url, tempdir.as_ref())?;
+        let repo = Repository::shallow_clone_bare(url.clone(), tempdir.as_ref())?;
 
         let config: RegistryConfig = {
             let config = repo
@@ -41,7 +41,7 @@ impl GitIndex {
                 .ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::NotFound,
-                        "config.toml not found in crates.io-index repository",
+                        format!("config.toml not found in repository `{url}`"),
                     )
                 })?;
 

--- a/crates/binstalk/src/drivers/registry/git_registry.rs
+++ b/crates/binstalk/src/drivers/registry/git_registry.rs
@@ -41,7 +41,7 @@ impl GitIndex {
                 .ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::NotFound,
-                        format!("config.toml not found in repository `{url}`"),
+                        format!("config.json not found in repository `{url}`"),
                     )
                 })?;
 

--- a/crates/binstalk/src/helpers/git.rs
+++ b/crates/binstalk/src/helpers/git.rs
@@ -53,7 +53,7 @@ impl FromStr for GitUrl {
 }
 
 #[derive(Debug)]
-pub struct Repository(gix::Repository);
+pub struct Repository(pub(crate) gix::Repository);
 
 impl Repository {
     /// WARNING: This is a blocking operation, if you want to use it in
@@ -72,7 +72,7 @@ impl Repository {
             clone::PrepareFetch::new(
                 url.0,
                 path,
-                create::Kind::WithWorktree,
+                create::Kind::Bare,
                 create::Options {
                     destination_must_be_empty: true,
                     ..Default::default()
@@ -82,10 +82,8 @@ impl Repository {
             .with_shallow(remote::fetch::Shallow::DepthAtRemote(
                 NonZeroU32::new(1).unwrap(),
             ))
-            .fetch_then_checkout(&mut progress, &AtomicBool::new(false))?
+            .fetch_only(&mut progress, &AtomicBool::new(false))?
             .0
-            .main_worktree(&mut progress, &AtomicBool::new(false))?
-            .0,
         ))
     }
 }

--- a/crates/binstalk/src/helpers/git.rs
+++ b/crates/binstalk/src/helpers/git.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, path::Path, str::FromStr, sync::atomic::AtomicBool};
+use std::{mem, num::NonZeroU32, path::Path, str::FromStr, sync::atomic::AtomicBool};
 
 use compact_str::CompactString;
 use gix::{clone, create, open, remote, Url};
@@ -19,14 +19,14 @@ pub enum GitError {
     #[error("Failed to fetch: {0}")]
     FetchError(#[source] Box<clone::fetch::Error>),
 
+    #[error("Failed to checkout: {0}")]
+    CheckOutError(#[source] Box<clone::checkout::main_worktree::Error>),
+
     #[error("HEAD ref was corrupt in crates-io index repository clone")]
     HeadCommit(#[source] Box<gix::reference::head_commit::Error>),
 
     #[error("tree of head commit wasn't present in crates-io index repository clone")]
     GetTreeOfCommit(#[source] Box<gix::object::commit::Error>),
-
-    #[error("config.json missing in crates.io repository")]
-    MissingConfigJson,
 
     #[error("An object was missing in the crates-io index repository clone")]
     ObjectLookup(#[source] Box<gix::object::find::existing::Error>),
@@ -41,6 +41,12 @@ impl From<clone::Error> for GitError {
 impl From<clone::fetch::Error> for GitError {
     fn from(e: clone::fetch::Error) -> Self {
         Self::FetchError(Box::new(e))
+    }
+}
+
+impl From<clone::checkout::main_worktree::Error> for GitError {
+    fn from(e: clone::checkout::main_worktree::Error) -> Self {
+        Self::CheckOutError(Box::new(e))
     }
 }
 
@@ -74,14 +80,14 @@ impl FromStr for GitUrl {
 }
 
 #[derive(Debug)]
-pub struct Repository(pub(crate) gix::Repository);
+pub struct Repository(gix::ThreadSafeRepository);
 
 impl Repository {
     /// WARNING: This is a blocking operation, if you want to use it in
     /// async context then you must wrap the call in [`tokio::task::spawn_blocking`].
     ///
     /// WARNING: This function must be called after tokio runtime is initialized.
-    pub fn shallow_clone(url: GitUrl, path: &Path) -> Result<Self, GitError> {
+    pub fn shallow_clone_bare(url: GitUrl, path: &Path) -> Result<Self, GitError> {
         let url_bstr = url.0.to_bstring();
         let url_str = String::from_utf8_lossy(&url_bstr);
 
@@ -104,7 +110,69 @@ impl Repository {
                 NonZeroU32::new(1).unwrap(),
             ))
             .fetch_only(&mut progress, &AtomicBool::new(false))?
-            .0,
+            .0
+            .into(),
         ))
+    }
+
+    /// WARNING: This is a blocking operation, if you want to use it in
+    /// async context then you must wrap the call in [`tokio::task::spawn_blocking`].
+    ///
+    /// WARNING: This function must be called after tokio runtime is initialized.
+    pub fn shallow_clone(url: GitUrl, path: &Path) -> Result<Self, GitError> {
+        let url_bstr = url.0.to_bstring();
+        let url_str = String::from_utf8_lossy(&url_bstr);
+
+        debug!(
+            "Shallow cloning {url_str} to {} with worktree",
+            path.display()
+        );
+
+        let mut progress = TracingProgress::new(CompactString::new("Cloning"));
+
+        Ok(Self(
+            clone::PrepareFetch::new(
+                url.0,
+                path,
+                create::Kind::WithWorktree,
+                create::Options {
+                    destination_must_be_empty: true,
+                    ..Default::default()
+                },
+                open::Options::isolated(),
+            )?
+            .with_shallow(remote::fetch::Shallow::DepthAtRemote(
+                NonZeroU32::new(1).unwrap(),
+            ))
+            .fetch_then_checkout(&mut progress, &AtomicBool::new(false))?
+            .0
+            .main_worktree(&mut progress, &AtomicBool::new(false))?
+            .0
+            .into(),
+        ))
+    }
+
+    #[inline(always)]
+    pub fn get_head_commit_entry_data_by_path(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<Option<Vec<u8>>, GitError> {
+        fn inner(this: &Repository, path: &Path) -> Result<Option<Vec<u8>>, GitError> {
+            Ok(
+                if let Some(entry) = this
+                    .0
+                    .to_thread_local()
+                    .head_commit()?
+                    .tree()?
+                    .lookup_entry_by_path(path)?
+                {
+                    Some(mem::take(&mut entry.object()?.data))
+                } else {
+                    None
+                },
+            )
+        }
+
+        inner(self, path.as_ref())
     }
 }


### PR DESCRIPTION
### Motivation

[Clones of the crates-index are very slow on windows.](https://github.com/Byron/gitoxide/discussions/931#discussion-5405751), and `cargo` is also not doing them but uses bare clones instead.

### Tasks

* [x] create bare clones to not even have a worktree checkout
* [x] access the repository directly instead of the worktree checkout

### Guidance

> > If you point me to the place where the full checkout is needed, I could probably figure out the rest from there as long as a git repository is present that contains the crates-index. It's not a big deal at all (probably not even famous last words ;)).
> 
> Here is the [code we use for cloning and checkout](https://github.com/cargo-bins/cargo-binstall/blob/main/crates/binstalk/src/helpers/git.rs).
> 
> It is then used in [`git_registry.rs`](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/drivers/registry/git_registry.rs#L40) and [`resolve.rs`](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/ops/resolve.rs#L374). In both scenario, they try to open a few files (could contain directory) and read their contents into memory and parse them.
> 
> In [`git_registry.rs`](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/drivers/registry/git_registry.rs#L40), we need to read `config.json` and then read a registry file for each crate queried [here](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/drivers/registry/git_registry.rs#L78).
> 
> In [`resolve.rs`](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/ops/resolve.rs#L374), we would call [`load_manifest_from_workspace`](https://github.com/cargo-bins/cargo-binstall/blob/963e9e97add0a681f117fe21c6b3fde074706ac7/crates/binstalk/src/helpers/cargo_toml_workspace.rs#L20) to load the find the crate requested in the workspace.

[Source](https://github.com/Byron/gitoxide/discussions/931#discussioncomment-6463360)
