### PR TITLE
Fixed binstalk-downloader docs.rs build

### DIFF
--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -92,5 +92,5 @@ gh-api-client = ["json"]
 json = ["serde", "serde_json"]
 
 [package.metadata.docs.rs]
-features = ["gh-api-client", "git"]
+features = ["gh-api-client"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Feature git is removed from binstalk-downloader, however we still enable it on docs.rs build.