### PR TITLE
Change Powershell architecture detection

### DIFF
--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -2,10 +2,10 @@ $ErrorActionPreference = "Stop"
 Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP
 $base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
-$type = (Get-ComputerInfo).CsSystemType.ToLower()
-if ($type.StartsWith("x64")) {
+$proc_arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
+if ($proc_arch -eq "AMD64") {
 	$arch = "x86_64"
-} elseif ($type.StartsWith("arm64")) {
+} elseif ($proc_arch -eq "ARM64") {
 	$arch = "aarch64"
 } else {
 	Write-Host "Unsupported Architecture: $type" -ForegroundColor Red


### PR DESCRIPTION
In some unusual configurations (perhaps something to do with Docker), `CsSystemType` on the result of `Get-ComputerInfo` can be null, preventing the script from running. Switch to using the environment variable `PROCESSOR_ARCHITECTURE` instead – if this is read from the machine environment variables instead of the process ones, it indicates the architecture of the machine.

This is also faster as `Get-ComputerInfo` can take several seconds to run.

I’ve validated this against my internal build pipeline, which I unfortunately cannot share.