### PR TITLE
Don't show warning if $CARGO_HOME/bin is in $PATH

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -27,8 +27,11 @@ fi
 
 ./cargo-binstall -y --force cargo-binstall
 
-if ! [[ ":$PATH:" == *":$HOME/.cargo/bin:"* ]]; then
+if ! [[ $CARGO_HOME ]]; then
+    CARGO_HOME=$HOME/.cargo
+fi
+if ! [[ ":$PATH:" == *":$CARGO_HOME/bin:"* ]]; then
     echo
-    printf "\033[0;31mYour path is missing ~/.cargo/bin, you might want to add it.\033[0m\n"
+    printf "\033[0;31mYour path is missing %s, you might want to add it.\033[0m\n" "$CARGO_HOME/bin"
     echo
 fi


### PR DESCRIPTION
This fixes the incorrect warning shown when installing in the rust docker image:

```
$ docker run --rm -it rust:1.71.0
# curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
++ mktemp -d
+ cd /tmp/tmp.EcCErDm2XW
+ base_url=https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-
++ uname -s
+ os=Linux
+ '[' Linux == Darwin ']'
+ '[' Linux == Linux ']'
++ uname -m
+ machine=x86_64
+ target=x86_64-unknown-linux-musl
+ '[' x86_64 == armv7 ']'
+ url=https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+ curl -L --proto =https --tlsv1.2 -sSf https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+ tar -xvzf -
cargo-binstall
+ ./cargo-binstall -y --force cargo-binstall
 INFO resolve: Resolving package: 'cargo-binstall'
 WARN The package cargo-binstall v1.1.2 will be downloaded from github.com
 INFO This will install the following binaries:
 INFO   - cargo-binstall (cargo-binstall -> /usr/local/cargo/bin/cargo-binstall)
 INFO Installing binaries...
 INFO Done in 3.08849114s
+ [[ :/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin: == *\:\/\r\o\o\t\/\.\c\a\r\g\o\/\b\i\n\:* ]]
+ echo

+ printf '\033[0;31mYour path is missing ~/.cargo/bin, you might want to add it.\033[0m\n'
Your path is missing ~/.cargo/bin, you might want to add it.
+ echo
```