### PR TITLE
Fix release build again

### DIFF
--- a/.github/scripts/ephemeral-crate.sh
+++ b/.github/scripts/ephemeral-crate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+cat >> crates/bin/Cargo.toml <<EOF
+[package.metadata.binstall.signing]
+algorithm = "minisign"
+pubkey = "$(tail -n1 minisign.pub)"
+EOF
+
+cp minisign.pub crates/bin/minisign.pub
+

--- a/.github/scripts/ephemeral-gen.sh
+++ b/.github/scripts/ephemeral-gen.sh
@@ -2,21 +2,12 @@
 
 set -euxo pipefail
 
-cargo binstall -y rsign2
+cargo binstall -y rsign2 rage
 rsign generate -f -W -p minisign.pub -s minisign.key
-
-cat >> crates/bin/Cargo.toml <<EOF
-[package.metadata.binstall.signing]
-algorithm = "minisign"
-pubkey = "$(tail -n1 minisign.pub)"
-EOF
-
-echo "public=$(tail -n1 minisign.pub)" >> "$GITHUB_OUTPUT"
-cp minisign.pub crates/bin/minisign.pub
 
 set +x
 echo "::add-mask::$(tail -n1 minisign.key)"
-echo "private=$(tail -n1 minisign.key)" >> "$GITHUB_OUTPUT"
 set -x
 
+rage --encrypt --recipient "$AGE_KEY_PUBLIC" --output minisign.key.age minisign.key
 rm minisign.key

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -10,7 +10,7 @@ set -x
 cargo binstall -y rsign2 rage
 rage --decrypt --identity age.key --output minisign.key minisign.key.age
 
-ts=$(date --utc --iso-8601=seconds)
+ts=$(node -e 'console.log((new Date).toISOString())')
 git=$(git rev-parse HEAD)
 comment="gh=$GITHUB_REPOSITORY git=$git ts=$ts run=$GITHUB_RUN_ID"
 

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+[[ -z "$AGE_KEY_SECRET" ]] && { echo "!!! Empty age key secret !!!"; exit 1; }
 cat >> age.key <<< "$AGE_KEY_SECRET"
 
 set -x

--- a/.github/scripts/ephemeral-sign.sh
+++ b/.github/scripts/ephemeral-sign.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-echo "untrusted comment: rsign encrypted secret key" > minisign.key
-cat >> minisign.key <<< "$SIGNING_KEY"
+cat >> age.key <<< "$AGE_KEY_SECRET"
 
 set -x
 
-cargo binstall -y rsign2
+cargo binstall -y rsign2 rage
+rage --decrypt --identity age.key --output minisign.key minisign.key.age
 
 ts=$(date --utc --iso-8601=seconds)
 git=$(git rev-parse HEAD)
@@ -17,3 +17,4 @@ for file in "$@"; do
     rsign sign -W -s minisign.key -x "$file.sig" -t "$comment" "$file"
 done
 
+rm age.key minisign.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
 
   release-dry-run:
     uses: ./.github/workflows/release-cli.yml
+    secrets: inherit
     with:
       info: |
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,16 @@ jobs:
     - run: just avoid-dev-deps
     - run: just lint
 
-  release-builds:
-    uses: ./.github/workflows/release-build.yml
+  release-dry-run:
+    uses: ./.github/workflows/release-cli.yml
     with:
+      info: |
+        {
+          "is-release": false,
+          "crate": "cargo-binstall",
+          "version": "0.0.0",
+          "notes": ""
+        }
       CARGO_PROFILE_RELEASE_LTO: no
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
 
@@ -179,7 +186,7 @@ jobs:
     - test
     - cross-check
     - lint
-    - release-builds
+    - release-dry-run
     - detect-targets-alpine-test
     - detect-targets-ubuntu-test
     if: always() # always run even if dependencies fail

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,10 +8,9 @@ on:
         description: "Set to the release metadata JSON to publish the release"
         required: false
         type: string
-      publickey:
-        description: "Minisign public key. Required when publishing"
+      signingkey:
+        description: "Minisign private key, shielded. Required when publishing"
         required: false
-        type: string
       CARGO_PROFILE_RELEASE_LTO:
         description: "Set to override default release profile lto settings"
         required: false
@@ -20,10 +19,6 @@ on:
         description: "Set to override default release profile codegen-units settings"
         required: false
         type: string
-    secrets:
-      signingkey:
-        description: "Minisign private key. Required when publishing"
-        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -69,15 +64,6 @@ jobs:
       if: inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS
       run: echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}" >> "$GITHUB_ENV"
 
-    - name: Include public key in package
-      if: inputs.publickey
-      env:
-        PUBLIC_KEY: ${{ inputs.publickey }}
-      shell: bash
-      run: |
-        echo "untrusted comment: minisign public key" > minisign.pub
-        cat >> minisign.pub <<< "$PUBLIC_KEY"
-
     - uses: ./.github/actions/just-setup
       with:
         tools: cargo-auditable
@@ -89,6 +75,9 @@ jobs:
     - run: just toolchain rust-src
     - run: just ci-install-deps
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: minisign.pub
     - run: just package
     - if: runner.os == 'Windows'
       run: Get-ChildItem packages/
@@ -103,10 +92,13 @@ jobs:
 
     - if: inputs.publish
       uses: cargo-bins/cargo-binstall@main
-
+    - if: inputs.publish
+      uses: actions/download-artifact@v3
+      with:
+        name: minisign.key.age
     - if: inputs.publish
       env:
-        SIGNING_KEY: ${{ secrets.signingkey }}
+        AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
 
@@ -120,6 +112,7 @@ jobs:
         body: ${{ fromJSON(inputs.publish).notes }}
         file: packages/cargo-binstall-*
         file_glob: true
+        prerelease: true
     - if: "! inputs.publish || runner.os == 'macOS'"
       name: Upload artifact
       uses: actions/upload-artifact@v3
@@ -145,15 +138,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Include public key in package
-      if: inputs.publickey
-      env:
-        PUBLIC_KEY: ${{ inputs.publickey }}
-      shell: bash
-      run: |
-        echo "untrusted comment: minisign public key" > minisign.pub
-        cat >> minisign.pub <<< "$PUBLIC_KEY"
-
     - uses: taiki-e/install-action@v2
       with:
         tool: just
@@ -171,16 +155,23 @@ jobs:
         name: aarch64-apple-darwin
         path: packages/
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: minisign.pub
     - run: ls -shalr packages/
     - run: just repackage-lipo
     - run: ls -shal packages/
 
     - if: inputs.publish
       uses: cargo-bins/cargo-binstall@main
-
+    - if: inputs.publish
+      uses: actions/download-artifact@v3
+      with:
+        name: minisign.key.age
     - if: inputs.publish
       env:
-        SIGNING_KEY: ${{ secrets.signingkey }}
+        AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+      shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
 
     - if: inputs.publish
@@ -194,6 +185,7 @@ jobs:
         file: packages/cargo-binstall-universal-*
         file_glob: true
         overwrite: true
+        prerelease: true
     - if: "! inputs.publish"
       name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,12 +5,9 @@ on:
   workflow_call:
     inputs:
       publish:
-        description: "Set to the release metadata JSON to publish the release"
-        required: false
+        description: "The release metadata JSON"
+        required: true
         type: string
-      signingkey:
-        description: "Minisign private key, shielded. Required when publishing"
-        required: false
       CARGO_PROFILE_RELEASE_LTO:
         description: "Set to override default release profile lto settings"
         required: false
@@ -64,6 +61,7 @@ jobs:
       if: inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS
       run: echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}" >> "$GITHUB_ENV"
 
+    - uses: cargo-bins/cargo-binstall@main
     - uses: ./.github/actions/just-setup
       with:
         tools: cargo-auditable
@@ -90,19 +88,16 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - if: inputs.publish
-      uses: cargo-bins/cargo-binstall@main
-    - if: inputs.publish
-      uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v3
       with:
         name: minisign.key.age
-    - if: inputs.publish
+    - name: Sign package
       env:
         AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
 
-    - if: inputs.publish
+    - if: fromJSON(inputs.publish).is-release == 'true'
       name: Upload to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -113,7 +108,7 @@ jobs:
         file: packages/cargo-binstall-*
         file_glob: true
         prerelease: true
-    - if: "! inputs.publish || runner.os == 'macOS'"
+    - if: "fromJSON(inputs.publish).is-release != 'true' || runner.os == 'macOS'"
       name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
@@ -137,7 +132,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
+    - uses: cargo-bins/cargo-binstall@main
     - uses: taiki-e/install-action@v2
       with:
         tool: just
@@ -162,19 +157,15 @@ jobs:
     - run: just repackage-lipo
     - run: ls -shal packages/
 
-    - if: inputs.publish
-      uses: cargo-bins/cargo-binstall@main
-    - if: inputs.publish
-      uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v3
       with:
         name: minisign.key.age
-    - if: inputs.publish
-      env:
+    - env:
         AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
 
-    - if: inputs.publish
+    - if: fromJSON(inputs.publish).is-release == 'true'
       name: Upload to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -186,7 +177,7 @@ jobs:
         file_glob: true
         overwrite: true
         prerelease: true
-    - if: "! inputs.publish"
+    - if: fromJSON(inputs.publish).is-release != 'true'
       name: Upload artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,95 @@
+name: Release CLI
+on:
+  workflow_call:
+    inputs:
+      info:
+        description: "The release metadata JSON"
+        required: true
+        type: string
+      CARGO_PROFILE_RELEASE_LTO:
+        description: "Used to speed up CI"
+        required: false
+        type: string
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS:
+        description: "Used to speed up CI"
+        required: false
+        type: string
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - if: fromJSON(inputs.info).is-release == 'true'
+      name: Push cli release tag
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ fromJSON(inputs.info).version }}
+        tag_prefix: v
+
+  keygen:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cargo-bins/cargo-binstall@main
+    - name: Create ephemeral keypair
+      id: keypair
+      env:
+        AGE_KEY_PUBLIC: ${{ vars.AGE_KEY_PUBLIC }}
+      run: .github/scripts/ephemeral-gen.sh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: minisign.pub
+        path: minisign.pub
+    - uses: actions/upload-artifact@v3
+      with:
+        name: minisign.key.age
+        path: minisign.key.age
+        retention-days: 1
+
+  package:
+    needs:
+    - tag
+    - keygen
+    uses: ./.github/workflows/release-packages.yml
+    with:
+      publish: ${{ inputs.info }}
+      CARGO_PROFILE_RELEASE_LTO: ${{ inputs.CARGO_PROFILE_RELEASE_LTO }}
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}
+
+  publish:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+      with:
+        name: minisign.pub
+    - run: .github/scripts/ephemeral-crate.sh
+
+    - if: fromJSON(inputs.info).is-release != 'true'
+      name: DRY-RUN Publish to crates.io
+      env:
+        crate: ${{ needs.info.outputs.crate }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p "$crate" --allow-dirty --dry-run
+
+    - if: fromJSON(inputs.info).is-release == 'true'
+      name: Publish to crates.io
+      env:
+        crate: ${{ needs.info.outputs.crate }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p "$crate" --allow-dirty
+
+    - if: fromJSON(inputs.info).is-release == 'true'
+      name: Make release latest
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        release_name: v${{ needs.info.outputs.version }}
+        tag: v${{ needs.info.outputs.version }}
+        body: ${{ needs.info.outputs.notes }}
+        promote: true
+        file: minisign.pub
+

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -47,6 +47,11 @@ jobs:
         name: minisign.key.age
         path: minisign.key.age
         retention-days: 1
+    - name: Check that key can be decrypted
+      env:
+        AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
+      shell: bash
+      run: .github/scripts/ephemeral-sign.sh minisign.pub
 
   package:
     needs:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -77,14 +77,14 @@ jobs:
     - if: fromJSON(inputs.info).is-release != 'true'
       name: DRY-RUN Publish to crates.io
       env:
-        crate: ${{ needs.info.outputs.crate }}
+        crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate" --allow-dirty --dry-run
 
     - if: fromJSON(inputs.info).is-release == 'true'
       name: Publish to crates.io
       env:
-        crate: ${{ needs.info.outputs.crate }}
+        crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate" --allow-dirty
 
@@ -93,9 +93,9 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        release_name: v${{ needs.info.outputs.version }}
-        tag: v${{ needs.info.outputs.version }}
-        body: ${{ needs.info.outputs.notes }}
+        release_name: v${{ fromJSON(inputs.info).version }}
+        tag: v${{ fromJSON(inputs.info).version }}
+        body: ${{ fromJSON(inputs.info).notes }}
         promote: true
         file: minisign.pub
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -99,3 +99,10 @@ jobs:
         promote: true
         file: minisign.pub
 
+    - if: fromJSON(inputs.info).is-release == 'true'
+      name: Delete signing key artifact
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: minisign.key.age
+          failOnError: false
+

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -58,6 +58,7 @@ jobs:
     - tag
     - keygen
     uses: ./.github/workflows/release-packages.yml
+    secrets: inherit
     with:
       publish: ${{ inputs.info }}
       CARGO_PROFILE_RELEASE_LTO: ${{ inputs.CARGO_PROFILE_RELEASE_LTO }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,7 +1,6 @@
-name: Build for release
+name: Build packages for release
 
 on:
-  workflow_dispatch: # can't publish from dispatch
   workflow_call:
     inputs:
       publish:
@@ -9,11 +8,11 @@ on:
         required: true
         type: string
       CARGO_PROFILE_RELEASE_LTO:
-        description: "Set to override default release profile lto settings"
+        description: "Used to speed up CI"
         required: false
         type: string
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS:
-        description: "Set to override default release profile codegen-units settings"
+        description: "Used to speed up CI"
         required: false
         type: string
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -92,7 +92,7 @@ jobs:
         name: minisign.key.age
     - name: Sign package
       env:
-        AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+        AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-*
 
@@ -160,7 +160,7 @@ jobs:
       with:
         name: minisign.key.age
     - env:
-        AGE_KEY_SECRET: ${{ secrets.SIGNING_KEY_SECRET }}
+        AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     if: needs.info.outputs.crate == 'cargo-binstall'
     needs: info
     uses: ./.github/workflows/release-cli.yml
+    secrets: inherit
     with:
       info: ${{ toJSON(needs.info.outputs) }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,23 +56,23 @@ jobs:
     - uses: cargo-bins/cargo-binstall@main
     - name: Create ephemeral keypair
       id: keypair
+      env:
+        AGE_KEY_PUBLIC: ${{ vars.AGE_KEY_PUBLIC }}
       run: .github/scripts/ephemeral-gen.sh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: minisign.pub
+        path: minisign.pub
+    - uses: actions/upload-artifact@v3
+      with:
+        name: minisign.key.age
+        path: minisign.key.age
+        retention-days: 1
     - name: Publish to crates.io
       env:
         crate: ${{ needs.info.outputs.crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate" --allow-dirty
-    - name: Upload public key to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        release_name: v${{ needs.info.outputs.version }}
-        tag: v${{ needs.info.outputs.version }}
-        body: ${{ needs.info.outputs.notes }}
-        file: minisign.pub
-    outputs:
-      publickey: ${{ steps.keypair.outputs.public }}
-      signingkey: ${{ steps.keypair.outputs.private }}
 
   package:
     if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
@@ -82,6 +82,30 @@ jobs:
     uses: ./.github/workflows/release-build.yml
     with:
       publish: ${{ toJSON(needs.info.outputs) }}
-      publickey: ${{ needs.clitag.publickey }}
-    secrets:
-      signingkey: ${{ needs.clitag.signingkey }}
+
+  publish:
+    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
+    needs:
+    - info
+    - package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: minisign.pub
+    - run: .github/scripts/ephemeral-crate.sh
+    - name: Publish to crates.io
+      env:
+        crate: ${{ needs.info.outputs.crate }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p "$crate" --allow-dirty
+    - name: Make release latest
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        release_name: v${{ needs.info.outputs.version }}
+        tag: v${{ needs.info.outputs.version }}
+        body: ${{ needs.info.outputs.notes }}
+        promote: true
+        file: minisign.pub
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         event-data: ${{ toJSON(github.event) }}
         extract-notes-under: '### Release notes'
 
-  libtag:
+  release-lib:
     if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate != 'cargo-binstall'
     needs: info
     runs-on: ubuntu-latest
@@ -41,82 +41,10 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  clitag:
-    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
+  release-cli:
+    if: needs.info.outputs.crate == 'cargo-binstall'
     needs: info
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Push cli release tag
-      uses: mathieudutour/github-tag-action@v6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ needs.info.outputs.version }}
-        tag_prefix: v
-    - uses: cargo-bins/cargo-binstall@main
-    - name: Create ephemeral keypair
-      id: keypair
-      env:
-        AGE_KEY_PUBLIC: ${{ vars.AGE_KEY_PUBLIC }}
-      run: .github/scripts/ephemeral-gen.sh
-    - uses: actions/upload-artifact@v3
-      with:
-        name: minisign.pub
-        path: minisign.pub
-    - uses: actions/upload-artifact@v3
-      with:
-        name: minisign.key.age
-        path: minisign.key.age
-        retention-days: 1
-    - name: Publish to crates.io
-      env:
-        crate: ${{ needs.info.outputs.crate }}
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty
-
-  package:
-    if: needs.info.outputs.crate == 'cargo-binstall'
-    needs:
-    - info
-    - clitag
-    uses: ./.github/workflows/release-build.yml
+    uses: ./.github/workflows/release-cli.yml
     with:
-      publish: ${{ toJSON(needs.info.outputs) }}
-
-  publish:
-    if: needs.info.outputs.crate == 'cargo-binstall'
-    needs:
-    - info
-    - package
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: minisign.pub
-    - run: .github/scripts/ephemeral-crate.sh
-
-    - if: needs.info.outputs.is-release != 'true'
-      name: DRY-RUN Publish to crates.io
-      env:
-        crate: ${{ needs.info.outputs.crate }}
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty --dry-run
-
-    - if: needs.info.outputs.is-release == 'true'
-      name: Publish to crates.io
-      env:
-        crate: ${{ needs.info.outputs.crate }}
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty
-
-    - if: needs.info.outputs.is-release == 'true'
-      name: Make release latest
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        release_name: v${{ needs.info.outputs.version }}
-        tag: v${{ needs.info.outputs.version }}
-        body: ${{ needs.info.outputs.notes }}
-        promote: true
-        file: minisign.pub
+      info: ${{ toJSON(needs.info.outputs) }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       run: cargo publish -p "$crate" --allow-dirty
 
   package:
-    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
+    if: needs.info.outputs.crate == 'cargo-binstall'
     needs:
     - info
     - clitag
@@ -84,7 +84,7 @@ jobs:
       publish: ${{ toJSON(needs.info.outputs) }}
 
   publish:
-    if: needs.info.outputs.is-release == 'true' && needs.info.outputs.crate == 'cargo-binstall'
+    if: needs.info.outputs.crate == 'cargo-binstall'
     needs:
     - info
     - package
@@ -94,12 +94,23 @@ jobs:
       with:
         name: minisign.pub
     - run: .github/scripts/ephemeral-crate.sh
-    - name: Publish to crates.io
+
+    - if: needs.info.outputs.is-release != 'true'
+      name: DRY-RUN Publish to crates.io
+      env:
+        crate: ${{ needs.info.outputs.crate }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p "$crate" --allow-dirty --dry-run
+
+    - if: needs.info.outputs.is-release == 'true'
+      name: Publish to crates.io
       env:
         crate: ${{ needs.info.outputs.crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate" --allow-dirty
-    - name: Make release latest
+
+    - if: needs.info.outputs.is-release == 'true'
+      name: Make release latest
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
(Set 1.3.2 back as latest and yanked 1.4.0 so it doesn't get used.)

- Knew there was a reason I was going with artifacts for the key: [github actions can't pass outputs into secrets](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjobs_idoutputs)
- Uses `rage` to encrypt the key instead of using minisign's janky password thing
- Changes the workflow so that we once again publish the crate _after_ the github release has built successfully
- Uploads all the packages to a prerelease, then promotes that prerelease to latest as the last step, so the release is always complete when it's published, which means that the action will always work
- Those changes mean that we can finally achieve what we wanted all along: dry-run the entire release process!