### PR TITLE
Sign our releases

### DIFF
--- a/.github/scripts/ephemeral-gen.sh
+++ b/.github/scripts/ephemeral-gen.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+cargo binstall -y rsign2
+
+set +x
+expect <<EXP
+spawn rsign generate -f -p minisign.pub -s minisign.key
+expect "Password:"
+send -- "$SIGNING_KEY_SECRET\r"
+expect "Password (one more time):"
+send -- "$SIGNING_KEY_SECRET\r"
+expect eof
+EXP
+set -x
+
+cat >> crates/bin/Cargo.toml <<EOF
+[package.metadata.binstall.signing]
+algorithm = "minisign"
+pubkey = "$(tail -n1 minisign.pub)"
+EOF

--- a/.github/scripts/ephemeral-gen.sh
+++ b/.github/scripts/ephemeral-gen.sh
@@ -3,20 +3,14 @@
 set -euxo pipefail
 
 cargo binstall -y rsign2
-
-set +x
-expect <<EXP
-spawn rsign generate -f -p minisign.pub -s minisign.key
-expect "Password:"
-send -- "$SIGNING_KEY_SECRET\r"
-expect "Password (one more time):"
-send -- "$SIGNING_KEY_SECRET\r"
-expect eof
-EXP
-set -x
+rsign generate -f -W -p minisign.pub -s minisign.key
 
 cat >> crates/bin/Cargo.toml <<EOF
 [package.metadata.binstall.signing]
 algorithm = "minisign"
 pubkey = "$(tail -n1 minisign.pub)"
 EOF
+
+set +x
+echo "::add-mask::$(tail -n1 minisign.key)"
+echo "private=$(tail -n1 minisign.key)" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
+
+cat > minisign.key <<< "$SIGNING_KEY"
+
+set -x
 
 cargo binstall -y rsign2
 
@@ -8,12 +12,7 @@ ts=$(date --utc --iso-8601=seconds)
 git=$(git rev-parse HEAD)
 comment="gh=$GITHUB_REPOSITORY git=$git ts=$ts run=$GITHUB_RUN_ID"
 
-set +x
-for file in "$@"; do expect <<EXP
-spawn rsign sign -s minisign.key -x "$file.sig" -t "$comment" "$file"
-expect "Password:"
-send -- "$SIGNING_KEY_SECRET\r"
-expect eof
-EXP
+for file in "$@"; do
+    rsign sign -W -s minisign.key -x "$file.sig" -t "$comment" "$file"
 done
 

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+cargo binstall -y rsign2
+
+ts=$(date --utc --iso-8601=seconds)
+git=$(git rev-parse HEAD)
+comment="gh=$GITHUB_REPOSITORY git=$git ts=$ts run=$GITHUB_RUN_ID"
+
+set +x
+for file in "$@"; do expect <<EXP
+spawn rsign sign -s minisign.key -x "$file.sig" -t "$comment" "$file"
+expect "Password:"
+send -- "$SIGNING_KEY_SECRET\r"
+expect eof
+EXP
+done
+

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-cat > minisign.key <<< "$SIGNING_KEY"
+echo "untrusted comment: rsign encrypted secret key" > minisign.key
+cat >> minisign.key <<< "$SIGNING_KEY"
 
 set -x
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,6 +16,10 @@ on:
         description: "Set to override default release profile codegen-units settings"
         required: false
         type: string
+    secrets:
+      signingkey:
+        description: "Minisign private key"
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -84,17 +88,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - if: inputs.publish
-      uses: actions/download-artifact@v3
-      with:
-        name: signing-key
-        path: minisign.key.enc
-    - if: inputs.publish
+    - if: inputs.publish && secrets.signingkey
       env:
-        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
-      run: |
-        apt-get install -y expect
-        .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
+        SIGNING_KEY: ${{ secrets.signingkey }}
+      run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
 
     - if: inputs.publish
       name: Upload to release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -85,6 +85,18 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - if: inputs.publish
+      uses: actions/download-artifact@v3
+      with:
+        name: signing-key
+        path: minisign.key.enc
+    - if: inputs.publish
+      env:
+        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+      run: |
+        apt-get install -y expect
+        .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
+
+    - if: inputs.publish
       name: Upload to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -139,6 +151,19 @@ jobs:
     - run: ls -shalr packages/
     - run: just repackage-lipo
     - run: ls -shal packages/
+
+    - if: inputs.publish
+      uses: actions/download-artifact@v3
+      with:
+        name: signing-key
+        path: minisign.key
+    - if: inputs.publish
+      env:
+        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+      shell: bash
+      run: |
+        apt-get install -y expect
+        .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
 
     - if: inputs.publish
       name: Upload to release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -149,18 +149,10 @@ jobs:
     - run: just repackage-lipo
     - run: ls -shal packages/
 
-    - if: inputs.publish
-      uses: actions/download-artifact@v3
-      with:
-        name: signing-key
-        path: minisign.key
-    - if: inputs.publish
+    - if: inputs.publish && secrets.signingkey
       env:
-        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
-      shell: bash
-      run: |
-        apt-get install -y expect
-        .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
+        SIGNING_KEY: ${{ secrets.signingkey }}
+      run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
 
     - if: inputs.publish
       name: Upload to release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,7 +18,7 @@ on:
         type: string
     secrets:
       signingkey:
-        description: "Minisign private key"
+        description: "Minisign private key. Required when publishing"
         required: false
 
 env:
@@ -88,7 +88,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - if: inputs.publish && secrets.signingkey
+    - if: inputs.publish
       env:
         SIGNING_KEY: ${{ secrets.signingkey }}
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
@@ -149,7 +149,7 @@ jobs:
     - run: just repackage-lipo
     - run: ls -shal packages/
 
-    - if: inputs.publish && secrets.signingkey
+    - if: inputs.publish
       env:
         SIGNING_KEY: ${{ secrets.signingkey }}
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -89,6 +89,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - if: inputs.publish
+      uses: cargo-bins/cargo-binstall@main
+
+    - if: inputs.publish
       env:
         SIGNING_KEY: ${{ secrets.signingkey }}
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
@@ -148,6 +151,9 @@ jobs:
     - run: ls -shalr packages/
     - run: just repackage-lipo
     - run: ls -shal packages/
+
+    - if: inputs.publish
+      uses: cargo-bins/cargo-binstall@main
 
     - if: inputs.publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
         event-data: ${{ toJSON(github.event) }}
         extract-notes-under: '### Release notes'
 
-  tag:
-    if: needs.info.outputs.is-release == 'true'
+  libtag:
+    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate != 'cargo-binstall'
     needs: info
     runs-on: ubuntu-latest
     steps:
@@ -35,24 +35,49 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ needs.info.outputs.version }}
         tag_prefix: ${{ needs.info.outputs.crate }}-v
-    - name: Push cli release tag
-      if: needs.info.outputs.crate == 'cargo-binstall'
-      uses: mathieudutour/github-tag-action@v6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ needs.info.outputs.version }}
-        tag_prefix: v
     - name: Publish to crates.io
       run: |
         cargo publish -p '${{ needs.info.outputs.crate }}'
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  clitag:
+    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
+    needs: info
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Push cli release tag
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ needs.info.outputs.version }}
+        tag_prefix: v
+    - uses: cargo-bins/cargo-binstall@main
+    - name: Create ephemeral keypair
+      env:
+        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+      run: |
+        apt-get install -y expect
+        .github/scripts/ephemeral-gen.sh
+    - name: Upload secret key to artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: signing-key
+        path: minisign.key
+        if-no-files-found: error
+        retention-days: 1
+    - name: Publish to crates.io
+      env:
+        crate: ${{ needs.info.outputs.crate }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p "$crate"
+
   package:
     if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
     needs:
     - info
-    - tag
+    - clitag
     uses: ./.github/workflows/release-build.yml
     with:
       publish: ${{ toJSON(needs.info.outputs) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,23 +55,15 @@ jobs:
         tag_prefix: v
     - uses: cargo-bins/cargo-binstall@main
     - name: Create ephemeral keypair
-      env:
-        SIGNING_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
-      run: |
-        apt-get install -y expect
-        .github/scripts/ephemeral-gen.sh
-    - name: Upload secret key to artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: signing-key
-        path: minisign.key
-        if-no-files-found: error
-        retention-days: 1
+      id: keypair
+      run: .github/scripts/ephemeral-gen.sh
     - name: Publish to crates.io
       env:
         crate: ${{ needs.info.outputs.crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate"
+    outputs:
+      signingkey: ${{ steps.keypair.outputs.private }}
 
   package:
     if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
@@ -81,3 +73,5 @@ jobs:
     uses: ./.github/workflows/release-build.yml
     with:
       publish: ${{ toJSON(needs.info.outputs) }}
+    secrets:
+      signingkey: ${{ needs.clitag.signingkey }}

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -59,7 +59,7 @@ It may or may not include the untrusted comment; it's ignored by Binstall so we 
 
 ## Just-in-time signing
 
-To reduce the risk of a key being stolen, this scheme supports just-in-time signing.
+To reduce the risk of a key being stolen, this scheme supports just-in-time or "keyless" signing.
 The idea is to generate a keypair when releasing, use it for signing the packages, save the key in the Cargo.toml before publishing to a registry, and then discard the private key when it's done.
 That way, there's no key to steal nor to store securely, and every release is signed by a different key.
 And because crates.io is immutable, it's impossible to overwrite the key.
@@ -73,7 +73,7 @@ There is one caveat to keep in mind: with the scheme as described above, Binstal
 The solution here is either:
 
 - Commit the Cargo.toml with the ephemeral public key to the repo when publishing.
-- Omit the `[...signing]` section in the source, and write the entire section on publish instead of just filling in the `pubkey`; signatures won't be checked for `--git` installs.
+- Omit the `[...signing]` section in the source, and write the entire section on publish instead of just filling in the `pubkey`; signatures won't be checked for `--git` installs. Binstall uses this approach.
 - Instruct your users to use `--skip-signatures` if they want to install with `--git`.
 
 ## Why not X? (Sigstore, GPG, signify, with SSH keys, ...)
@@ -84,10 +84,10 @@ We chose minisign as the first supported algorithm as it's lightweight, fairly p
 
 ## There's a competing project that does package signature verification differently!
 
-[Tell use about it](https://github.com/cargo-bins/cargo-binstall/issues/1)!
+[Tell us about it](https://github.com/cargo-bins/cargo-binstall/issues/1)!
 We're not looking to fracture the ecosystem here, and will gladly implement support if something exists already.
 
-We'll also work with others in the space to eventually formalise this beyond Binstall, for example around the `cargo-dist.json` metadata format.
+We'll also work with others in the space to eventually formalise this beyond Binstall, for example around the [`dist-manifest.json`](https://crates.io/crates/cargo-dist-schema) metadata format.
 
 ## What's the relationship to crate/registry signing?
 


### PR DESCRIPTION
This uses an ephemeral key.

It writes the `[signing]` section to the Cargo.toml just before publish, so the Cargo.toml in the source remains without, which makes `--git` installs work (just without verifying signatures).

It uses rsign2 so we can install it via binstall (dogfooding!).