### PR TITLE
dep: Bump tokio to v1.30.0 & disable feat `parking_lot`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,20 +3551,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -39,8 +39,7 @@ strum = "0.25.0"
 target-lexicon = { version = "0.12.11", features = ["std"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
-# parking_lot for `tokio::sync::OnceCell::const_new`
-tokio = { version = "1.28.2", features = ["rt", "process", "sync", "signal", "parking_lot"], default-features = false }
+tokio = { version = "1.30.0", features = ["rt", "process", "sync", "signal"], default-features = false }
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 xz2 = "0.1.7"


### PR DESCRIPTION
In tokio v1.30.0, MSRV is bumped to rust 1.63 and all `const_new` methods in `tokio::sync` are now always available, so there is no need to enable feat `parking_lot`.