### PR TITLE
Upload packaged crate

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -79,7 +79,16 @@ jobs:
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty --dry-run
+      run: |
+        set -ex
+        cargo publish -p "$crate" --allow-dirty --dry-run
+        cargo package --no-verify -p "$crate" --allow-dirty
+    - if: fromJSON(inputs.info).is-release != 'true'
+      name: Upload crate package as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: crate-package
+        path: target/package/*.crate
 
     - if: fromJSON(inputs.info).is-release == 'true'
       name: Publish to crates.io


### PR DESCRIPTION
Had this idea just after the build finally passed: when not releasing, we can cargo-package and upload the `.crate` file as artifact to check it if wanted.