### PR TITLE
feat: Verify cksum of crate tarball from cargo registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +235,7 @@ name = "binstalk"
 version = "0.14.1"
 dependencies = [
  "async-trait",
+ "base16",
  "binstalk-downloader",
  "binstalk-types",
  "cargo_toml",
@@ -251,6 +258,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "target-lexicon",
  "tempfile",
@@ -280,6 +288,7 @@ dependencies = [
  "generic-array",
  "httpdate",
  "percent-encoding",
+ "quinn 0.10.2",
  "reqwest",
  "serde",
  "serde-tuple-vec-map",
@@ -3257,6 +3266,17 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     env, fs,
     future::Future,
     path::{Path, PathBuf},

--- a/crates/binstalk-downloader/src/lib.rs
+++ b/crates/binstalk-downloader/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+pub use bytes;
+
 pub mod download;
 
 /// Github API client.

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -11,6 +11,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 async-trait = "0.1.68"
+base16 = "0.2.1"
 binstalk-downloader = { version = "0.6.1", path = "../binstalk-downloader", default-features = false, features = ["gh-api-client"] }
 binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
 cargo_toml = "0.15.3"
@@ -33,6 +34,7 @@ reflink-copy = "0.1.5"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.99"
+sha2 = "0.10.7"
 strum = "0.25.0"
 target-lexicon = { version = "0.12.11", features = ["std"] }
 tempfile = "3.5.0"

--- a/crates/binstalk/src/drivers/registry.rs
+++ b/crates/binstalk/src/drivers/registry.rs
@@ -1,5 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
+use base16::DecodeError as Base16DecodeError;
 use cargo_toml::Manifest;
 use compact_str::CompactString;
 use leon::{ParseError, RenderError};
@@ -56,6 +57,12 @@ pub enum RegistryError {
 
     #[error("Failed to render dl config: {0}")]
     RenderDlConfig(#[from] RenderError),
+
+    #[error("Failed to parse checksum encoded in hex: {0}")]
+    InvalidHex(#[from] Base16DecodeError),
+
+    #[error("Expected checksum `{expected}`, actual checksum `{actual}`")]
+    UnmatchedChecksum { expected: String, actual: String },
 }
 
 #[derive(Clone, Debug)]

--- a/crates/binstalk/src/drivers/registry/sparse_registry.rs
+++ b/crates/binstalk/src/drivers/registry/sparse_registry.rs
@@ -88,7 +88,7 @@ impl SparseRegistry {
     ) -> Result<Manifest<Meta>, BinstallError> {
         let crate_prefix = crate_prefix_components(crate_name)?;
         let dl_template = self.get_dl_template(&client).await?;
-        let MatchedVersion { version, cksum } = Self::find_crate_matched_ver(
+        let matched_version = Self::find_crate_matched_ver(
             &client,
             self.url.clone(),
             crate_name,
@@ -100,10 +100,9 @@ impl SparseRegistry {
             dl_template,
             crate_name,
             &crate_prefix,
-            &version,
-            &cksum,
+            &matched_version,
         )?)?;
 
-        parse_manifest(client, crate_name, &version, dl_url).await
+        parse_manifest(client, crate_name, dl_url, matched_version).await
     }
 }

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -8,8 +8,8 @@ pub mod signal;
 pub(crate) mod target_triple;
 pub mod tasks;
 
-pub(crate) use binstalk_downloader::download;
 pub use binstalk_downloader::gh_api_client;
+pub(crate) use binstalk_downloader::{bytes, download};
 
 pub(crate) fn is_universal_macos(target: &str) -> bool {
     ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)


### PR DESCRIPTION
Fixed #1183

Since the crate tarball could be downloaded from a different set of servers than where the cargo registry is hosted, verifying the checksum is necessary to verify its integrity.