### PR TITLE
feat: Support passing workspace to `--manifest-path`

### DIFF
--- a/crates/binstalk/tests/parse-meta.rs
+++ b/crates/binstalk/tests/parse-meta.rs
@@ -1,12 +1,14 @@
 use binstalk::ops::resolve::load_manifest_path;
 use cargo_toml::Product;
+use std::path::PathBuf;
 
 #[test]
 fn parse_meta() {
-    let mut manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    manifest_dir.push_str("/tests/parse-meta.Cargo.toml");
+    let mut manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    manifest_dir.push("tests/parse-meta.Cargo.toml");
 
-    let manifest = load_manifest_path(&manifest_dir).expect("Error parsing metadata");
+    let manifest =
+        load_manifest_path(&manifest_dir, "cargo-binstall-test").expect("Error parsing metadata");
     let package = manifest.package.unwrap();
     let meta = package.metadata.and_then(|m| m.binstall).unwrap();
 


### PR DESCRIPTION
Previously it will load the root `Cargo.toml` and treat it as the manifest for the crate, now it will check its `package.name` and would search for the workspace if the `package.name` does not match the crate name.