### PR TITLE
Fix `binstalk-downloader` feature activation

### DIFF
--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -21,7 +21,7 @@ derive_destructure2 = "0.1"
 flate2 = { version = "1.0.26", default-features = false }
 futures-util = "0.3.28"
 generic-array = "0.14.7"
-gix = { version = "0.51.0", features = ["blocking-http-transport-reqwest-rust-tls"], optional = true }
+gix = { version = "0.51.0", features = ["blocking-http-transport-reqwest"], optional = true }
 httpdate = "1.0.2"
 reqwest = { version = "0.11.18", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
 percent-encoding = "2.2.0"
@@ -76,8 +76,16 @@ rustls = [
     # trust-dns-resolver currently supports https with rustls
     "trust-dns-resolver?/dns-over-https-rustls",
     "trust-dns-resolver?/dns-over-quic",
+
+    "gix?/blocking-http-transport-reqwest-rust-tls",
 ]
-native-tls = ["__tls", "reqwest/native-tls", "trust-dns-resolver?/dns-over-native-tls"]
+native-tls = [
+    "__tls",
+    "reqwest/native-tls",
+    "trust-dns-resolver?/dns-over-native-tls",
+
+    "gix?/blocking-http-transport-reqwest-native-tls",
+]
 
 # Enable trust-dns-resolver so that features on it will also be enabled.
 trust-dns = ["trust-dns-resolver", "reqwest/trust-dns"]


### PR DESCRIPTION
Fix use of `native-tls` and `git`, make sure that `gix` actually uses `native-tls` in this scenario.