### PR TITLE
Fix `detect-targets` on ubuntu 20.04, glibc 2.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.os }}
     - name: Build detect-targets
       run: cargo build --bin detect-targets
     - name: Run test in ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,13 @@ jobs:
           alpine test.sh "$TARGET"
 
   detect-targets-ubuntu-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2

--- a/crates/detect-targets/src/detect/linux.rs
+++ b/crates/detect-targets/src/detect/linux.rs
@@ -108,6 +108,19 @@ You are not meant to run this directly.
         } else {
             None
         }
+    } else if status.code() == Some(127) {
+        // On Ubuntu 20.04 (glibc 2.31), the `--version` flag is not supported
+        // and it will exit with status 127.
+        let status = Command::new(cmd)
+            .arg("/bin/true")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .ok()?;
+
+        status.success().then_some(Libc::Gnu)
     } else {
         None
     }


### PR DESCRIPTION
Fixed #1375 and fixed #1378

glibc 2.31 does not support `--version`, so we need to detect and fallback to passing an executable linked with that glibc to check if it is indeed glibc.