### PR TITLE
Fix `detect-targets` on Linux and add CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,11 +138,7 @@ jobs:
       TARGET: x86_64-unknown-linux-musl
     steps:
     - uses: actions/checkout@v3
-    - uses: ./.github/actions/just-setup
-      env:
-        # just-setup use binstall to install sccache,
-        # which works better when we provide it with GITHUB_TOKEN.
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: Swatinem/rust-cache@v2
     - name: Build detect-targets
       run: |
         pip3 install -r zigbuild-requirements.txt
@@ -158,11 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ./.github/actions/just-setup
-      env:
-        # just-setup use binstall to install sccache,
-        # which works better when we provide it with GITHUB_TOKEN.
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: Swatinem/rust-cache@v2
     - name: Build detect-targets
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,12 +161,6 @@ jobs:
       run: |
         set -exuo pipefail
         [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
-    - name: Install musl on ubuntu
-      run: apt update && apt install musl
-    - name: Run test in ubuntu with musl
-      run: |
-        set -exuo pipefail
-        [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,11 +138,13 @@ jobs:
       TARGET: x86_64-unknown-linux-musl
     steps:
     - uses: actions/checkout@v3
+    - name: Install x86_64-unknown-linux-musl target
+      run: rustup target add $TARGET
     - uses: Swatinem/rust-cache@v2
     - name: Build detect-targets
       run: |
         pip3 install -r zigbuild-requirements.txt
-        cargo zigbuild --bin detect-targets --target $TARGET
+        cd crates/detect-targets && cargo zigbuild --target $TARGET
     - name: Run test in alpine
       run: |
         docker run --rm \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,6 @@ jobs:
         pip3 install -r zigbuild-requirements.txt
         cargo zigbuild --bin detect-targets --target $TARGET
     - name: Run test in alpine
-      shell: bash -exuo pipefail
       run: |
         docker run --rm \
           --mount src="$PWD/target/$TARGET/debug/detect-targets",dst=/usr/local/bin/detect-targets,type=bind \
@@ -168,7 +167,7 @@ jobs:
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu
       run: |
-        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
+        [ "$(detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
     - name: Install musl on ubuntu
       run: apt update && apt install musl
     - name: Run test in ubuntu with musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,31 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: no
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
 
+  detect-targets-test:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+      TARGET: x86_64-unknown-linux-musl
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/just-setup
+      with:
+        tools: cargo-hack
+      env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build detect-targets
+      run: |
+        pip3 install -r zigbuild-requirements.txt
+        cargo zigbuild --bin detect-targets --target $TARGET
+    - name: Run test in alpine
+      run: |
+        docker run --rm \
+          --mount src="$PWD/target/$TARGET/debug/detect-targets",dst=/usr/local/bin/detect-targets,type=bind \
+          --mount src="$PWD/test-detect-targets-musl.sh",dst=/usr/local/bin/test.sh,type=bind \
+          alpine test.sh $TARGET
+
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:
     name: Tests pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,12 @@ jobs:
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu
       run: |
-        [ "$(detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
+        [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
     - name: Install musl on ubuntu
       run: apt update && apt install musl
     - name: Run test in ubuntu with musl
       run: |
-        [ "$(detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
+        [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,13 @@ jobs:
     - name: Run test in ubuntu
       shell: bash -exuo pipefail
       run: |
-        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu aarch64-unknown-linux-musl)" ]
+        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
+    - name: Install musl on ubuntu
+      run: apt update && apt install musl
+    - name: Run test in ubuntu with musl
+      shell: bash -exuo pipefail
+      run: |
+        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu x86_64-ubuntu-linux-musl x86_64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     - name: Run test in ubuntu with musl
       shell: bash -exuo pipefail
       run: |
-        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu x86_64-ubuntu-linux-musl x86_64-unknown-linux-musl)" ]
+        [ "$(detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: no
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
 
-  detect-targets-test:
+  detect-targets-alpine-test:
     runs-on: ubuntu-latest
     env:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
@@ -139,8 +139,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/just-setup
-      with:
-        tools: cargo-hack
       env:
         # just-setup use binstall to install sccache,
         # which works better when we provide it with GITHUB_TOKEN.
@@ -150,11 +148,28 @@ jobs:
         pip3 install -r zigbuild-requirements.txt
         cargo zigbuild --bin detect-targets --target $TARGET
     - name: Run test in alpine
+      shell: bash -exuo pipefail
       run: |
         docker run --rm \
           --mount src="$PWD/target/$TARGET/debug/detect-targets",dst=/usr/local/bin/detect-targets,type=bind \
           --mount src="$PWD/test-detect-targets-musl.sh",dst=/usr/local/bin/test.sh,type=bind \
-          alpine test.sh $TARGET
+          alpine test.sh "$TARGET"
+
+  detect-targets-ubuntu-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/just-setup
+      env:
+        # just-setup use binstall to install sccache,
+        # which works better when we provide it with GITHUB_TOKEN.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build detect-targets
+      run: cargo build --bin detect-targets
+    - name: Run test in ubuntu
+      shell: bash -exuo pipefail
+      run: |
+        [ "$(detect-targets)" = "$(printf '%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu aarch64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:
@@ -164,6 +179,8 @@ jobs:
     - cross-check
     - lint
     - release-builds
+    - detect-targets-alpine-test
+    - detect-targets-ubuntu-test
     if: always() # always run even if dependencies fail
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,11 +167,13 @@ jobs:
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu
       run: |
+        set -exuo pipefail
         [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
     - name: Install musl on ubuntu
       run: apt update && apt install musl
     - name: Run test in ubuntu with musl
       run: |
+        set -exuo pipefail
         [ "$(./target/debug/detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
 
   # Dummy job to have a stable name for the "all tests pass" requirement

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,11 @@ jobs:
     - name: Build detect-targets
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu
-      shell: bash -exuo pipefail
       run: |
         [ "$(detect-targets)" = "$(printf '%s\n%s\n%s' x86_64-ubuntu-linux-gnu x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
     - name: Install musl on ubuntu
       run: apt update && apt install musl
     - name: Run test in ubuntu with musl
-      shell: bash -exuo pipefail
       run: |
         [ "$(detect-targets)" = "$(printf '%s\n%s' x86_64-unknown-linux-gnu x86_64-unknown-linux-musl)" ]
 

--- a/crates/detect-targets/Cargo.toml
+++ b/crates/detect-targets/Cargo.toml
@@ -20,3 +20,6 @@ windows-dll = { version = "0.4.1", features = ["windows"], default-features = fa
 
 [dev-dependencies]
 tokio = { version = "1.28.2", features = ["macros"], default-features = false }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/cargo-binstall-{ target }.full.{ archive-format }"

--- a/crates/detect-targets/src/detect.rs
+++ b/crates/detect-targets/src/detect.rs
@@ -38,19 +38,21 @@ pub async fn detect_targets() -> Vec<String> {
             .to_string()
     });
 
-    let mut targets = vec![target];
-
     cfg_if! {
         if #[cfg(target_os = "macos")] {
+            let mut targets = vec![target];
             targets.extend(macos::detect_alternative_targets(&targets[0]).await);
+            targets
         } else if #[cfg(target_os = "windows")] {
+            let mut targets = vec![target];
             targets.extend(windows::detect_alternative_targets(&targets[0]));
+            targets
         } else if #[cfg(target_os = "linux")] {
-            targets.extend(linux::detect_alternative_targets(&targets[0]).await);
+            // Linux is a bit special, since the result from `guess_host_triple`
+            // might be wrong about whether glibc or musl is used.
+            linux::detect_targets(target).await
         }
     }
-
-    targets
 }
 
 /// Figure out what the host target is using `rustc`.

--- a/crates/detect-targets/src/detect/linux.rs
+++ b/crates/detect-targets/src/detect/linux.rs
@@ -39,9 +39,9 @@ pub(super) async fn detect_targets(target: String) -> Vec<String> {
             let cpu_arch_suffix = cpu_arch.replace('_', "-");
 
             let handles: Vec<_> = [
-                format!("/lib/ld-linux-{cpu_arch_suffix}.so.1"),
-                format!("/lib/{cpu_arch}-linux-gnu/ld-linux-{cpu_arch_suffix}.so.1"),
-                format!("/usr/lib/{cpu_arch}-linux-gnu/ld-linux-{cpu_arch_suffix}.so.1"),
+                format!("/lib/ld-linux-{cpu_arch_suffix}.so.2"),
+                format!("/lib/{cpu_arch}-linux-gnu/ld-linux-{cpu_arch_suffix}.so.2"),
+                format!("/usr/lib/{cpu_arch}-linux-gnu/ld-linux-{cpu_arch_suffix}.so.2"),
             ]
             .into_iter()
             .map(|p| AutoAbortHandle(tokio::spawn(is_gnu_ld(p))))

--- a/crates/detect-targets/src/detect/linux.rs
+++ b/crates/detect-targets/src/detect/linux.rs
@@ -105,8 +105,14 @@ async fn get_ld_flavor(cmd: &str) -> Option<Libc> {
         .await
         .ok()?;
 
+    const ALPINE_GCOMPAT: &str = r#"This is the gcompat ELF interpreter stub.
+You are not meant to run this directly.
+"#;
+
     if status.success() {
         Libc::parse(&stdout).or_else(|| Libc::parse(&stderr))
+    } else if String::from_utf8(stdout).ok().as_deref() == Some(ALPINE_GCOMPAT) {
+        Some(Libc::Gnu)
     } else {
         None
     }

--- a/crates/detect-targets/src/main.rs
+++ b/crates/detect-targets/src/main.rs
@@ -1,0 +1,17 @@
+use std::io;
+
+use detect_targets::detect_targets;
+use tokio::runtime;
+
+fn main() -> io::Result<()> {
+    let targets = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(detect_targets());
+
+    for target in targets {
+        println!("{target}");
+    }
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -211,7 +211,7 @@ print-rustflags:
     @echo "$RUSTFLAGS"
 
 build: print-env
-    {{cargo-bin}} build --bins {{cargo-build-args}}
+    {{cargo-bin}} build {{cargo-build-args}}
 
 check: print-env
     {{cargo-bin}} check {{cargo-build-args}} --profile check-only
@@ -297,8 +297,8 @@ package-prepare: build package-dir
     just get-output detect-wasi{{output-ext}} packages/prep
     -just get-output detect-wasi.dSYM packages/prep
 
-    just get-output detect-target{{output-ext}} packages/prep
-    -just get-output detect-target.dSYM packages/prep
+    just get-output detect-targets{{output-ext}} packages/prep
+    -just get-output detect-targets.dSYM packages/prep
 
 # when https://github.com/rust-lang/cargo/pull/11384 lands, we can use
 # -just get-output cargo_binstall.dwp packages/prep
@@ -311,7 +311,7 @@ package-prepare: build package-dir
     just get-output detect-wasi packages/prep
     -cp {{output-folder}}/deps/detect_wasi-*.dwp packages/prep/detect_wasi.dwp
 
-    just get-output detect-target packages/prep
+    just get-output detect-targets packages/prep
     -cp {{output-folder}}/deps/detect_target-*.dwp packages/prep/detect_target.dwp
 
 # underscored pdb name needs to remain for debuggers to find the file properly
@@ -324,7 +324,7 @@ package-prepare: build package-dir
     just get-output detect-wasi.exe packages/prep
     -just get-output deps/detect_wasi.pdb packages/prep
 
-    just get-output detect-target.exe packages/prep
+    just get-output detect-targets.exe packages/prep
     -just get-output deps/detect_target.pdb packages/prep
 
 # we don't get dSYM bundles for universal binaries; unsure if it's even a thing
@@ -344,10 +344,10 @@ lipo-prepare: package-dir
     just target=x86_64h-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64h
     lipo -create -output packages/prep/detect-wasi{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-wasi{{output-ext}}
 
-    just target=aarch64-apple-darwin get-output detect-target{{output-ext}} packages/prep/arm64
-    just target=x86_64-apple-darwin get-output detect-target{{output-ext}} packages/prep/x64
-    just target=x86_64h-apple-darwin get-output detect-target{{output-ext}} packages/prep/x64h
-    lipo -create -output packages/prep/detect-target{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-target{{output-ext}}
+    just target=aarch64-apple-darwin get-output detect-targets{{output-ext}} packages/prep/arm64
+    just target=x86_64-apple-darwin get-output detect-targets{{output-ext}} packages/prep/x64
+    just target=x86_64h-apple-darwin get-output detect-targets{{output-ext}} packages/prep/x64h
+    lipo -create -output packages/prep/detect-targets{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-targets{{output-ext}}
 
     rm -rf packages/prep/{arm64,x64,x64h}
 
@@ -384,7 +384,7 @@ repackage-lipo: package-dir
 
     lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64,x64h}/{{output-filename}}
     lipo -create -output packages/prep/detect-wasi packages/prep/{arm64,x64,x64h}/detect-wasi
-    lipo -create -output packages/prep/detect-target packages/prep/{arm64,x64,x64h}/detect-target
+    lipo -create -output packages/prep/detect-targets packages/prep/{arm64,x64,x64h}/detect-targets
 
     ./packages/prep/{{output-filename}} -vV
 

--- a/justfile
+++ b/justfile
@@ -297,6 +297,9 @@ package-prepare: build package-dir
     just get-output detect-wasi{{output-ext}} packages/prep
     -just get-output detect-wasi.dSYM packages/prep
 
+    just get-output detect-target{{output-ext}} packages/prep
+    -just get-output detect-target.dSYM packages/prep
+
 # when https://github.com/rust-lang/cargo/pull/11384 lands, we can use
 # -just get-output cargo_binstall.dwp packages/prep
 # underscored dwp name needs to remain for debuggers to find the file properly
@@ -308,6 +311,9 @@ package-prepare: build package-dir
     just get-output detect-wasi packages/prep
     -cp {{output-folder}}/deps/detect_wasi-*.dwp packages/prep/detect_wasi.dwp
 
+    just get-output detect-target packages/prep
+    -cp {{output-folder}}/deps/detect_target-*.dwp packages/prep/detect_target.dwp
+
 # underscored pdb name needs to remain for debuggers to find the file properly
 # read from deps because sometimes cargo doesn't copy the pdb to the output folder
 [windows]
@@ -317,6 +323,9 @@ package-prepare: build package-dir
 
     just get-output detect-wasi.exe packages/prep
     -just get-output deps/detect_wasi.pdb packages/prep
+
+    just get-output detect-target.exe packages/prep
+    -just get-output deps/detect_target.pdb packages/prep
 
 # we don't get dSYM bundles for universal binaries; unsure if it's even a thing
 [macos]
@@ -334,6 +343,11 @@ lipo-prepare: package-dir
     just target=x86_64-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64
     just target=x86_64h-apple-darwin get-output detect-wasi{{output-ext}} packages/prep/x64h
     lipo -create -output packages/prep/detect-wasi{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-wasi{{output-ext}}
+
+    just target=aarch64-apple-darwin get-output detect-target{{output-ext}} packages/prep/arm64
+    just target=x86_64-apple-darwin get-output detect-target{{output-ext}} packages/prep/x64
+    just target=x86_64h-apple-darwin get-output detect-target{{output-ext}} packages/prep/x64h
+    lipo -create -output packages/prep/detect-target{{output-ext}} packages/prep/{arm64,x64,x64h}/detect-target{{output-ext}}
 
     rm -rf packages/prep/{arm64,x64,x64h}
 
@@ -370,6 +384,7 @@ repackage-lipo: package-dir
 
     lipo -create -output packages/prep/{{output-filename}} packages/prep/{arm64,x64,x64h}/{{output-filename}}
     lipo -create -output packages/prep/detect-wasi packages/prep/{arm64,x64,x64h}/detect-wasi
+    lipo -create -output packages/prep/detect-target packages/prep/{arm64,x64,x64h}/detect-target
 
     ./packages/prep/{{output-filename}} -vV
 

--- a/justfile
+++ b/justfile
@@ -211,7 +211,7 @@ print-rustflags:
     @echo "$RUSTFLAGS"
 
 build: print-env
-    {{cargo-bin}} build {{cargo-build-args}}
+    {{cargo-bin}} build --bins {{cargo-build-args}}
 
 check: print-env
     {{cargo-bin}} check {{cargo-build-args}} --profile check-only

--- a/test-detect-targets-musl.sh
+++ b/test-detect-targets-musl.sh
@@ -5,15 +5,14 @@
 set -exuo pipefail
 
 TARGET=${1?}
-ALPINE_TARGET=$(echo "$TARGET" | sed 's/unknown/alpine/')
 
-[ "$(detect-targets)" = "$(printf '%s\n%s' "$ALPINE_TARGET" "$TARGET")" ]
+[ "$(detect-targets)" = "$TARGET" ]
 
 apk update
 apk add gcompat
 
 GNU_TARGET=$(echo "$TARGET" | sed 's/musl/gnu/')
 
-[ "$(detect-targets)" = "$(printf '%s\n%s\n%s' "$GNU_TARGET" "$ALPINE_TARGET" "$TARGET")" ]
+[ "$(detect-targets)" = "$(printf '%s\n%s' "$GNU_TARGET" "$TARGET")" ]
 
 echo

--- a/test-detect-targets-musl.sh
+++ b/test-detect-targets-musl.sh
@@ -1,5 +1,7 @@
 #!/bin/ash
 
+# shellcheck shell=dash
+
 set -exuo pipefail
 
 TARGET=${1?}

--- a/test-detect-targets-musl.sh
+++ b/test-detect-targets-musl.sh
@@ -1,0 +1,17 @@
+#!/bin/ash
+
+set -exuo pipefail
+
+TARGET=${1?}
+ALPINE_TARGET=$(echo "$TARGET" | sed 's/unknown/alpine/')
+
+[ "$(detect-targets)" = "$(printf '%s\n%s' "$ALPINE_TARGET" "$TARGET")" ]
+
+apk update
+apk add gcompat
+
+GNU_TARGET=$(echo "$TARGET" | sed 's/musl/gnu/')
+
+[ "$(detect-targets)" = "$(printf '%s\n%s\n%s' "$GNU_TARGET" "$ALPINE_TARGET" "$TARGET")" ]
+
+echo

--- a/test-detect-targets-musl.sh
+++ b/test-detect-targets-musl.sh
@@ -11,6 +11,8 @@ TARGET=${1?}
 apk update
 apk add gcompat
 
+ls -lsha /lib
+
 GNU_TARGET=$(echo "$TARGET" | sed 's/musl/gnu/')
 
 [ "$(detect-targets)" = "$(printf '%s\n%s' "$GNU_TARGET" "$TARGET")" ]


### PR DESCRIPTION
Fixed the bug introduced #1343

 - Fix `linux::detect_targets`: `guess_host_triple` could return gnu suffix on musl system, so always check that in `detect_targets` instead of using the target provided by `guess_host_triple`
 - Remove distro-specific targets since it breaks fallback to `cargo`
 - Fix `linux::detect_targets` on Alpine's gcompat version glibc
 - Fix `linux::detect_targets` on Ubuntu where glibc is stored in `/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2`
 - Add testing for `detect-targets`
 - Add `package.metadata.binstall` for `detect-targets`