### PR TITLE
 Fix `release-cli.yml`: Do not dry run cargo-publish

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -90,9 +90,7 @@ jobs:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
-        set -ex
-        cargo publish -p "$crate" --allow-dirty --dry-run
-        cargo package --no-verify -p "$crate" --allow-dirty
+        cargo package -p "$crate" --allow-dirty
     - if: fromJSON(inputs.info).is-release != 'true'
       name: Upload crate package as artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -84,13 +84,14 @@ jobs:
         name: minisign.pub
     - run: .github/scripts/ephemeral-crate.sh
 
+    - uses: ./.github/actions/just-setup
+
     - if: fromJSON(inputs.info).is-release != 'true'
       name: DRY-RUN Publish to crates.io
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: |
-        cargo package -p "$crate" --allow-dirty
+      run: cargo package -p "$crate" --allow-dirty --no-default-features
     - if: fromJSON(inputs.info).is-release != 'true'
       name: Upload crate package as artifact
       uses: actions/upload-artifact@v3
@@ -103,7 +104,7 @@ jobs:
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty
+      run: cargo publish -p "$crate" --allow-dirty  --no-default-features
 
     - if: fromJSON(inputs.info).is-release == 'true'
       name: Make release latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -82,9 +82,10 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: minisign.pub
-    - run: .github/scripts/ephemeral-crate.sh
 
     - uses: ./.github/actions/just-setup
+
+    - run: .github/scripts/ephemeral-crate.sh
 
     - if: fromJSON(inputs.info).is-release != 'true'
       name: DRY-RUN Publish to crates.io


### PR DESCRIPTION
If dependencies of `cargo-binstall` is bumped, then `cargo-publish` dry run will fail since the dependency has not published yet, so to fix this `cargo-publish` dry run is removed and `cargo-package` is now run with verification.

This PR also uses `just-setup` to cache rust/zig compilation and disables all features to reduce dependencies pulled in during `publish` step of `release-cli.yml`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>