### PR TITLE
Enable cross-lang-lto & icf for all targets

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -18,6 +18,12 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Use rust-lld
+    run: |
+      TARGET="$(echo "${CARGO_BUILD_TARGET?}" | tr '[:lower:]' '[:upper:]' | sed 's/-/_/g')"
+      echo "CARGO_TARGET_${TARGET?}_LINKER=rust-lld"  >> "$GITHUB_ENV"
+    shell: bash -euo pipefail
+
   - name: Add just to tools to install
     run: echo "tools=just" >>$GITHUB_ENV
     shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use rust-lld
-      run: |
-        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
-
     - uses: ./.github/actions/just-setup
       env:
         # just-setup use binstall to install sccache,
@@ -88,10 +84,6 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:
     - uses: actions/checkout@v3
-    - name: Use rust-lld
-      run: |
-        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
-
     - uses: ./.github/actions/just-setup
       with:
         tools: cargo-hack

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -51,6 +51,13 @@ jobs:
       JUST_USE_CARGO_ZIGBUILD: ${{ matrix.c }}
       JUST_FOR_RELEASE: true
       JUST_USE_AUDITABLE: true
+      # Since rust-lld is used, we can turn on cross-lang-LTO since the
+      # llvm version is always the same as `rustc` and it is always higher than
+      # the one found in `zig`.
+      JUST_USE_CROSS_LANG_LTO: true
+      # Since rust-lld is used, we can turn on ICF since it is guaranteed
+      # to be supported.
+      JUST_USE_ICF: true
 
     steps:
     - uses: actions/checkout@v3
@@ -62,10 +69,6 @@ jobs:
     - name: Override release profile codegen-units settings
       if: inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS
       run: echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}" >> "$GITHUB_ENV"
-
-    - name: Use rust-lld
-      run: |
-        echo "CARGO_TARGET_${CARGO_BUILD_TARGET}_LINKER=rust-lld" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/just-setup
       with:


### PR DESCRIPTION
Since now we use `rust-lld` on all targets and it is guaranteed to support cross-lang-lto (same LLVM version as rustc and always higher LLVM version than `zig`) and support icf.

Also fixed using `rust-lld`: Use upper case when exporting environment name.