### PR TITLE
feat: Support data verification in `Download`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ dependencies = [
  "bytes",
  "bzip2",
  "compact_str",
- "digest",
  "flate2",
  "futures-lite",
  "futures-util",

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -17,7 +17,6 @@ binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
 bytes = "1.4.0"
 bzip2 = "0.4.4"
 compact_str = "0.7.0"
-digest = "0.10.7"
 flate2 = { version = "1.0.26", default-features = false }
 futures-lite = { version = "1.13.0", default-features = false }
 futures-util = "0.3.28"

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -21,7 +21,7 @@ use crate::utils::{extract_with_blocking_task, StreamReadable};
 
 pub async fn extract_bin<S>(stream: S, path: &Path) -> Result<ExtractedFiles, DownloadError>
 where
-    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin + 'static,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin,
 {
     debug!("Writing to `{}`", path.display());
 
@@ -45,7 +45,7 @@ where
 
 pub async fn extract_zip<S>(stream: S, path: &Path) -> Result<ExtractedFiles, DownloadError>
 where
-    S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + Send + Sync + 'static,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Unpin + Send + Sync,
 {
     debug!("Decompressing from zip archive to `{}`", path.display());
 
@@ -79,7 +79,7 @@ pub async fn extract_tar_based_stream<S>(
     fmt: TarBasedFmt,
 ) -> Result<ExtractedFiles, DownloadError>
 where
-    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin + 'static,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin,
 {
     debug!("Extracting from {fmt} archive to {}", dst.display());
 
@@ -162,7 +162,7 @@ fn extract_with_blocking_decoder<S, F, T>(
     f: F,
 ) -> impl Future<Output = Result<T, DownloadError>>
 where
-    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin + 'static,
+    S: Stream<Item = Result<Bytes, DownloadError>> + Send + Sync + Unpin,
     F: FnOnce(mpsc::Receiver<Bytes>, &Path) -> io::Result<T> + Send + Sync + 'static,
     T: Send + 'static,
 {

--- a/crates/binstalk-downloader/src/utils.rs
+++ b/crates/binstalk-downloader/src/utils.rs
@@ -18,7 +18,7 @@ where
     T: Send + 'static,
     E: From<io::Error>,
     E: From<StreamError>,
-    S: Stream<Item = Result<Bytes, StreamError>> + Send + Sync + Unpin + 'static,
+    S: Stream<Item = Result<Bytes, StreamError>> + Send + Sync + Unpin,
     F: FnOnce(mpsc::Receiver<Bytes>) -> io::Result<T> + Send + Sync + 'static,
 {
     async fn inner<S, StreamError, Fut, T, E>(
@@ -31,7 +31,7 @@ where
         E: From<StreamError>,
         // We do not use trait object for S since there will only be one
         // S used with this function.
-        S: Stream<Item = Result<Bytes, StreamError>> + Send + Sync + Unpin + 'static,
+        S: Stream<Item = Result<Bytes, StreamError>> + Send + Sync + Unpin,
         // asyncify would always return the same future, so no need to
         // use trait object here.
         Fut: Future<Output = io::Result<T>> + Send + Sync,


### PR DESCRIPTION
By accepting `&mut dyn DataVerifier` for users to pass any callback that uses `digest::Digest`/`digest::Mac`, `sigstore` or whatever they want.