### PR TITLE
Minor refactor for `binstalk-downloader`

### DIFF
--- a/crates/binstalk-downloader/src/lib.rs
+++ b/crates/binstalk-downloader/src/lib.rs
@@ -12,7 +12,4 @@ pub mod gh_api_client;
 
 pub mod remote;
 
-#[cfg(feature = "trust-dns")]
-mod resolver;
-
 mod utils;

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -18,9 +18,6 @@ use tracing::{debug, info, instrument};
 pub use reqwest::{header, Error as ReqwestError, Method, StatusCode};
 pub use url::Url;
 
-#[cfg(feature = "trust-dns")]
-use crate::resolver::TrustDnsResolver;
-
 mod delay_request;
 use delay_request::DelayRequest;
 
@@ -32,6 +29,11 @@ pub use request_builder::{Body, RequestBuilder, Response};
 
 mod tls_version;
 pub use tls_version::TLSVersion;
+
+#[cfg(feature = "trust-dns")]
+mod resolver;
+#[cfg(feature = "trust-dns")]
+use resolver::TrustDnsResolver;
 
 #[cfg(feature = "json")]
 pub use request_builder::JsonError;

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use hyper::client::connect::dns::Name;
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Resolve};
+#[cfg(windows)]
 use trust_dns_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use trust_dns_resolver::TokioAsyncResolver;
 


### PR DESCRIPTION
 - Mv `resolver.rs` => `remote/resolver.rs`
 - Fix clippy warnings in `resolver.rs` on unix