### PR TITLE
binstalk-registry: Use crates.io sparse index by default

### DIFF
--- a/crates/binstalk-registry/Cargo.toml
+++ b/crates/binstalk-registry/Cargo.toml
@@ -35,9 +35,12 @@ url = "2.3.1"
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml_edit = { version = "0.19.11", features = ["serde"] }
+binstalk-downloader = { version = "0.7.0", path = "../binstalk-downloader", default-features = false, features = ["rustls"] }
 
 [features]
 git = ["simple-git"]
+
+crates_io_api = []
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/binstalk-registry/src/crates_io_registry.rs
+++ b/crates/binstalk-registry/src/crates_io_registry.rs
@@ -105,7 +105,7 @@ async fn fetch_crate_cratesio_version_matched(
 
 /// Find the crate by name, get its latest stable version matches `version_req`,
 /// retrieve its Cargo.toml and infer all its bins.
-pub async fn fetch_crate_cratesio(
+pub async fn fetch_crate_cratesio_api(
     client: Client,
     name: &str,
     version_req: &VersionReq,


### PR DESCRIPTION
Fixed #1310

Also add rename `fetch_crate_cratesio` => `fetch_crate_cratesio_api` and put it behind a new feature `crates_io_api`.