### PR TITLE
Fix GitHub token auto discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,6 @@ dependencies = [
  "dirs",
  "embed-resource",
  "file-format",
- "gh-token",
  "home",
  "log",
  "miette",
@@ -1167,18 +1166,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "gh-token"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29796559a0962994fcc5994ff97a18e68618508d3f0d8de794475a5045caf09"
-dependencies = [
- "home",
- "serde",
- "serde_derive",
- "serde_yaml",
 ]
 
 [[package]]
@@ -3364,19 +3351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
-dependencies = [
- "indexmap 2.0.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,12 +4001,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -28,7 +28,6 @@ clap = { version = "4.3.0", features = ["derive", "env"] }
 compact_str = "0.7.0"
 dirs = "5.0.1"
 file-format = { version = "0.19.0", default-features = false }
-gh-token = "0.1.2"
 home = "0.5.5"
 log = { version = "0.4.18", features = ["std"] }
 miette = "5.9.0"

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -538,12 +538,6 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
     if opts.github_token.is_none() {
         if let Ok(github_token) = env::var("GH_TOKEN") {
             opts.github_token = Some(github_token.into());
-        } else if !opts.no_discover_github_token {
-            if let Some(github_token) = crate::git_credentials::try_from_home() {
-                opts.github_token = Some(github_token);
-            } else if let Ok(github_token) = gh_token::get() {
-                opts.github_token = Some(github_token.into());
-            }
         }
     }
 

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -1,0 +1,41 @@
+use std::{io, process};
+
+use compact_str::CompactString;
+use tracing::warn;
+
+fn get_inner() -> io::Result<CompactString> {
+    let process::Output { status, stdout, .. } = process::Command::new("gh")
+        .args(["auth", "token"])
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::null())
+        .output()?;
+
+    if !status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Failed to execute `gh auth token`, exit status `{status}`"),
+        ));
+    }
+
+    // Use String here instead of CompactString here since
+    // `CompactString::from_utf8` allocates if it's longer than 24B.
+    let s = String::from_utf8(stdout).map_err(|_err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Invalid token: expected ASCII"),
+        )
+    })?;
+
+    Ok(s.trim().into())
+}
+
+pub(super) fn get() -> Option<CompactString> {
+    match get_inner() {
+        Ok(token) => Some(token),
+        Err(err) => {
+            warn!(?err);
+            None
+        }
+    }
+}

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -21,7 +21,10 @@ fn get_inner() -> io::Result<CompactString> {
     // Use String here instead of CompactString here since
     // `CompactString::from_utf8` allocates if it's longer than 24B.
     let s = String::from_utf8(stdout).map_err(|_err| {
-        io::Error::new(io::ErrorKind::InvalidData, "Invalid token: expected ASCII")
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Invalid output from `gh auth token`: expected ASCII",
+        )
     })?;
 
     Ok(s.trim().into())

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -21,10 +21,7 @@ fn get_inner() -> io::Result<CompactString> {
     // Use String here instead of CompactString here since
     // `CompactString::from_utf8` allocates if it's longer than 24B.
     let s = String::from_utf8(stdout).map_err(|_err| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Invalid token: expected ASCII"),
-        )
+        io::Error::new(io::ErrorKind::InvalidData, "Invalid token: expected ASCII")
     })?;
 
     Ok(s.trim().into())

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -14,17 +14,14 @@ fn get_inner() -> io::Result<CompactString> {
     if !status.success() {
         return Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("Failed to execute `gh auth token`, exit status `{status}`"),
+            format!("process exited with `{status}`"),
         ));
     }
 
     // Use String here instead of CompactString here since
     // `CompactString::from_utf8` allocates if it's longer than 24B.
     let s = String::from_utf8(stdout).map_err(|_err| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            "Invalid output from `gh auth token`: expected ASCII",
-        )
+        io::Error::new(io::ErrorKind::InvalidData, "Invalid output, expected utf8")
     })?;
 
     Ok(s.trim().into())
@@ -34,7 +31,7 @@ pub(super) fn get() -> Option<CompactString> {
     match get_inner() {
         Ok(token) => Some(token),
         Err(err) => {
-            warn!(?err);
+            warn!(?err, "Failed to retrieve token from `gh auth token`");
             None
         }
     }

--- a/crates/bin/src/lib.rs
+++ b/crates/bin/src/lib.rs
@@ -3,6 +3,7 @@
 mod args;
 mod bin_util;
 mod entry;
+mod gh_token;
 mod git_credentials;
 mod install_path;
 mod logging;

--- a/crates/binstalk-downloader/src/gh_api_client.rs
+++ b/crates/binstalk-downloader/src/gh_api_client.rs
@@ -132,21 +132,19 @@ struct Inner {
 #[derive(Clone, Debug)]
 pub struct GhApiClient(Arc<Inner>);
 
-fn is_ascii_alphanumeric(s: Option<&str>) -> bool {
-    if let Some(s) = s {
-        s.as_bytes().iter().all(|byte| byte.is_ascii_alphanumeric())
-    } else {
-        true
-    }
+fn is_ascii_alphanumeric(s: &[u8]) -> bool {
+    s.iter().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 fn is_valid_gh_token(token: &str) -> bool {
+    let token = token.as_bytes();
+
     token.len() >= 40
-        && ((token.get(0..2) == Some("gh")
-            && is_ascii_alphanumeric(token.get(2..3))
-            && token.get(3..4) == Some("_")
-            && is_ascii_alphanumeric(token.get(4..)))
-            || (token.starts_with("github_") && is_ascii_alphanumeric(token.get(7..))))
+        && ((&token[0..2] == b"gh"
+            && token[2].is_ascii_alphanumeric()
+            && token[3] == b'_'
+            && is_ascii_alphanumeric(&token[4..]))
+            || (token.starts_with(b"github_") && is_ascii_alphanumeric(&token[7..])))
 }
 
 impl GhApiClient {

--- a/crates/binstalk-downloader/src/gh_api_client.rs
+++ b/crates/binstalk-downloader/src/gh_api_client.rs
@@ -134,7 +134,7 @@ pub struct GhApiClient(Arc<Inner>);
 
 fn is_ascii_alphanumeric(s: Option<&str>) -> bool {
     if let Some(s) = s {
-        s.as_bytes().all(|byte| byte.is_ascii_alphanumeric())
+        s.as_bytes().iter().all(|byte| byte.is_ascii_alphanumeric())
     } else {
         true
     }
@@ -146,7 +146,7 @@ fn is_valid_gh_token(token: &str) -> bool {
             && is_ascii_alphanumeric(token.get(2..3))
             && token.get(3..4) == Some("_")
             && is_ascii_alphanumeric(token.get(4..)))
-            || (token.starts_with("github_") && is_valid_gh_(token.get(7..))))
+            || (token.starts_with("github_") && is_ascii_alphanumeric(token.get(7..))))
 }
 
 impl GhApiClient {


### PR DESCRIPTION
Fixed #1333

 - Rm dep `gh-token` since it is broken and we can simply run `gh auth token` in `cargo-binstall` instead.
 - binstalk-downloader: Make sure GitHub token is at least 40B long and other than the `_`, composes of only alphanumeric characters.
 - Warn on failure to read `git/credential` files
 - Optimize `try_from_home` to avoid heap allocation of `PathBuf`