### PR TITLE
Refactor `cargo-toml-workspace`: Rm dep on `binstalk-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,11 +543,11 @@ dependencies = [
 name = "cargo-toml-workspace"
 version = "1.0.0"
 dependencies = [
- "binstalk-types",
  "cargo_toml",
  "compact_str",
  "glob",
  "normalize-path",
+ "serde",
  "tempfile",
  "thiserror",
  "tracing",

--- a/crates/cargo-toml-workspace/Cargo.toml
+++ b/crates/cargo-toml-workspace/Cargo.toml
@@ -10,11 +10,11 @@ authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-binstalk-types = { version = "0.6.0", path = "../binstalk-types" }
 cargo_toml = "0.16.0"
 compact_str = { version = "0.7.0", features = ["serde"] }
 glob = "0.3.1"
 normalize-path = { version = "0.2.1", path = "../normalize-path" }
+serde = "1.0.163"
 thiserror = "1.0.40"
 tracing = "0.1.37"
 


### PR DESCRIPTION
`cargo-toml-workspace` should not depend on and be coupled with `binstalk-types` but instead be a generic crate that can be used outside `cargo-binstall`.