### PR TITLE
fix: use custom DNS resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,13 @@ dependencies = [
  "bytes",
  "bzip2",
  "compact_str",
+ "default-net",
  "flate2",
  "futures-util",
  "httpdate",
+ "hyper",
+ "ipconfig",
+ "once_cell",
  "percent-encoding",
  "reqwest",
  "serde",
@@ -787,6 +791,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "default-net"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d1b93f7700c45c26856522aed3982b685edb0532e4dbdd3a4ec84bb4185526"
+dependencies = [
+ "dlopen2",
+ "libc",
+ "memalloc",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +871,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -2403,6 +2435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memalloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2547,54 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -2663,6 +2749,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -3463,6 +3555,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,12 +208,6 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -301,7 +295,7 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tracing",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.23.0",
  "url",
  "xz2",
  "zstd 0.12.4",
@@ -931,6 +925,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.35",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,15 +1161,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1836,7 +1833,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8d976844844f8b42e70a2c2e60d68407f7055ff7e37553d1e7f2718acc3547"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bstr",
  "gix-command",
  "gix-credentials",
@@ -1996,8 +1993,8 @@ dependencies = [
  "bytes",
  "futures",
  "h3",
- "quinn 0.10.2",
- "quinn-proto 0.10.4",
+ "quinn",
+ "quinn-proto",
  "tokio-util",
 ]
 
@@ -2118,9 +2115,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.7",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2843,58 +2840,19 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "fxhash",
- "quinn-proto 0.8.4",
- "quinn-udp 0.1.4",
- "rustls 0.20.9",
- "thiserror",
- "tokio",
- "tracing",
- "webpki",
-]
-
-[[package]]
-name = "quinn"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto 0.10.4",
- "quinn-udp 0.4.1",
+ "quinn-proto",
+ "quinn-udp",
  "rustc-hash",
- "rustls 0.21.7",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
-dependencies = [
- "bytes",
- "fxhash",
- "rand",
- "ring",
- "rustls 0.20.9",
- "rustls-native-certs",
- "rustls-pemfile 0.2.1",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -2907,24 +2865,10 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.21.7",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07946277141531aea269befd949ed16b2c85a780ba1043244eda0969e538e54"
-dependencies = [
- "futures-util",
- "libc",
- "quinn-proto 0.8.4",
- "socket2 0.4.9",
- "tokio",
  "tracing",
 ]
 
@@ -3056,7 +3000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "async-compression 0.4.3",
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3078,24 +3022,24 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn 0.10.2",
- "rustls 0.21.7",
- "rustls-pemfile 1.0.3",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.22.0",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots",
  "winreg 0.50.0",
 ]
 
@@ -3160,18 +3104,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
@@ -3183,33 +3115,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.3",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.4",
+ "base64",
 ]
 
 [[package]]
@@ -3734,22 +3645,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls",
  "tokio",
 ]
 
@@ -3866,6 +3766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3935,34 +3836,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.5.1",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc775440033cb114085f6f2437682b194fa7546466024b1037e82a48a052a69"
+dependencies = [
+ "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.6.0",
  "futures-channel",
  "futures-io",
  "futures-util",
  "h2",
  "http",
- "idna 0.2.3",
+ "idna 0.4.0",
  "ipnet",
- "lazy_static",
  "native-tls",
- "quinn 0.8.5",
+ "once_cell",
+ "quinn",
  "rand",
  "ring",
- "rustls 0.20.9",
- "rustls-pemfile 1.0.3",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-webpki",
  "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tracing",
  "url",
- "webpki",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3978,15 +3904,34 @@ dependencies = [
  "lru-cache",
  "parking_lot",
  "resolv-conf",
- "rustls 0.20.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto 0.22.0",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff7aed33ef3e8bf2c9966fccdfed93f93d46f432282ea875cd66faabc6ef2f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rustls",
  "smallvec",
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tracing",
- "trust-dns-proto",
- "webpki-roots 0.22.6",
+ "trust-dns-proto 0.23.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4235,25 +4180,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,12 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -295,7 +301,7 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tracing",
- "trust-dns-resolver 0.23.0",
+ "trust-dns-resolver",
  "url",
  "xz2",
  "zstd 0.12.4",
@@ -925,18 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.35",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1155,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1833,7 +1836,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8d976844844f8b42e70a2c2e60d68407f7055ff7e37553d1e7f2718acc3547"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bstr",
  "gix-command",
  "gix-credentials",
@@ -1993,8 +1996,8 @@ dependencies = [
  "bytes",
  "futures",
  "h3",
- "quinn",
- "quinn-proto",
+ "quinn 0.10.2",
+ "quinn-proto 0.10.4",
  "tokio-util",
 ]
 
@@ -2115,9 +2118,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.7",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2840,19 +2843,58 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto 0.8.4",
+ "quinn-udp 0.1.4",
+ "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.10.4",
+ "quinn-udp 0.4.1",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.7",
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand",
+ "ring",
+ "rustls 0.20.9",
+ "rustls-native-certs",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki",
 ]
 
 [[package]]
@@ -2865,10 +2907,24 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.7",
  "slab",
  "thiserror",
  "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07946277141531aea269befd949ed16b2c85a780ba1043244eda0969e538e54"
+dependencies = [
+ "futures-util",
+ "libc",
+ "quinn-proto 0.8.4",
+ "socket2 0.4.9",
+ "tokio",
  "tracing",
 ]
 
@@ -3000,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "async-compression 0.4.3",
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3022,24 +3078,24 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pemfile",
+ "quinn 0.10.2",
+ "rustls 0.21.7",
+ "rustls-pemfile 1.0.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
- "trust-dns-resolver 0.22.0",
+ "trust-dns-resolver",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.2",
  "winreg 0.50.0",
 ]
 
@@ -3104,6 +3160,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
@@ -3115,12 +3183,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -3645,11 +3734,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.7",
  "tokio",
 ]
 
@@ -3766,7 +3866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3836,59 +3935,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.5.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc775440033cb114085f6f2437682b194fa7546466024b1037e82a48a052a69"
-dependencies = [
- "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.6.0",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
  "h2",
  "http",
- "idna 0.4.0",
+ "idna 0.2.3",
  "ipnet",
+ "lazy_static",
  "native-tls",
- "once_cell",
- "quinn",
+ "quinn 0.8.5",
  "rand",
  "ring",
- "rustls",
- "rustls-pemfile",
- "rustls-webpki",
+ "rustls 0.20.9",
+ "rustls-pemfile 1.0.3",
  "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -3904,34 +3978,15 @@ dependencies = [
  "lru-cache",
  "parking_lot",
  "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto 0.22.0",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff7aed33ef3e8bf2c9966fccdfed93f93d46f432282ea875cd66faabc6ef2f"
-dependencies = [
- "cfg-if",
- "futures-util",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "rustls",
+ "rustls 0.20.9",
  "smallvec",
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tracing",
- "trust-dns-proto 0.23.0",
- "webpki-roots",
+ "trust-dns-proto",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4180,6 +4235,25 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -47,6 +47,8 @@ xz2 = "0.1.7"
 # because it uses the same zstd-sys version.
 # Otherwise there will be a link conflict.
 zstd = { version = "0.12.3", default-features = false }
+hyper = "0.14.27"
+once_cell = "1.18.0"
 
 [features]
 default = ["static", "rustls"]
@@ -78,7 +80,7 @@ native-tls = [
 ]
 
 # Enable trust-dns-resolver so that features on it will also be enabled.
-trust-dns = ["trust-dns-resolver", "reqwest/trust-dns"]
+trust-dns = ["trust-dns-resolver", "reqwest/trust-dns", "default-net", "ipconfig"]
 
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.
@@ -90,6 +92,10 @@ cross-lang-fat-lto = ["zstd/fat-lto"]
 
 gh-api-client = ["json"]
 json = ["serde", "serde_json"]
+
+[target."cfg(windows)".dependencies]
+default-net = { version = "0.17.0", optional = true }
+ipconfig = { version = "0.3.2", optional = true }
 
 [package.metadata.docs.rs]
 features = ["gh-api-client"]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -95,7 +95,7 @@ json = ["serde", "serde_json"]
 
 [target."cfg(windows)".dependencies]
 default-net = { version = "0.17.0", optional = true }
-ipconfig = { version = "0.3.2", optional = true }
+ipconfig = { version = "0.3.2", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 features = ["gh-api-client"]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -37,7 +37,7 @@ tokio-tar = "0.3.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.37"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.23.0", optional = true, default-features = false, features = ["dnssec-ring"] }
+trust-dns-resolver = { version = "0.22.0", optional = true, features = ["dnssec-ring"] }
 hyper = { version = "0.14.27", optional = true }
 once_cell = { version = "1.18.0", optional = true }
 url = "2.3.1"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -37,7 +37,7 @@ tokio-tar = "0.3.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.37"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", optional = true, default-features = false, features = ["dnssec-ring"] }
+trust-dns-resolver = { version = "0.23.0", optional = true, default-features = false, features = ["dnssec-ring"] }
 url = "2.3.1"
 
 xz2 = "0.1.7"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -80,7 +80,7 @@ native-tls = [
 ]
 
 # Enable trust-dns-resolver so that features on it will also be enabled.
-trust-dns = ["trust-dns-resolver", "reqwest/trust-dns", "default-net", "ipconfig"]
+trust-dns = ["trust-dns-resolver", "default-net", "ipconfig"]
 
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -38,6 +38,8 @@ tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.37"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
 trust-dns-resolver = { version = "0.23.0", optional = true, default-features = false, features = ["dnssec-ring"] }
+hyper = { version = "0.14.27", optional = true }
+once_cell = { version = "1.18.0", optional = true }
 url = "2.3.1"
 
 xz2 = "0.1.7"
@@ -47,8 +49,6 @@ xz2 = "0.1.7"
 # because it uses the same zstd-sys version.
 # Otherwise there will be a link conflict.
 zstd = { version = "0.12.3", default-features = false }
-hyper = "0.14.27"
-once_cell = "1.18.0"
 
 [features]
 default = ["static", "rustls"]
@@ -80,7 +80,7 @@ native-tls = [
 ]
 
 # Enable trust-dns-resolver so that features on it will also be enabled.
-trust-dns = ["trust-dns-resolver", "default-net", "ipconfig"]
+trust-dns = ["trust-dns-resolver", "default-net", "ipconfig", "hyper", "once_cell"]
 
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.

--- a/crates/binstalk-downloader/src/lib.rs
+++ b/crates/binstalk-downloader/src/lib.rs
@@ -12,4 +12,7 @@ pub mod gh_api_client;
 
 pub mod remote;
 
+#[cfg(feature= "trust-dns")]
+mod resolver;
+
 mod utils;

--- a/crates/binstalk-downloader/src/lib.rs
+++ b/crates/binstalk-downloader/src/lib.rs
@@ -12,7 +12,7 @@ pub mod gh_api_client;
 
 pub mod remote;
 
-#[cfg(feature= "trust-dns")]
+#[cfg(feature = "trust-dns")]
 mod resolver;
 
 mod utils;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -18,6 +18,9 @@ use tracing::{debug, info, instrument};
 pub use reqwest::{header, Error as ReqwestError, Method, StatusCode};
 pub use url::Url;
 
+#[cfg(feature = "trust-dns")]
+use crate::resolver::DefaultResolver;
+
 mod delay_request;
 use delay_request::DelayRequest;
 
@@ -106,6 +109,11 @@ impl Client {
                 .user_agent(user_agent)
                 .https_only(true)
                 .tcp_nodelay(false);
+
+            #[cfg(feature = "trust-dns")]
+            {
+                builder = builder.dns_resolver(Arc::new(DefaultResolver::default()));
+            }
 
             #[cfg(feature = "__tls")]
             {

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -19,7 +19,7 @@ pub use reqwest::{header, Error as ReqwestError, Method, StatusCode};
 pub use url::Url;
 
 #[cfg(feature = "trust-dns")]
-use crate::resolver::DefaultResolver;
+use crate::resolver::TrustDnsResolver;
 
 mod delay_request;
 use delay_request::DelayRequest;
@@ -112,7 +112,7 @@ impl Client {
 
             #[cfg(feature = "trust-dns")]
             {
-                builder = builder.dns_resolver(Arc::new(DefaultResolver::default()));
+                builder = builder.dns_resolver(Arc::new(TrustDnsResolver::default()));
             }
 
             #[cfg(feature = "__tls")]

--- a/crates/binstalk-downloader/src/resolver.rs
+++ b/crates/binstalk-downloader/src/resolver.rs
@@ -1,0 +1,75 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use hyper::client::connect::dns::Name;
+use once_cell::sync::OnceCell;
+use reqwest::dns::{Addrs, Resolve};
+#[cfg(unix)]
+use trust_dns_resolver::system_conf;
+use trust_dns_resolver::{
+    config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts},
+    TokioAsyncResolver,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct DefaultResolver(Arc<OnceCell<TokioAsyncResolver>>);
+
+impl Resolve for DefaultResolver {
+    fn resolve(&self, name: Name) -> reqwest::dns::Resolving {
+        let resolver = self.clone();
+        Box::pin(async move {
+            let resolver = resolver.0.get_or_try_init(new_resolver)?;
+
+            let lookup = resolver.lookup_ip(name.as_str()).await?;
+            let addrs: Addrs = Box::new(lookup.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+            Ok(addrs)
+        })
+    }
+}
+
+fn new_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send + Sync>> {
+    #[cfg(unix)]
+    {
+        let (config, opts) = system_conf::read_system_conf()?;
+        Ok(TokioAsyncResolver::tokio(config, opts)?)
+    }
+    #[cfg(windows)]
+    {
+        let mut config = ResolverConfig::new();
+        let opts = ResolverOpts::default();
+
+        let current_interface = default_net::get_default_interface()?;
+        let adapters = ipconfig::get_adapters()?;
+        let ipaddrs = adapters
+            .iter()
+            .filter_map(|adapter| {
+                if adapter.adapter_name() == current_interface.name {
+                    Some(adapter.dns_servers())
+                } else {
+                    None
+                }
+            })
+            .flatten();
+
+        for ipaddr in ipaddrs {
+            config.add_name_server(NameServerConfig {
+                socket_addr: SocketAddr::new(ipaddr.to_owned(), 53),
+                protocol: Protocol::Tcp,
+                tls_dns_name: None,
+                trust_nx_responses: false,
+                #[cfg(feature = "rustls")]
+                tls_config: None,
+                bind_addr: None,
+            });
+            config.add_name_server(NameServerConfig {
+                socket_addr: SocketAddr::new(ipaddr.to_owned(), 53),
+                protocol: Protocol::Udp,
+                tls_dns_name: None,
+                trust_nx_responses: false,
+                #[cfg(feature = "rustls")]
+                tls_config: None,
+                bind_addr: None,
+            })
+        }
+        Ok(TokioAsyncResolver::tokio(config, opts)?)
+    }
+}

--- a/crates/binstalk-downloader/src/resolver.rs
+++ b/crates/binstalk-downloader/src/resolver.rs
@@ -26,7 +26,7 @@ fn new_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send
     #[cfg(unix)]
     {
         let (config, opts) = trust_dns_resolver::system_conf::read_system_conf()?;
-        Ok(TokioAsyncResolver::tokio(config, opts))
+        Ok(TokioAsyncResolver::tokio(config, opts)?)
     }
     #[cfg(windows)]
     {
@@ -50,7 +50,7 @@ fn new_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send
                     socket_addr: SocketAddr::new(*addr, DNS_PORT),
                     protocol: Protocol::Tcp,
                     tls_dns_name: None,
-                    trust_negative_responses: false,
+                    trust_nx_responses: false,
                     #[cfg(feature = "rustls")]
                     tls_config: None,
                     bind_addr: None,
@@ -59,13 +59,13 @@ fn new_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send
                     socket_addr: SocketAddr::new(*addr, DNS_PORT),
                     protocol: Protocol::Udp,
                     tls_dns_name: None,
-                    trust_negative_responses: false,
+                    trust_nx_responses: false,
                     #[cfg(feature = "rustls")]
                     tls_config: None,
                     bind_addr: None,
                 })
             });
 
-        Ok(TokioAsyncResolver::tokio(config, opts))
+        Ok(TokioAsyncResolver::tokio(config, opts)?)
     }
 }

--- a/crates/binstalk-downloader/src/resolver.rs
+++ b/crates/binstalk-downloader/src/resolver.rs
@@ -45,25 +45,18 @@ fn new_resolver() -> Result<TokioAsyncResolver, Box<dyn std::error::Error + Send
             })
             .flatten()
             .for_each(|addr| {
-                const DNS_PORT: u16 = 53;
-                config.add_name_server(NameServerConfig {
-                    socket_addr: SocketAddr::new(*addr, DNS_PORT),
-                    protocol: Protocol::Tcp,
-                    tls_dns_name: None,
-                    trust_nx_responses: false,
-                    #[cfg(feature = "rustls")]
-                    tls_config: None,
-                    bind_addr: None,
-                });
-                config.add_name_server(NameServerConfig {
-                    socket_addr: SocketAddr::new(*addr, DNS_PORT),
-                    protocol: Protocol::Udp,
-                    tls_dns_name: None,
-                    trust_nx_responses: false,
-                    #[cfg(feature = "rustls")]
-                    tls_config: None,
-                    bind_addr: None,
-                })
+                let socket_addr = SocketAddr::new(*addr, 53);
+                for protocol in [Protocol::Udp, Protocol::Tcp] {
+                    config.add_name_server(NameServerConfig {
+                        socket_addr,
+                        protocol,
+                        tls_dns_name: None,
+                        trust_nx_responses: false,
+                        #[cfg(feature = "rustls")]
+                        tls_config: None,
+                        bind_addr: None,
+                    })
+                }
             });
 
         Ok(TokioAsyncResolver::tokio(config, opts)?)


### PR DESCRIPTION
## Summary
This PR applies the fix from @GNQG + some formatting changes.

Patch applied: https://github.com/GNQG/cargo-binstall/commit/cb40519ff6e02e624abb25491b0f86ccb829e478
Fixes #1339

## Explanation
By default, `trust-dns` loops through all available interfaces and tries to use them, but when you have applications installed such as VMware or VirtualBox, it creates interfaces that resolve to the loopback address. Given that `trust-dns` has a timeout of 5s and then retries many times, it becomes really slow. This PR adds a custom DNS resolver struct that instructs `trust-dns` to only query the default network interface (which is either "WiFi" or "Ethernet", most of the time).