### PR TITLE
Use `rust-lld` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,18 @@ jobs:
             os: windows-latest
 
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
 
     steps:
     - uses: actions/checkout@v3
+    - name: Use rust-lld
+      run: |
+        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
+
     - uses: ./.github/actions/just-setup
       env:
         # just-setup use binstall to install sccache,
@@ -74,10 +81,17 @@ jobs:
           - target: aarch64-pc-windows-msvc
             os: windows-latest
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:
     - uses: actions/checkout@v3
+    - name: Use rust-lld
+      run: |
+        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
+
     - uses: ./.github/actions/just-setup
       with:
         tools: cargo-hack
@@ -107,6 +121,9 @@ jobs:
             os: windows-latest
 
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,6 +42,9 @@ jobs:
 
     name: ${{ matrix.t }}
     runs-on: ${{ matrix.o }}
+    defaults:
+      run:
+        shell: bash
     env:
       CARGO_BUILD_TARGET: ${{ matrix.t }}
       GLIBC_VERSION: ${{ matrix.g }}
@@ -60,6 +63,10 @@ jobs:
       if: inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS
       run: echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}" >> "$GITHUB_ENV"
 
+    - name: Use rust-lld
+      run: |
+        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
+
     - uses: ./.github/actions/just-setup
       with:
         tools: cargo-auditable
@@ -73,6 +80,7 @@ jobs:
 
     - run: just package
     - if: runner.os == 'Windows'
+      shell: pwsh
       run: Get-ChildItem packages/
     - if: runner.os != 'Windows'
       run: ls -shal packages/


### PR DESCRIPTION
Which guarantees:
 - faster linking on all targets when `cargo-zigbuild` is not used
 - allow cross-lang-lto to be enabled