### PR TITLE
Fix `release-pr.yml`: Do not `check-semver` for cargo-binstall release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -51,5 +51,5 @@ jobs:
           pr-label: release
           pr-release-notes: ${{ inputs.crate == 'bin' }}
           pr-template-file: .github/scripts/release-pr-template.ejs
-          check-semver: true
+          check-semver: ${{ inputs.crate != 'bin' }}
           check-package: true


### PR DESCRIPTION
Checking semver caused [release-pr](https://github.com/cargo-bins/cargo-binstall/actions/runs/5587299243) to failed when requesting new cargo-binstall release.

cargo-binstall is not a library crate so there's no need to check it.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>