### PR TITLE
Refactor: Extract new crate `binstalk-registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,8 +246,8 @@ version = "0.15.0"
 dependencies = [
  "async-trait",
  "atomic-file-install",
- "base16",
  "binstalk-downloader",
+ "binstalk-registry",
  "binstalk-types",
  "cargo-toml-workspace",
  "command-group",
@@ -264,18 +264,13 @@ dependencies = [
  "normalize-path",
  "once_cell",
  "semver",
- "serde",
- "serde_json",
- "sha2",
  "strum",
  "target-lexicon",
  "tempfile",
  "thiserror",
  "tokio",
- "toml_edit",
  "tracing",
  "url",
- "xz2",
 ]
 
 [[package]]
@@ -332,6 +327,32 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml_edit",
+ "url",
+]
+
+[[package]]
+name = "binstalk-registry"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "base16",
+ "binstalk-downloader",
+ "binstalk-types",
+ "cargo-toml-workspace",
+ "compact_str",
+ "leon",
+ "miette",
+ "normalize-path",
+ "once_cell",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "toml_edit",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/atomic-file-install",
     "crates/bin",
     "crates/binstalk",
+    "crates/binstalk-registry",
     "crates/binstalk-manifests",
     "crates/binstalk-types",
     "crates/binstalk-downloader",

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -8,10 +8,10 @@ use std::{
 };
 
 use binstalk::{
-    drivers::Registry,
     helpers::remote,
     manifests::cargo_toml_binstall::PkgFmt,
     ops::resolve::{CrateName, VersionReqExt},
+    registry::Registry,
 };
 use clap::{error::ErrorKind, CommandFactory, Parser, ValueEnum};
 use compact_str::CompactString;
@@ -102,7 +102,7 @@ pub struct Args {
     ///
     /// This option cannot be used with `--manifest-path`.
     #[clap(help_heading = "Overrides", long, conflicts_with("manifest_path"))]
-    pub(crate) git: Option<binstalk::drivers::GitUrl>,
+    pub(crate) git: Option<binstalk::registry::GitUrl>,
 
     /// Override Cargo.toml package manifest bin-dir.
     #[clap(help_heading = "Overrides", long)]

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -37,6 +37,7 @@ const MAX_RETRY_DURATION: Duration = Duration::from_secs(120);
 const MAX_RETRY_COUNT: u8 = 3;
 const DEFAULT_RETRY_DURATION_FOR_RATE_LIMIT: Duration = Duration::from_millis(200);
 const RETRY_DURATION_FOR_TIMEOUT: Duration = Duration::from_millis(200);
+#[allow(dead_code)]
 const DEFAULT_MIN_TLS: TLSVersion = TLSVersion::TLS_1_2;
 
 #[derive(Debug, ThisError)]

--- a/crates/binstalk-registry/Cargo.toml
+++ b/crates/binstalk-registry/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "binstalk-registry"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.65.0"
+
+description = "The binstall toolkit for fetching package from arbitrary registry"
+repository = "https://github.com/cargo-bins/cargo-binstall"
+documentation = "https://docs.rs/binstalk-registry"
+authors = ["Jiahao_XU@outlook <Jiahao_XU@outlook.com>"]
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+async-trait = "0.1.68"
+base16 = "0.2.1"
+binstalk-downloader = { version = "0.7.0", path = "../binstalk-downloader", default-features = false, features = ["json"] }
+binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
+cargo-toml-workspace = { version = "0.0.0", path = "../cargo-toml-workspace" }
+compact_str = { version = "0.7.0", features = ["serde"] }
+leon = { version = "2.0.1", path = "../leon" }
+miette = "5.9.0"
+normalize-path = { version = "0.2.1", path = "../normalize-path" }
+once_cell = "1.18.0"
+semver = { version = "1.0.17", features = ["serde"] }
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.99"
+sha2 = "0.10.7"
+tempfile = "3.5.0"
+thiserror = "1.0.40"
+tokio = { version = "1.30.0", features = ["rt", "sync", "time"], default-features = false }
+tracing = "0.1.37"
+url = "2.3.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+toml_edit = { version = "0.19.11", features = ["serde"] }
+
+[features]
+git = ["binstalk-downloader/git"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/binstalk-registry/LICENSE-APACHE
+++ b/crates/binstalk-registry/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/crates/binstalk-registry/LICENSE-MIT
+++ b/crates/binstalk-registry/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/binstalk-registry/src/sparse_registry.rs
+++ b/crates/binstalk-registry/src/sparse_registry.rs
@@ -1,3 +1,6 @@
+use binstalk_downloader::remote::{Client, Error as RemoteError};
+use binstalk_types::cargo_toml_binstall::Meta;
+use cargo_toml_workspace::cargo_toml::Manifest;
 use compact_str::CompactString;
 use semver::VersionReq;
 use serde_json::Deserializer as JsonDeserializer;
@@ -5,16 +8,8 @@ use tokio::sync::OnceCell;
 use url::Url;
 
 use crate::{
-    drivers::registry::{
-        crate_prefix_components, parse_manifest, render_dl_template, MatchedVersion,
-        RegistryConfig, RegistryError,
-    },
-    errors::BinstallError,
-    helpers::{
-        cargo_toml::Manifest,
-        remote::{Client, Error as RemoteError},
-    },
-    manifests::cargo_toml_binstall::Meta,
+    crate_prefix_components, parse_manifest, render_dl_template, MatchedVersion, RegistryConfig,
+    RegistryError,
 };
 
 #[derive(Debug)]
@@ -53,7 +48,7 @@ impl SparseRegistry {
         crate_name: &str,
         (c1, c2): &(CompactString, Option<CompactString>),
         version_req: &VersionReq,
-    ) -> Result<MatchedVersion, BinstallError> {
+    ) -> Result<MatchedVersion, RegistryError> {
         {
             let mut path = url.path_segments_mut().unwrap();
 
@@ -87,7 +82,7 @@ impl SparseRegistry {
         client: Client,
         crate_name: &str,
         version_req: &VersionReq,
-    ) -> Result<Manifest<Meta>, BinstallError> {
+    ) -> Result<Manifest<Meta>, RegistryError> {
         let crate_prefix = crate_prefix_components(crate_name)?;
         let dl_template = self.get_dl_template(&client).await?;
         let matched_version = Self::find_crate_matched_ver(

--- a/crates/binstalk-registry/src/vfs.rs
+++ b/crates/binstalk-registry/src/vfs.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use crate::helpers::cargo_toml::AbstractFilesystem;
+use cargo_toml_workspace::cargo_toml::AbstractFilesystem;
 use normalize_path::NormalizePath;
 
 /// This type stores the filesystem structure for the crate tarball

--- a/crates/binstalk-registry/src/visitor.rs
+++ b/crates/binstalk-registry/src/visitor.rs
@@ -1,18 +1,13 @@
 use std::path::{Path, PathBuf};
 
+use binstalk_downloader::download::{DownloadError, TarEntriesVisitor, TarEntry};
+use binstalk_types::cargo_toml_binstall::Meta;
+use cargo_toml_workspace::cargo_toml::{Manifest, Value};
 use normalize_path::NormalizePath;
 use tokio::io::AsyncReadExt;
 use tracing::debug;
 
-use super::vfs::Vfs;
-use crate::{
-    errors::BinstallError,
-    helpers::{
-        cargo_toml::{Manifest, Value},
-        download::{DownloadError, TarEntriesVisitor, TarEntry},
-    },
-    manifests::cargo_toml_binstall::Meta,
-};
+use crate::{vfs::Vfs, RegistryError};
 
 #[derive(Debug)]
 pub(super) struct ManifestVisitor {
@@ -71,7 +66,7 @@ impl TarEntriesVisitor for ManifestVisitor {
 
 impl ManifestVisitor {
     /// Load binstall metadata using the extracted information stored in memory.
-    pub(super) fn load_manifest(self) -> Result<Manifest<Meta>, BinstallError> {
+    pub(super) fn load_manifest(self) -> Result<Manifest<Meta>, RegistryError> {
         debug!("Loading manifest directly from extracted file");
 
         // Load and parse manifest

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -12,8 +12,8 @@ license = "GPL-3.0-only"
 [dependencies]
 async-trait = "0.1.68"
 atomic-file-install = { version = "0.0.0", path = "../atomic-file-install" }
-base16 = "0.2.1"
 binstalk-downloader = { version = "0.7.0", path = "../binstalk-downloader", default-features = false, features = ["gh-api-client"] }
+binstalk-registry = { version = "0.0.0", path = "../binstalk-registry" }
 binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
 cargo-toml-workspace = { version = "0.0.0", path = "../cargo-toml-workspace" }
 command-group = { version = "2.1.0", features = ["with-tokio"] }
@@ -30,9 +30,6 @@ miette = "5.9.0"
 normalize-path = { version = "0.2.1", path = "../normalize-path" }
 once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.99"
-sha2 = "0.10.7"
 strum = "0.25.0"
 target-lexicon = { version = "0.12.11", features = ["std"] }
 tempfile = "3.5.0"
@@ -40,16 +37,12 @@ thiserror = "1.0.40"
 tokio = { version = "1.30.0", features = ["rt", "process", "sync"], default-features = false }
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
-xz2 = "0.1.7"
-
-[dev-dependencies]
-toml_edit = { version = "0.19.11", features = ["serde"] }
 
 [features]
 default = ["static", "rustls", "git"]
 
-git = ["binstalk-downloader/git"]
-git-max-perf = ["binstalk-downloader/git-max-perf"]
+git = ["binstalk-registry/git"]
+git-max-perf = ["git", "binstalk-downloader/git-max-perf"]
 
 static = ["binstalk-downloader/static"]
 pkg-config = ["binstalk-downloader/pkg-config"]

--- a/crates/binstalk/src/drivers.rs
+++ b/crates/binstalk/src/drivers.rs
@@ -1,8 +1,0 @@
-mod registry;
-pub use registry::{
-    fetch_crate_cratesio, CratesIoRateLimit, InvalidRegistryError, Registry, RegistryError,
-    SparseRegistry,
-};
-
-#[cfg(feature = "git")]
-pub use registry::{GitRegistry, GitUrl, GitUrlParseError};

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -15,10 +15,10 @@ use tokio::task;
 use tracing::{error, warn};
 
 use crate::{
-    drivers::{InvalidRegistryError, RegistryError},
     helpers::{
         cargo_toml::Error as CargoTomlError, cargo_toml_workspace::Error as LoadManifestFromWSError,
     },
+    registry::{InvalidRegistryError, RegistryError},
 };
 
 #[derive(Debug, Error)]
@@ -198,18 +198,6 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::version::parse))]
     VersionParse(#[from] Box<VersionParseError>),
 
-    /// No available version matches the requirements.
-    ///
-    /// This may be the case when using the `--version` option.
-    ///
-    /// Note that using `--version 1.2.3` is interpreted as the requirement `=1.2.3`.
-    ///
-    /// - Code: `binstall::version::mismatch`
-    /// - Exit: 82
-    #[error("no version matching requirement '{req}'")]
-    #[diagnostic(severity(error), code(binstall::version::mismatch))]
-    VersionMismatch { req: semver::VersionReq },
-
     /// The crate@version syntax was used at the same time as the --version option.
     ///
     /// You can't do that as it's ambiguous which should apply.
@@ -374,7 +362,6 @@ impl BinstallError {
             CargoManifest { .. } => 78,
             RegistryParseError(..) => 79,
             VersionParse { .. } => 80,
-            VersionMismatch { .. } => 82,
             SuperfluousVersionOption => 84,
             UnspecifiedBinaries => 86,
             NoViableTargets => 87,

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -4,8 +4,8 @@ pub mod remote;
 pub(crate) mod target_triple;
 pub mod tasks;
 
+pub(crate) use binstalk_downloader::download;
 pub use binstalk_downloader::gh_api_client;
-pub(crate) use binstalk_downloader::{bytes, download};
 
 #[cfg(feature = "git")]
 pub(crate) use binstalk_downloader::git;

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod bins;
-pub mod drivers;
 pub mod errors;
 pub mod fetchers;
 pub mod helpers;
 pub mod ops;
 
 use atomic_file_install as fs;
+pub use binstalk_registry as registry;
 pub use binstalk_types as manifests;
 pub use detect_targets::{get_desired_targets, DesiredTargets, TARGET};
 pub use home;

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -5,12 +5,12 @@ use std::{path::PathBuf, sync::Arc};
 use semver::VersionReq;
 
 use crate::{
-    drivers::Registry,
     fetchers::{Data, Fetcher, TargetData},
     helpers::{
         self, gh_api_client::GhApiClient, jobserver_client::LazyJobserverClient, remote::Client,
     },
     manifests::cargo_toml_binstall::PkgOverride,
+    registry::Registry,
     DesiredTargets,
 };
 


### PR DESCRIPTION
To speedup codegen of `binstalk` and enable it to be reused.