### PR TITLE
Remove dep `futures-lite` from `binstalk-downloader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,6 @@ dependencies = [
  "bzip2",
  "compact_str",
  "flate2",
- "futures-lite",
  "futures-util",
  "generic-array",
  "httpdate",
@@ -961,16 +960,6 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -18,7 +18,6 @@ bytes = "1.4.0"
 bzip2 = "0.4.4"
 compact_str = "0.7.0"
 flate2 = { version = "1.0.26", default-features = false }
-futures-lite = { version = "1.13.0", default-features = false }
 futures-util = "0.3.28"
 generic-array = "0.14.7"
 httpdate = "1.0.2"

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -2,7 +2,7 @@ use std::{fmt, io, marker::PhantomData, path::Path};
 
 use binstalk_types::cargo_toml_binstall::PkgFmtDecomposed;
 use bytes::Bytes;
-use futures_lite::stream::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use thiserror::Error as ThisError;
 use tracing::{debug, instrument};
 

--- a/crates/binstalk-downloader/src/download/async_extracter.rs
+++ b/crates/binstalk-downloader/src/download/async_extracter.rs
@@ -8,7 +8,7 @@ use std::{
 
 use async_zip::base::read::stream::ZipFileReader;
 use bytes::{Bytes, BytesMut};
-use futures_lite::stream::Stream;
+use futures_util::Stream;
 use tokio::sync::mpsc;
 use tokio_util::io::StreamReader;
 use tracing::debug;

--- a/crates/binstalk-downloader/src/download/async_tar_visitor.rs
+++ b/crates/binstalk-downloader/src/download/async_tar_visitor.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Debug, io, path::Path, pin::Pin};
 
 use async_compression::tokio::bufread;
 use bytes::Bytes;
-use futures_lite::stream::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use tokio::io::{copy, sink, AsyncRead};
 use tokio_tar::{Archive, Entry, EntryType};
 use tokio_util::io::StreamReader;

--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -9,7 +9,7 @@ use async_zip::{
     ZipString,
 };
 use bytes::{Bytes, BytesMut};
-use futures_lite::future::try_zip as try_join;
+use futures_util::future::try_join;
 use futures_util::io::Take;
 use thiserror::Error as ThisError;
 use tokio::{

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_lite::stream::Stream;
+use futures_util::Stream;
 use httpdate::parse_http_date;
 use reqwest::{
     header::{HeaderMap, RETRY_AFTER},

--- a/crates/binstalk-downloader/src/remote/request_builder.rs
+++ b/crates/binstalk-downloader/src/remote/request_builder.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use bytes::Bytes;
-use futures_lite::stream::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use reqwest::Method;
 
 use super::{header, Client, Error, HttpError, StatusCode, Url};

--- a/crates/binstalk-downloader/src/utils.rs
+++ b/crates/binstalk-downloader/src/utils.rs
@@ -4,10 +4,7 @@ use std::{
 };
 
 use bytes::{Buf, Bytes};
-use futures_lite::{
-    future::poll_once,
-    stream::{Stream, StreamExt},
-};
+use futures_util::{FutureExt, Stream, StreamExt};
 use tokio::{sync::mpsc, task};
 
 pub(super) fn extract_with_blocking_task<E, StreamError, S, F, T>(
@@ -77,7 +74,7 @@ where
             res = &mut task_fut => {
                 // The task finishes before the read task, return early
                 // after checking for errors in read_fut.
-                if let Some(Err(err)) = poll_once(read_fut).await {
+                if let Some(Err(err)) = read_fut.now_or_never() {
                     Err(err)
                 } else {
                     res


### PR DESCRIPTION
I planned to replace `futures-util` with `futures-lite`, but it turns out that `reqwest` actually depends on `futures-util`, so there is no point removing it and introduce yet another dependency.