### PR TITLE
feat: `git::Repository` cancellation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "bytes",
  "bzip2",
  "compact_str",
+ "derive_destructure2",
  "flate2",
  "futures-util",
  "generic-array",
@@ -746,6 +747,17 @@ name = "deranged"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
+name = "derive_destructure2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35cb7e5875e1028a73e551747d6d0118f25c3d6dbba2dadf97cc0f4d0c53f2f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "detect-targets"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -17,6 +17,7 @@ binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
 bytes = "1.4.0"
 bzip2 = "0.4.4"
 compact_str = "0.7.0"
+derive_destructure2 = "0.1"
 flate2 = { version = "1.0.26", default-features = false }
 futures-util = "0.3.28"
 generic-array = "0.14.7"

--- a/crates/binstalk-downloader/src/git/cancellation_token.rs
+++ b/crates/binstalk-downloader/src/git/cancellation_token.rs
@@ -1,0 +1,44 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering::Relaxed},
+    Arc,
+};
+
+use derive_destructure2::destructure;
+
+/// Token that can be used to cancel git operation.
+#[derive(Clone, Debug, Default)]
+pub struct GitCancellationToken(Arc<AtomicBool>);
+
+impl GitCancellationToken {
+    /// Create a guard that cancel the git operation on drop.
+    #[must_use = "You must assign the guard to a variable, \
+otherwise it is equivalent to `GitCancellationToken::cancel()`"]
+    pub fn cancel_on_drop(self) -> GitCancelOnDrop {
+        GitCancelOnDrop(self)
+    }
+
+    /// Cancel the git operation.
+    pub fn cancel(&self) {
+        self.0.store(true, Relaxed)
+    }
+
+    pub(super) fn get_atomic(&self) -> &AtomicBool {
+        &self.0
+    }
+}
+
+/// Guard used to cancel git operation on drop
+#[derive(Debug, destructure)]
+pub struct GitCancelOnDrop(GitCancellationToken);
+
+impl Drop for GitCancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel()
+    }
+}
+impl GitCancelOnDrop {
+    /// Disarm the guard, return the token.
+    pub fn disarm(self) -> GitCancellationToken {
+        self.destructure().0
+    }
+}

--- a/crates/binstalk-downloader/src/git/progress_tracing.rs
+++ b/crates/binstalk-downloader/src/git/progress_tracing.rs
@@ -27,7 +27,7 @@ const SEP: &str = "::";
 
 impl TracingProgress {
     /// Create a new instanCompactce from `name`.
-    pub fn new(name: CompactString) -> Self {
+    pub fn new(name: &str) -> Self {
         let trigger = Arc::new(AtomicBool::new(true));
         tokio::spawn({
             let mut interval = time::interval(Duration::from_secs_f32(EMIT_LOG_EVERY_S));
@@ -43,7 +43,7 @@ impl TracingProgress {
             }
         });
         Self {
-            name,
+            name: CompactString::new(name),
             id: UNKNOWN,
             max: None,
             step: 0,


### PR DESCRIPTION
To make sure users can cancel git operation via signal, e.g. when the git operation fail or users no longer want to install.