### PR TITLE
Include `x86_64` & `x86_64h` in universal apple pre-built binary

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -129,6 +129,10 @@ jobs:
         path: packages/
     - uses: actions/download-artifact@v3
       with:
+        name: x86_64-apple-darwin
+        path: packages/
+    - uses: actions/download-artifact@v3
+      with:
         name: aarch64-apple-darwin
         path: packages/
 

--- a/justfile
+++ b/justfile
@@ -322,17 +322,20 @@ package-prepare: build package-dir
 [macos]
 lipo-prepare: package-dir
     just target=aarch64-apple-darwin build get-binary packages/prep/arm64
-    just target=x86_64h-apple-darwin build get-binary packages/prep/x64
+    just target=x86_64-apple-darwin build get-binary packages/prep/x64
+    just target=x86_64h-apple-darwin build get-binary packages/prep/x64h
 
     just target=aarch64-apple-darwin get-binary packages/prep/arm64
-    just target=x86_64h-apple-darwin get-binary packages/prep/x64
-    lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64}/{{output-filename}}
+    just target=x86_64-apple-darwin get-binary packages/prep/x64
+    just target=x86_64h-apple-darwin get-binary packages/prep/x64h
+    lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64,x64h}/{{output-filename}}
 
     just target=aarch64-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/arm64
-    just target=x86_64h-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64
-    lipo -create -output packages/prep/detect-wasi{{output-ext}} packages/prep/{arm64,x64}/detect-wasi{{output-ext}}
+    just target=x86_64-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64
+    just target=x86_64h-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64h
+    lipo -create -output packages/prep/detect-wasi{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-wasi{{output-ext}}
 
-    rm -rf packages/prep/{arm64,x64}
+    rm -rf packages/prep/{arm64,x64,x64h}
 
 
 [linux]
@@ -358,13 +361,18 @@ package-lipo: lipo-prepare
 # assuming x64 and arm64 packages are already built, extract and lipo them
 [macos]
 repackage-lipo: package-dir
-    mkdir -p packages/prep/{arm64,x64}
-    cd packages/prep/x64 && unzip -o "../../cargo-binstall-x86_64h-apple-darwin.full.zip"
+    set -euxo pipefail
+
+    mkdir -p packages/prep/{arm64,x64,x64h}
+    cd packages/prep/x64 && unzip -o "../../cargo-binstall-x86_64-apple-darwin.full.zip"
+    cd packages/prep/x64h && unzip -o "../../cargo-binstall-x86_64h-apple-darwin.full.zip"
     cd packages/prep/arm64 && unzip -o "../../cargo-binstall-aarch64-apple-darwin.full.zip"
 
-    lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64}/{{output-filename}}
-    lipo -create -output packages/prep/detect-wasi packages/prep/{arm64,x64}/detect-wasi
+    lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64,x64h}/{{output-filename}}
+    lipo -create -output packages/prep/detect-wasi packages/prep/{arm64,x64,x64h}/detect-wasi
 
-    rm -rf packages/prep/{arm64,x64}
+    ./packages/prep/{{output-filename}} -vV
+
+    rm -rf packages/prep/{arm64,x64,x64h}
     cd packages/prep && zip -9 "../cargo-binstall-universal-apple-darwin.zip" {{output-filename}}
     cd packages/prep && zip -9 "../cargo-binstall-universal-apple-darwin.full.zip" *


### PR DESCRIPTION
To makre sure it can run on pre-haswell Intel CPUs.

Fixed #1277