### PR TITLE
Use resolver 2 for cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "crates/atomic-file-install",
     "crates/bin",


### PR DESCRIPTION
Since some of our dependencies still uses edition 2018, we need to explicitly specify the resolver.