### PR TITLE
ci: Build MacOS universal exe from x86_64h-apple-darwin

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,7 +124,7 @@ jobs:
 
     - uses: actions/download-artifact@v3
       with:
-        name: x86_64-apple-darwin
+        name: x86_64h-apple-darwin
         path: packages/
     - uses: actions/download-artifact@v3
       with:

--- a/justfile
+++ b/justfile
@@ -318,14 +318,14 @@ package-prepare: build package-dir
 [macos]
 lipo-prepare: package-dir
     just target=aarch64-apple-darwin build get-binary packages/prep/arm64
-    just target=x86_64-apple-darwin build get-binary packages/prep/x64
+    just target=x86_64h-apple-darwin build get-binary packages/prep/x64
 
     just target=aarch64-apple-darwin get-binary packages/prep/arm64
-    just target=x86_64-apple-darwin get-binary packages/prep/x64
+    just target=x86_64h-apple-darwin get-binary packages/prep/x64
     lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64}/{{output-filename}}
 
     just target=aarch64-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/arm64
-    just target=x86_64-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64
+    just target=x86_64h-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64
     lipo -create -output packages/prep/detect-wasi{{output-ext}} packages/prep/{arm64,x64}/detect-wasi{{output-ext}}
 
     rm -rf packages/prep/{arm64,x64}
@@ -355,7 +355,7 @@ package-lipo: lipo-prepare
 [macos]
 repackage-lipo: package-dir
     mkdir -p packages/prep/{arm64,x64}
-    cd packages/prep/x64 && unzip -o "../../cargo-binstall-x86_64-apple-darwin.full.zip"
+    cd packages/prep/x64 && unzip -o "../../cargo-binstall-x86_64h-apple-darwin.full.zip"
     cd packages/prep/arm64 && unzip -o "../../cargo-binstall-aarch64-apple-darwin.full.zip"
 
     lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64}/{{output-filename}}


### PR DESCRIPTION
instead of `x86_64-apple-darwin` for better optimization since any machine that support universal support x86_64h.