### PR TITLE
`binstalk-registry`: Rm rate-limit for crates.io registry

### DIFF
--- a/crates/binstalk-registry/Cargo.toml
+++ b/crates/binstalk-registry/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.99"
 sha2 = "0.10.7"
 tempfile = "3.5.0"
 thiserror = "1.0.40"
-tokio = { version = "1.30.0", features = ["rt", "sync", "time"], default-features = false }
+tokio = { version = "1.30.0", features = ["rt", "sync"], default-features = false }
 tracing = "0.1.37"
 url = "2.3.1"
 


### PR DESCRIPTION
Fixed #1295

The 1 request per second rate-limit is too strict and it makes `cargo-binstall` very slow when resolving many crates in parallel.

Relying on the rate-limit in `binstalk_downloader::remote::Client` should be good enough.