### PR TITLE
Rm unnecessary warning msg "Failed to read git credential file"

### DIFF
--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -114,7 +114,14 @@ pub fn install_crates(
             if args.no_discover_github_token {
                 None
             } else {
-                git_credentials::try_from_home().or_else(gh_token::get)
+                git_credentials::try_from_home().or_else(|| match gh_token::get() {
+                    Ok(token) => Some(token),
+                    Err(err) => {
+                        warn!(?err, "Failed to retrieve token from `gh auth token`");
+                        warn!("Failed to read git credential file");
+                        None
+                    }
+                })
             }
         }),
     );

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -1,9 +1,8 @@
 use std::{io, process};
 
 use compact_str::CompactString;
-use tracing::warn;
 
-fn get_inner() -> io::Result<CompactString> {
+pub(super) fn get() -> io::Result<CompactString> {
     let process::Output { status, stdout, .. } = process::Command::new("gh")
         .args(["auth", "token"])
         .stdin(process::Stdio::null())
@@ -25,14 +24,4 @@ fn get_inner() -> io::Result<CompactString> {
     })?;
 
     Ok(s.trim().into())
-}
-
-pub(super) fn get() -> Option<CompactString> {
-    match get_inner() {
-        Ok(token) => Some(token),
-        Err(err) => {
-            warn!(?err, "Failed to retrieve token from `gh auth token`");
-            None
-        }
-    }
 }

--- a/crates/bin/src/git_credentials.rs
+++ b/crates/bin/src/git_credentials.rs
@@ -24,7 +24,7 @@ pub fn try_from_home() -> Option<CompactString> {
 }
 
 fn from_file(path: PathBuf) -> Option<CompactString> {
-    fs::read_to_string(&path)
+    fs::read_to_string(path)
         .ok()?
         .lines()
         .find_map(from_line)

--- a/crates/bin/src/git_credentials.rs
+++ b/crates/bin/src/git_credentials.rs
@@ -2,7 +2,6 @@ use std::{env, fs, path::PathBuf};
 
 use compact_str::CompactString;
 use dirs::home_dir;
-use tracing::warn;
 
 pub fn try_from_home() -> Option<CompactString> {
     if let Some(mut home) = home_dir() {
@@ -25,7 +24,8 @@ pub fn try_from_home() -> Option<CompactString> {
 }
 
 fn from_file(path: PathBuf) -> Option<CompactString> {
-    read_cred_file(path)?
+    fs::read_to_string(&path)
+        .ok()?
         .lines()
         .find_map(from_line)
         .map(CompactString::from)
@@ -38,20 +38,6 @@ fn from_line(line: &str) -> Option<&str> {
         .strip_suffix("@github.com")?;
 
     Some(cred.split_once(':')?.1)
-}
-
-fn read_cred_file(path: PathBuf) -> Option<String> {
-    match fs::read_to_string(&path) {
-        Ok(s) => Some(s),
-        Err(err) => {
-            warn!(
-                ?err,
-                "Failed to read git credential file {}",
-                path.display()
-            );
-            None
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixed #1476

If `gh auth token` executed successfully and binstall obtained a gh token from it, then there's no reason to issue any warning msg.

Only when binstall cannot read from `.git-credential` and `gh auth token` failed does binstall need to issue warning.