### PR TITLE
Speedup `ci.yml`: Set codegen-units to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   JUST_ENABLE_H3: true
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
+  CARGO_PROFILE_DEV_CODEGEN_UNITS: 4
+  CARGO_PROFILE_CHECK_ONLY_CODEGEN_UNITS: 4
 
 jobs:
   test:
@@ -121,7 +124,7 @@ jobs:
     uses: ./.github/workflows/release-build.yml
     with:
       CARGO_PROFILE_RELEASE_LTO: no
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1024
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:


### PR DESCRIPTION
Set `CARGO_PROFILE_RELEASE_CODEGEN_UNITS` to 4
since 1024 units are too many and our CI only have 2-3 cores.