### PR TITLE
CI: Skip signing if triggered by pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         }
       CARGO_PROFILE_RELEASE_LTO: no
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 4
+      SKIP_SIGNING: ${{ github.event_name == 'pull_request' }}
 
   detect-targets-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -94,12 +94,12 @@ jobs:
     - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
       run: exit 1
     - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      uses: actions/download-artifact@v3
       with:
         name: minisign.pub
-    - run: .github/scripts/ephemeral-crate.sh
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      run: .github/scripts/ephemeral-crate.sh
 
     - if: fromJSON(inputs.info).is-release != 'true'
       name: DRY-RUN Publish to crates.io

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,6 +14,10 @@ on:
         description: "Used to speed up CI"
         required: false
         type: string
+      SKIP_SIGNING:
+        description: "Used to skip signing"
+        required: false
+        type: boolean
 
 jobs:
   tag:
@@ -32,6 +36,7 @@ jobs:
 
   keygen:
     runs-on: ubuntu-latest
+    if: "! inputs.SKIP_SIGNING"
     steps:
     - uses: actions/checkout@v4
 
@@ -67,22 +72,33 @@ jobs:
     - keygen
     uses: ./.github/workflows/release-packages.yml
     secrets: inherit
+    if: always()
     with:
       publish: ${{ inputs.info }}
       CARGO_PROFILE_RELEASE_LTO: ${{ inputs.CARGO_PROFILE_RELEASE_LTO }}
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}
+      SKIP_SIGNING: ${{ inputs.SKIP_SIGNING }}
 
   publish:
-    needs: package
+    needs:
+    - tag
+    - keygen
+    - package
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: always()
     steps:
+    # fail if ANY dependency has failed or or cancelled
+    - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
+      run: exit 1
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v3
+      if: "! inputs.SKIP_SIGNING"
       with:
         name: minisign.pub
     - run: .github/scripts/ephemeral-crate.sh
+      if: "! inputs.SKIP_SIGNING"
 
     - if: fromJSON(inputs.info).is-release != 'true'
       name: DRY-RUN Publish to crates.io

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -18,6 +18,7 @@ on:
         description: "Used to skip signing"
         required: false
         type: boolean
+        default: false
 
 jobs:
   tag:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -76,8 +76,8 @@ jobs:
     - run: just toolchain rust-src
     - run: just ci-install-deps
 
-    - uses: actions/download-artifact@v3
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      uses: actions/download-artifact@v3
       with:
         name: minisign.pub
     - run: just package
@@ -92,12 +92,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/download-artifact@v3
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      uses: actions/download-artifact@v3
       with:
         name: minisign.key.age
-    - name: Sign package
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      name: Sign package
       env:
         AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
@@ -160,20 +160,20 @@ jobs:
         name: aarch64-apple-darwin
         path: packages/
 
-    - uses: actions/download-artifact@v3
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      uses: actions/download-artifact@v3
       with:
         name: minisign.pub
     - run: ls -shalr packages/
     - run: just repackage-lipo
     - run: ls -shal packages/
 
-    - uses: actions/download-artifact@v3
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      uses: actions/download-artifact@v3
       with:
         name: minisign.key.age
-    - env:
-      if: "! inputs.SKIP_SIGNING"
+    - if: "! inputs.SKIP_SIGNING"
+      env:
         AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -15,6 +15,10 @@ on:
         description: "Used to speed up CI"
         required: false
         type: string
+      SKIP_SIGNING:
+        description: "Used to skip signing"
+        required: false
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -72,6 +76,7 @@ jobs:
     - run: just ci-install-deps
 
     - uses: actions/download-artifact@v3
+      if: "! inputs.SKIP_SIGNING"
       with:
         name: minisign.pub
     - run: just package
@@ -87,9 +92,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/download-artifact@v3
+      if: "! inputs.SKIP_SIGNING"
       with:
         name: minisign.key.age
     - name: Sign package
+      if: "! inputs.SKIP_SIGNING"
       env:
         AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
@@ -153,6 +160,7 @@ jobs:
         path: packages/
 
     - uses: actions/download-artifact@v3
+      if: "! inputs.SKIP_SIGNING"
       with:
         name: minisign.pub
     - run: ls -shalr packages/
@@ -160,9 +168,11 @@ jobs:
     - run: ls -shal packages/
 
     - uses: actions/download-artifact@v3
+      if: "! inputs.SKIP_SIGNING"
       with:
         name: minisign.key.age
     - env:
+      if: "! inputs.SKIP_SIGNING"
         AGE_KEY_SECRET: ${{ secrets.AGE_KEY_SECRET }}
       shell: bash
       run: .github/scripts/ephemeral-sign.sh packages/cargo-binstall-universal-*

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -19,6 +19,7 @@ on:
         description: "Used to skip signing"
         required: false
         type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
For PRs opened by contributors who are not part of the cargo-bins team and for PRs opened by dependabot, they cannot access the secrets, thus signing will always fail.

Skipping signing on pull_request would fix that for them, while retaining the signing stage on merge_queue and on main to ensure that the release workflow is working.