### PR TITLE
ci: Fix `release.yml` being cancelled due to `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      additional_key:
+        required: true
+        type: string
+        default: ""
   merge_group:
   pull_request:
     types:
@@ -17,7 +22,7 @@ on:
       - SUPPORT.md
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}-${{ inputs.additional_key }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     if: needs.info.outputs.is-release == 'true'
     needs: info
     uses: ./.github/workflows/ci.yml
+    with:
+      additional_key: ${{ github.run_id }}
 
   tag:
     if: needs.info.outputs.is-release == 'true'


### PR DESCRIPTION
Add a unique value to `concurrency.group` in `ci.yml` to prevent it from being cancelled when releasing crates.