### PR TITLE
CI: Skip release-dry-run on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
 
   release-dry-run:
     uses: ./.github/workflows/release-cli.yml
+    if: github.event_name != 'pull_request'
     secrets: inherit
     with:
       info: |
@@ -258,7 +259,7 @@ jobs:
     if: always() # always run even if dependencies fail
     runs-on: ubuntu-latest
     steps:
-    # fail if ANY dependency has failed or been skipped or cancelled
-    - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')"
+    # fail if ANY dependency has failed or cancelled
+    - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
       run: exit 1
     - run: exit 0


### PR DESCRIPTION
For PRs opened by contributors who are not part of the cargo-bins team and for PRs opened by dependabot, they cannot access the secrets, thus signing will always fail.

Skipping release-dry-run on pull_request would fix that for them, while retaining the signing stage on merge_queue and on main to ensure that the release workflow is working.

It will also speedup CI for PR.