### PR TITLE
dep: Update trust-dns-resolver v0.23.0 => hickory-resolver 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "default-net",
  "flate2",
  "futures-util",
+ "hickory-resolver",
  "httpdate",
  "hyper",
  "ipconfig",
@@ -295,7 +296,6 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tracing",
- "trust-dns-resolver",
  "url",
  "xz2",
  "zstd 0.13.0",
@@ -2012,6 +2012,66 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "h3",
+ "h3-quinn",
+ "http",
+ "idna",
+ "ipnet",
+ "native-tls",
+ "once_cell",
+ "quinn",
+ "rand",
+ "ring",
+ "rustls",
+ "rustls-pemfile",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "rustls",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tracing",
+]
 
 [[package]]
 name = "home"
@@ -3799,34 +3859,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc775440033cb114085f6f2437682b194fa7546466024b1037e82a48a052a69"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna",
  "ipnet",
- "native-tls",
  "once_cell",
- "quinn",
  "rand",
- "ring",
- "rustls",
- "rustls-pemfile",
- "rustls-webpki",
  "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls",
  "tracing",
  "url",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3843,15 +3891,11 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "rustls",
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls",
  "tracing",
  "trust-dns-proto",
- "webpki-roots",
 ]
 
 [[package]]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -36,8 +36,7 @@ tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "sync", "
 tokio-tar = "0.3.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.39"
-# trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.23.0", optional = true, features = ["dnssec-ring"] }
+hickory-resolver = { version = "0.24.0", optional = true, features = ["dnssec-ring"] }
 hyper = { version = "0.14.27", optional = true }
 once_cell = { version = "1.18.0", optional = true }
 url = "2.3.1"
@@ -67,20 +66,24 @@ rustls = [
 
     "reqwest/rustls-tls",
 
-    # Enable the following features only if trust-dns-resolver is enabled.
-    "trust-dns-resolver?/dns-over-rustls",
-    # trust-dns-resolver currently supports https with rustls
-    "trust-dns-resolver?/dns-over-https-rustls",
-    "trust-dns-resolver?/dns-over-quic",
+    # Enable the following features only if hickory-resolver is enabled.
+    "hickory-resolver?/dns-over-rustls",
+    # hickory-resolver currently supports https with rustls
+    "hickory-resolver?/dns-over-https-rustls",
+    "hickory-resolver?/dns-over-quic",
+    "hickory-resolver?/dns-over-h3",
 ]
 native-tls = [
     "__tls",
     "reqwest/native-tls",
-    "trust-dns-resolver?/dns-over-native-tls",
+    "hickory-resolver?/dns-over-native-tls",
 ]
 
-# Enable trust-dns-resolver so that features on it will also be enabled.
-trust-dns = ["trust-dns-resolver", "default-net", "ipconfig", "hyper", "once_cell"]
+# Enable hickory-resolver so that features on it will also be enabled.
+hickory-dns = ["hickory-resolver", "default-net", "ipconfig", "hyper", "once_cell"]
+
+# Deprecated alias for hickory-dns, since trust-dns is renamed to hickory-dns
+trust-dns = ["hickory-dns"]
 
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -30,9 +30,9 @@ pub use request_builder::{Body, RequestBuilder, Response};
 mod tls_version;
 pub use tls_version::TLSVersion;
 
-#[cfg(feature = "trust-dns")]
+#[cfg(feature = "hickory-dns")]
 mod resolver;
-#[cfg(feature = "trust-dns")]
+#[cfg(feature = "hickory-dns")]
 use resolver::TrustDnsResolver;
 
 #[cfg(feature = "json")]
@@ -112,7 +112,7 @@ impl Client {
                 .https_only(true)
                 .tcp_nodelay(false);
 
-            #[cfg(feature = "trust-dns")]
+            #[cfg(feature = "hickory-dns")]
             {
                 builder = builder.dns_resolver(Arc::new(TrustDnsResolver::default()));
             }

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -1,13 +1,13 @@
 use std::{net::SocketAddr, sync::Arc};
 
+use hickory_resolver::TokioAsyncResolver;
 use hyper::client::connect::dns::Name;
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Resolve};
 use tracing::{debug, instrument, warn};
-use trust_dns_resolver::TokioAsyncResolver;
 
 #[cfg(windows)]
-use trust_dns_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
+use hickory_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 


### PR DESCRIPTION
It's renamed to hickory-resolver.

Also enabled new feature `hickory-resolver/dns-over-h3` if `rustls` is enabled.