### PR TITLE
CI: Cache zig global_cache to speedup build

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -19,14 +19,14 @@ runs:
   using: composite
   steps:
   - name: Add just to tools to install
-    run: echo "tools=just" >>$GITHUB_ENV
+    run: echo "tools=just" >>"$GITHUB_ENV"
     shell: bash
 
   - name: Add inputs.tools to tools to install
     if: inputs.tools != ''
     env:
       inputs_tools: ${{ inputs.tools }}
-    run: echo "tools=$tools,$inputs_tools" >>$GITHUB_ENV
+    run: echo "tools=$tools,$inputs_tools" >>"$GITHUB_ENV"
     shell: bash
 
   - name: Install tools
@@ -62,3 +62,29 @@ runs:
       env-vars: "CARGO CC CFLAGS CXX CMAKE RUST JUST"
     env:
       RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}
+
+  - name: Calculate zig cache key
+    if: env.JUST_USE_CARGO_ZIGBUILD
+    run: |
+      ZIG_VERSION=$(zig version)
+      SYS_CRATE_HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | sha1sum | sed 's/[ -]*//g')
+      echo "ZIG_CACHE_KEY=zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-${SYS_CRATE_HASHSUM}" >> "$GITHUB_ENV"
+      echo -e "ZIG_CACHE_RESTORE_KEY=zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-" >> "$GITHUB_ENV"
+    shell: bash
+    env:
+      RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}
+
+  - name: Get zig global cache dir
+    if: env.JUST_USE_CARGO_ZIGBUILD
+    id: zig_global_cache_dir_path
+    run: zig env | jq -r '.global_cache_dir'
+
+  - name: Cache zig compilation
+    if: env.JUST_USE_CARGO_ZIGBUILD
+    uses: actions/cache@v3
+    with:
+      path: ${{ steps.zig_global_cache_dir_path.outputs }}
+      key: ${{ env.ZIG_CACHE_KEY }}
+      restore-keys: |
+        ${{ env.ZIG_CACHE_KEY }}
+        ${{ env.ZIG_CACHE_RESTORE_KEY }}

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -84,14 +84,16 @@ runs:
   - name: Get zig global cache dir
     if: env.JUST_USE_CARGO_ZIGBUILD
     id: zig_global_cache_dir_path
-    run: zig env | jq -r '.global_cache_dir'
+    run: |
+      cache_dir=$(zig env | jq -r '.global_cache_dir')
+      echo "cache_dir=$cache_dir" >> "$GITHUB_OUTPUT"
     shell: bash
 
   - name: Cache zig compilation
     if: env.JUST_USE_CARGO_ZIGBUILD
     uses: actions/cache@v3
     with:
-      path: ${{ steps.zig_global_cache_dir_path.outputs }}
+      path: ${{ steps.zig_global_cache_dir_path.outputs.cache_dir }}
       key: ${{ env.ZIG_CACHE_KEY }}
       restore-keys: |
         ${{ env.ZIG_CACHE_KEY }}

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -78,6 +78,7 @@ runs:
     if: env.JUST_USE_CARGO_ZIGBUILD
     id: zig_global_cache_dir_path
     run: zig env | jq -r '.global_cache_dir'
+    shell: bash
 
   - name: Cache zig compilation
     if: env.JUST_USE_CARGO_ZIGBUILD

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -75,11 +75,13 @@ runs:
     run: |
       ZIG_VERSION=$(zig version)
       SYS_CRATE_HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | sha1sum | sed 's/[ -]*//g')
-      echo "ZIG_CACHE_KEY=zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-${SYS_CRATE_HASHSUM}" >> "$GITHUB_ENV"
-      echo -e "ZIG_CACHE_RESTORE_KEY=zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-" >> "$GITHUB_ENV"
+      PREFIX=v0-${JOB_ID}-zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-
+      echo "ZIG_CACHE_KEY=${PREFIX}${SYS_CRATE_HASHSUM}" >> "$GITHUB_ENV"
+      echo -e "ZIG_CACHE_RESTORE_KEY=$PREFIX" >> "$GITHUB_ENV"
     shell: bash
     env:
       RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}
+      JOB_ID: ${{ github.job }}
 
   - name: Get zig global cache dir
     if: env.JUST_USE_CARGO_ZIGBUILD
@@ -96,5 +98,4 @@ runs:
       path: ${{ steps.zig_global_cache_dir_path.outputs.cache_dir }}
       key: ${{ env.ZIG_CACHE_KEY }}
       restore-keys: |
-        ${{ env.ZIG_CACHE_KEY }}
         ${{ env.ZIG_CACHE_RESTORE_KEY }}

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -63,6 +63,13 @@ runs:
     env:
       RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}
 
+  - name: Find zig location and create symlink to it in ~/.local/bin
+    if: env.JUST_USE_CARGO_ZIGBUILD
+    run: |
+      python_package_path=$(python3 -m site --user-site)
+      ln -s "${python_package_path}/ziglang/zig" "$HOME/.local/bin/zig"
+    shell: bash
+
   - name: Calculate zig cache key
     if: env.JUST_USE_CARGO_ZIGBUILD
     run: |


### PR DESCRIPTION
This can be helpful in two situations:
 - If `cc` is bumped to a new release, then all the `*-sys` crates will be rebuilt even if their source doesn't change. Caching zig global_cache would avoid expensive rebuilds.
 - For target `x86_64h-apple-darwin`, it uses build-std which means the rust cache is quite ineffective (only build-dependencies are cached), so we would also need zig global_cache to avoid rebuilding c dependencies in CI.