### PR TITLE
Refactor: Extract `cargo_toml_workspace` as a new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,12 +238,11 @@ dependencies = [
  "base16",
  "binstalk-downloader",
  "binstalk-types",
- "cargo_toml",
+ "cargo-toml-workspace",
  "command-group",
  "compact_str",
  "detect-targets",
  "either",
- "glob",
  "home",
  "itertools",
  "jobslot",
@@ -486,6 +485,20 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "vergen",
+]
+
+[[package]]
+name = "cargo-toml-workspace"
+version = "0.0.0"
+dependencies = [
+ "binstalk-types",
+ "cargo_toml",
+ "compact_str",
+ "glob",
+ "normalize-path",
+ "tempfile",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/binstalk-manifests",
     "crates/binstalk-types",
     "crates/binstalk-downloader",
+    "crates/cargo-toml-workspace",
     "crates/detect-wasi",
     "crates/fs-lock",
     "crates/normalize-path",

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -197,6 +197,7 @@ pub fn logging(log_level: LevelFilter, json_output: bool) {
         "binstalk",
         "binstalk_downloader",
         "cargo_binstall",
+        "cargo_toml_workspace",
     ]);
 
     // Forward log to tracing

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -14,12 +14,11 @@ async-trait = "0.1.68"
 base16 = "0.2.1"
 binstalk-downloader = { version = "0.7.0", path = "../binstalk-downloader", default-features = false, features = ["gh-api-client"] }
 binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
-cargo_toml = "0.15.3"
+cargo-toml-workspace = { version = "0.0.0", path = "../cargo-toml-workspace" }
 command-group = { version = "2.1.0", features = ["with-tokio"] }
 compact_str = { version = "0.7.0", features = ["serde"] }
 detect-targets = { version = "0.1.10", path = "../detect-targets" }
 either = "1.8.1"
-glob = "0.3.1"
 home = "0.5.5"
 itertools = "0.11.0"
 jobslot = { version = "0.2.11", features = ["tokio"] }

--- a/crates/binstalk/src/drivers/registry.rs
+++ b/crates/binstalk/src/drivers/registry.rs
@@ -1,7 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
 use base16::DecodeError as Base16DecodeError;
-use cargo_toml::Manifest;
 use compact_str::CompactString;
 use leon::{ParseError, RenderError};
 use miette::Diagnostic;
@@ -11,7 +10,10 @@ use thiserror::Error as ThisError;
 
 use crate::{
     errors::BinstallError,
-    helpers::remote::{Client, Error as RemoteError, Url, UrlParseError},
+    helpers::{
+        cargo_toml::Manifest,
+        remote::{Client, Error as RemoteError, Url, UrlParseError},
+    },
     manifests::cargo_toml_binstall::Meta,
 };
 

--- a/crates/binstalk/src/drivers/registry/common.rs
+++ b/crates/binstalk/src/drivers/registry/common.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use base16::{decode as decode_base16, encode_lower as encode_base16};
-use cargo_toml::Manifest;
 use compact_str::{format_compact, CompactString, ToCompactString};
 use leon::{Template, Values};
 use semver::{Version, VersionReq};
@@ -15,6 +14,7 @@ use crate::{
     errors::BinstallError,
     helpers::{
         bytes::Bytes,
+        cargo_toml::Manifest,
         download::{DataVerifier, Download},
         remote::{Client, Url},
     },

--- a/crates/binstalk/src/drivers/registry/crates_io_registry.rs
+++ b/crates/binstalk/src/drivers/registry/crates_io_registry.rs
@@ -1,5 +1,4 @@
 use binstalk_downloader::remote::Error as RemoteError;
-use cargo_toml::Manifest;
 use compact_str::{CompactString, ToCompactString};
 use semver::{Comparator, Op as ComparatorOp, Version as SemVersion, VersionReq};
 use serde::Deserialize;
@@ -12,7 +11,10 @@ use tracing::debug;
 use crate::{
     drivers::registry::{parse_manifest, MatchedVersion, RegistryError},
     errors::BinstallError,
-    helpers::remote::{Client, Url},
+    helpers::{
+        cargo_toml::Manifest,
+        remote::{Client, Url},
+    },
     manifests::cargo_toml_binstall::Meta,
 };
 

--- a/crates/binstalk/src/drivers/registry/git_registry.rs
+++ b/crates/binstalk/src/drivers/registry/git_registry.rs
@@ -1,6 +1,5 @@
 use std::{io, path::PathBuf, sync::Arc};
 
-use cargo_toml::Manifest;
 use compact_str::{CompactString, ToCompactString};
 use once_cell::sync::OnceCell;
 use semver::VersionReq;
@@ -16,6 +15,7 @@ use crate::{
     },
     errors::BinstallError,
     helpers::{
+        cargo_toml::Manifest,
         git::{GitUrl, Repository},
         remote::Client,
     },

--- a/crates/binstalk/src/drivers/registry/sparse_registry.rs
+++ b/crates/binstalk/src/drivers/registry/sparse_registry.rs
@@ -1,4 +1,3 @@
-use cargo_toml::Manifest;
 use compact_str::CompactString;
 use semver::VersionReq;
 use serde_json::Deserializer as JsonDeserializer;
@@ -11,7 +10,10 @@ use crate::{
         RegistryConfig, RegistryError,
     },
     errors::BinstallError,
-    helpers::remote::{Client, Error as RemoteError},
+    helpers::{
+        cargo_toml::Manifest,
+        remote::{Client, Error as RemoteError},
+    },
     manifests::cargo_toml_binstall::Meta,
 };
 

--- a/crates/binstalk/src/drivers/registry/vfs.rs
+++ b/crates/binstalk/src/drivers/registry/vfs.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use cargo_toml::AbstractFilesystem;
+use crate::helpers::cargo_toml::AbstractFilesystem;
 use normalize_path::NormalizePath;
 
 /// This type stores the filesystem structure for the crate tarball

--- a/crates/binstalk/src/drivers/registry/visitor.rs
+++ b/crates/binstalk/src/drivers/registry/visitor.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use cargo_toml::{Manifest, Value};
 use normalize_path::NormalizePath;
 use tokio::io::AsyncReadExt;
 use tracing::debug;
@@ -8,7 +7,10 @@ use tracing::debug;
 use super::vfs::Vfs;
 use crate::{
     errors::BinstallError,
-    helpers::download::{DownloadError, TarEntriesVisitor, TarEntry},
+    helpers::{
+        cargo_toml::{Manifest, Value},
+        download::{DownloadError, TarEntriesVisitor, TarEntry},
+    },
     manifests::cargo_toml_binstall::Meta,
 };
 

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -7,7 +7,6 @@ use std::{
 use binstalk_downloader::{
     download::DownloadError, gh_api_client::GhApiError, remote::Error as RemoteError,
 };
-use cargo_toml::Error as CargoTomlError;
 use compact_str::CompactString;
 use miette::{Diagnostic, Report};
 use target_lexicon::ParseError as TargetTripleParseError;
@@ -17,7 +16,9 @@ use tracing::{error, warn};
 
 use crate::{
     drivers::{InvalidRegistryError, RegistryError},
-    helpers::cargo_toml_workspace::LoadManifestFromWSError,
+    helpers::{
+        cargo_toml::Error as CargoTomlError, cargo_toml_workspace::Error as LoadManifestFromWSError,
+    },
 };
 
 #[derive(Debug, Error)]
@@ -498,5 +499,11 @@ impl From<RegistryError> for BinstallError {
 impl From<InvalidRegistryError> for BinstallError {
     fn from(e: InvalidRegistryError) -> Self {
         BinstallError::RegistryParseError(Box::new(e))
+    }
+}
+
+impl From<LoadManifestFromWSError> for BinstallError {
+    fn from(e: LoadManifestFromWSError) -> Self {
+        BinstallError::LoadManifestFromWSError(Box::new(e))
     }
 }

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -1,4 +1,3 @@
-pub(crate) mod cargo_toml_workspace;
 pub(crate) mod futures_resolver;
 pub mod jobserver_client;
 pub mod remote;
@@ -11,6 +10,7 @@ pub(crate) use binstalk_downloader::{bytes, download};
 
 #[cfg(feature = "git")]
 pub(crate) use binstalk_downloader::git;
+pub(crate) use cargo_toml_workspace::{self, cargo_toml};
 
 pub(crate) fn is_universal_macos(target: &str) -> bool {
     ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use cargo_toml::Manifest;
 use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use leon::Template;
@@ -22,8 +21,8 @@ use crate::{
     errors::{BinstallError, VersionParseError},
     fetchers::{Data, Fetcher, TargetData},
     helpers::{
-        self, cargo_toml_workspace::load_manifest_from_workspace, download::ExtractedFiles,
-        remote::Client, target_triple::TargetTriple,
+        self, cargo_toml::Manifest, cargo_toml_workspace::load_manifest_from_workspace,
+        download::ExtractedFiles, remote::Client, target_triple::TargetTriple,
     },
     manifests::cargo_toml_binstall::{Meta, PkgMeta, PkgOverride},
     ops::{CargoTomlFetchOverride, Options},
@@ -381,7 +380,7 @@ impl PackageInfo {
                     let dir = TempDir::new()?;
                     helpers::git::Repository::shallow_clone(git_url, dir.as_ref())?;
 
-                    load_manifest_from_workspace(dir.as_ref(), &name)
+                    load_manifest_from_workspace(dir.as_ref(), &name).map_err(BinstallError::from)
                 })
                 .await??
             }

--- a/crates/binstalk/tests/parse-meta.rs
+++ b/crates/binstalk/tests/parse-meta.rs
@@ -1,5 +1,5 @@
 use binstalk::ops::resolve::load_manifest_path;
-use cargo_toml::Product;
+use cargo_toml_workspace::cargo_toml::{Edition, Product};
 use std::path::PathBuf;
 
 #[test]
@@ -24,7 +24,7 @@ fn parse_meta() {
         &[Product {
             name: Some("cargo-binstall".to_string()),
             path: Some("src/main.rs".to_string()),
-            edition: cargo_toml::Edition::E2021,
+            edition: Edition::E2021,
             ..Default::default()
         },],
     );

--- a/crates/cargo-toml-workspace/Cargo.toml
+++ b/crates/cargo-toml-workspace/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cargo-toml-workspace"
+version = "0.0.0"
+edition = "2021"
+description = "Parse cargo workspace and load specific crate"
+repository = "https://github.com/cargo-bins/cargo-binstall"
+documentation = "https://docs.rs/cargo-toml-workspace"
+rust-version = "1.65.0"
+authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
+cargo_toml = "0.15.3"
+compact_str = { version = "0.7.0", features = ["serde"] }
+glob = "0.3.1"
+normalize-path = { version = "0.2.1", path = "../normalize-path" }
+thiserror = "1.0.40"
+tracing = "0.1.37"
+
+[dev-dependencies]
+tempfile = "3.5.0"

--- a/crates/cargo-toml-workspace/LICENSE-APACHE
+++ b/crates/cargo-toml-workspace/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/crates/cargo-toml-workspace/LICENSE-MIT
+++ b/crates/cargo-toml-workspace/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
To reduce codegen time of `binstalk` and also enable others to reuse this crate.