### PR TITLE
Fix fallback to `cargo-install`: Use the default target unless user override

### DIFF
--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -126,11 +126,6 @@ impl ResolutionFetch {
 
 impl ResolutionSource {
     pub async fn install(self, opts: Arc<Options>) -> Result<(), BinstallError> {
-        let desired_targets = opts.desired_targets.get().await;
-        let target = desired_targets
-            .first()
-            .ok_or(BinstallError::NoViableTargets)?;
-
         let name = &self.name;
         let version = &self.version;
 
@@ -139,7 +134,7 @@ impl ResolutionSource {
             .unwrap_or_else(|| Cow::Borrowed(OsStr::new("cargo")));
 
         debug!(
-            "Running `{} install {name} --version {version} --target {target}`",
+            "Running `{} install {name} --version {version}`",
             Path::new(&cargo).display(),
         );
 
@@ -149,8 +144,6 @@ impl ResolutionSource {
             .arg(name)
             .arg("--version")
             .arg(version)
-            .arg("--target")
-            .arg(target)
             .kill_on_drop(true);
 
         if opts.quiet {

--- a/crates/detect-targets/src/desired_targets.rs
+++ b/crates/detect-targets/src/desired_targets.rs
@@ -41,6 +41,17 @@ impl DesiredTargets {
             AutoDetect(once_cell) => once_cell.get_or_init(detect_targets).await,
         }
     }
+
+    /// If `DesiredTargets` is provided with a list of desired targets instead
+    /// of detecting the targets, then this function would return `Some`.
+    pub fn get_initialized(&self) -> Option<&[String]> {
+        use DesiredTargetsInner::*;
+
+        match &self.0 {
+            Initialized(targets) => Some(targets),
+            AutoDetect(..) => None,
+        }
+    }
 }
 
 /// If opts_targets is `Some`, then it will be used.


### PR DESCRIPTION
which is guaranteed to work, instead of providing a custom `--target` from `detect-targets`.

The one from `detect-targets` might report musl even if the `rustc` reports gnu, since OSes like NixOS could use a custom glibc location that prevent glibc binaries built for other OSes be run for them.

However, if we are compiling the crate and `rustc` defaults to glibc, then it should be guaranteed to work.