### PR TITLE
Fixed and simplify dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,77 +8,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # If we include `/`, then dependabot would also create PR
-  # for every compatible updates.
-  #
-  # We only want incompatible updates for direct dependencies
-  # from dependabot since compatible updates is covered by
-  # `update-transitive-deps.yml`
   - package-ecosystem: "cargo"
-    directory: "/crates/atomic-file-install"
+    directory: "/"
     schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/bin"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-bins"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-fetchers"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-registry"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-downloader"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-manifests"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/binstalk-types"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/cargo-toml-workspace"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/detect-targets"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/detect-wasi"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/fs-lock"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/leon"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/leon-macros"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/normalize-path"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/crates/simple-git"
-    schedule:
-      interval: "daily"
+      # Only run dependabot after all compatible upgrades and transitive deps
+      # are done to reduce amount of PRs opened.
+      interval: "weekly"
+      day: "saturday"
+    groups:
+      deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixed #1353

Merge all dependabot configuration for cargo into one, with directory setting to `/` so that it will check for dep updates for entire workspace while also updating lockfile in PR.

To prevent it from opening too many PRs, it's configured to run on every Saturday, after `upgrade-transitive-deps.yml` is run.

It will also group all dependencies into one PR to prevent opening too many PRs.