### PR TITLE
feat: Improve resolution logging and verbose logging

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -422,15 +422,17 @@ pub fn parse() -> Args {
     // Load options
     let mut opts = Args::parse_from(args);
 
-    if let (true, Some(log)) = (
-        opts.log_level.is_none(),
-        env::var("BINSTALL_LOG_LEVEL")
+    if opts.log_level.is_none() {
+        if let Some(log) = env::var("BINSTALL_LOG_LEVEL")
             .ok()
-            .and_then(|s| s.parse().ok()),
-    ) {
-        opts.log_level = Some(log);
-    } else if opts.quiet {
-        opts.log_level = Some(LevelFilter::Off);
+            .and_then(|s| s.parse().ok())
+        {
+            opts.log_level = Some(log);
+        } else if opts.quiet {
+            opts.log_level = Some(LevelFilter::Off);
+        } else if opts.verbose {
+            opts.log_level = Some(LevelFilter::Debug);
+        }
     }
 
     // Ensure no conflict

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -318,14 +318,15 @@ pub struct Args {
     #[clap(help_heading = "Meta", long, value_name = "LEVEL")]
     pub log_level: Option<LevelFilter>,
 
-    /// Used with `--version` to print out verbose information.
-    #[clap(help_heading = "Meta", short, long, default_value_t = false)]
+    /// Implies `--log-level debug` and it can also be used with `--version`
+    /// to print out verbose information,
+    #[clap(help_heading = "Meta", short, long)]
     pub verbose: bool,
 
     /// Equivalent to setting `log_level` to `off`.
     ///
     /// This would override the `log_level`.
-    #[clap(help_heading = "Meta", short, long)]
+    #[clap(help_heading = "Meta", short, long, conflicts_with("verbose"))]
     pub(crate) quiet: bool,
 }
 

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -93,15 +93,15 @@ impl ResolutionFetch {
         let bin_files = &self.bin_files;
         let name = &self.name;
         let new_version = &self.new_version;
+        let target = fetcher.target();
 
         debug!(
-            "Found a binary install source: {} ({})",
+            "Found a binary install source: {} ({target})",
             fetcher.source_name(),
-            fetcher.target()
         );
 
         warn!(
-            "The package {name} v{new_version} will be downloaded from {}{}",
+            "The package {name} v{new_version} ({target}) has been downloaded from {}{}",
             if fetcher.is_third_party() {
                 "third-party source "
             } else {


### PR DESCRIPTION
Fixed https://github.com/cargo-bins/cargo-binstall/issues/1336

 - Log target of the pre-built binaries which will be installed
 - Fix args parsing: quiet & verbose cannot be set at the same time
 - feat: Implies `--log-level debug` if `--verbose` is set