### PR TITLE
Refactor: Extract new crate `binstalk-bins`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 name = "binstalk"
 version = "0.15.0"
 dependencies = [
- "atomic-file-install",
+ "binstalk-bins",
  "binstalk-downloader",
  "binstalk-fetchers",
  "binstalk-registry",
@@ -254,13 +254,11 @@ dependencies = [
  "compact_str",
  "detect-targets",
  "either",
- "home",
  "itertools",
  "jobslot",
  "leon",
  "maybe-owned",
  "miette",
- "normalize-path",
  "semver",
  "strum",
  "target-lexicon",
@@ -269,6 +267,20 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "binstalk-bins"
+version = "0.0.0"
+dependencies = [
+ "atomic-file-install",
+ "binstalk-types",
+ "compact_str",
+ "leon",
+ "miette",
+ "normalize-path",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -520,6 +532,7 @@ dependencies = [
  "file-format",
  "fs-lock",
  "gh-token",
+ "home",
  "log",
  "miette",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/atomic-file-install",
     "crates/bin",
     "crates/binstalk",
+    "crates/binstalk-bins",
     "crates/binstalk-fetchers",
     "crates/binstalk-registry",
     "crates/binstalk-manifests",

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5.0.1"
 file-format = { version = "0.18.0", default-features = false }
 fs-lock = { version = "0.1.0", path = "../fs-lock" }
 gh-token = "0.1.2"
+home = "0.5.5"
 log = { version = "0.4.18", features = ["std"] }
 miette = "5.9.0"
 mimalloc = { version = "0.1.37", default-features = false, optional = true }

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -15,7 +15,6 @@ use binstalk::{
         remote::{Certificate, Client},
         tasks::AutoAbortJoinHandle,
     },
-    home::cargo_home,
     ops::{
         self,
         resolve::{CrateName, Resolution, ResolutionFetch, VersionReqExt},
@@ -25,6 +24,7 @@ use binstalk::{
 use binstalk_manifests::cargo_config::Config;
 use binstalk_manifests::cargo_toml_binstall::PkgOverride;
 use file_format::FileFormat;
+use home::cargo_home;
 use log::LevelFilter;
 use miette::{miette, Result, WrapErr};
 use tokio::task::block_in_place;

--- a/crates/bin/src/logging.rs
+++ b/crates/bin/src/logging.rs
@@ -196,6 +196,7 @@ pub fn logging(log_level: LevelFilter, json_output: bool) {
     let allowed_targets = (log_level != LevelFilter::Trace).then_some([
         "atomic_file_install",
         "binstalk",
+        "binstalk_bins",
         "binstalk_downloader",
         "binstalk_fetchers",
         "binstalk_registry",

--- a/crates/binstalk-bins/Cargo.toml
+++ b/crates/binstalk-bins/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "binstalk-bins"
+version = "0.0.0"
+edition = "2021"
+
+description = "The binstall binaries discovery and installation crate."
+repository = "https://github.com/cargo-bins/cargo-binstall"
+documentation = "https://docs.rs/binstalk-bins"
+rust-version = "1.65.0"
+authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
+license = "GPL-3.0-only"
+
+[dependencies]
+atomic-file-install = { version = "0.0.0", path = "../atomic-file-install" }
+binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
+compact_str = { version = "0.7.0", features = ["serde"] }
+leon = { version = "2.0.1", path = "../leon" }
+miette = "5.9.0"
+normalize-path = { version = "0.2.1", path = "../normalize-path" }
+thiserror = "1.0.40"
+tracing = "0.1.37"

--- a/crates/binstalk-fetchers/Cargo.toml
+++ b/crates/binstalk-fetchers/Cargo.toml
@@ -17,7 +17,7 @@ binstalk-types = { version = "0.5.0", path = "../binstalk-types" }
 compact_str = { version = "0.7.0" }
 either = "1.8.1"
 itertools = "0.11.0"
-leon = { version = "2.0.1", path = "../leon", features = ["miette"] }
+leon = { version = "2.0.1", path = "../leon" }
 leon-macros = { version = "1.0.0", path = "../leon-macros" }
 miette = "5.9.0"
 once_cell = "1.18.0"

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 license = "GPL-3.0-only"
 
 [dependencies]
-atomic-file-install = { version = "0.0.0", path = "../atomic-file-install" }
+binstalk-bins = { version = "0.0.0", path = "../binstalk-bins" }
 binstalk-downloader = { version = "0.7.0", path = "../binstalk-downloader", default-features = false, features = ["gh-api-client"] }
 binstalk-fetchers = { version = "0.0.0", path = "../binstalk-fetchers" }
 binstalk-registry = { version = "0.0.0", path = "../binstalk-registry" }
@@ -20,13 +20,11 @@ command-group = { version = "2.1.0", features = ["with-tokio"] }
 compact_str = { version = "0.7.0", features = ["serde"] }
 detect-targets = { version = "0.1.10", path = "../detect-targets" }
 either = "1.8.1"
-home = "0.5.5"
 itertools = "0.11.0"
 jobslot = { version = "0.2.11", features = ["tokio"] }
 leon = { version = "2.0.1", path = "../leon" }
 maybe-owned = "0.3.4"
 miette = "5.9.0"
-normalize-path = { version = "0.2.1", path = "../normalize-path" }
 semver = { version = "1.0.17", features = ["serde"] }
 strum = "0.25.0"
 target-lexicon = { version = "0.12.11", features = ["std"] }

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -1,13 +1,11 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-mod bins;
 pub mod errors;
 pub mod helpers;
 pub mod ops;
 
-use atomic_file_install as fs;
+use binstalk_bins as bins;
 pub use binstalk_fetchers as fetchers;
 pub use binstalk_registry as registry;
 pub use binstalk_types as manifests;
 pub use detect_targets::{get_desired_targets, DesiredTargets, TARGET};
-pub use home;

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -51,7 +51,7 @@ impl Resolution {
 
 impl ResolutionFetch {
     pub fn install(self, opts: &Options) -> Result<CrateInfo, BinstallError> {
-        type InstallFp = fn(&bins::BinFile) -> Result<(), BinstallError>;
+        type InstallFp = fn(&bins::BinFile) -> Result<(), bins::Error>;
 
         let (install_bin, install_link): (InstallFp, InstallFp) = match (opts.no_track, opts.force)
         {

--- a/e2e-tests/no-track.sh
+++ b/e2e-tests/no-track.sh
@@ -18,8 +18,8 @@ exit_code="$?"
 
 set -e
 
-if [ "$exit_code" != 74 ]; then
-    echo "Expected exit code 74 Io Error, but actual exit code $exit_code"
+if [ "$exit_code" != 88 ]; then
+    echo "Expected exit code 88 BinFile Error, but actual exit code $exit_code"
     exit 1
 fi
 


### PR DESCRIPTION
To reduce `binstalk` codegen and enable reuse of it.