### PR TITLE
Fix `release-cli.yml`: Skip `cargo-package` on dry-run

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -73,6 +73,7 @@ jobs:
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ inputs.CARGO_PROFILE_RELEASE_CODEGEN_UNITS }}
 
   publish:
+    if: fromJSON(inputs.info).is-release == 'true'
     needs: package
     permissions:
       contents: write
@@ -87,28 +88,13 @@ jobs:
 
     - run: .github/scripts/ephemeral-crate.sh
 
-    - if: fromJSON(inputs.info).is-release != 'true'
-      name: DRY-RUN Publish to crates.io
-      env:
-        crate: ${{ fromJSON(inputs.info).crate }}
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo package -p "$crate" --allow-dirty --no-default-features
-    - if: fromJSON(inputs.info).is-release != 'true'
-      name: Upload crate package as artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: crate-package
-        path: target/package/*.crate
-
-    - if: fromJSON(inputs.info).is-release == 'true'
-      name: Publish to crates.io
+    - name: Publish to crates.io
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish -p "$crate" --allow-dirty  --no-default-features
 
-    - if: fromJSON(inputs.info).is-release == 'true'
-      name: Make release latest
+    - name: Make release latest
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -118,8 +104,7 @@ jobs:
         promote: true
         file: minisign.pub
 
-    - if: fromJSON(inputs.info).is-release == 'true'
-      name: Delete signing key artifact
+    - name: Delete signing key artifact
       uses: geekyeggo/delete-artifact@v2
       with:
           name: minisign.key.age


### PR DESCRIPTION
Turns out that just skipping `cargo-publish` isn't good enough, `cargo-package` still checks for dependencies not present in https://crates.io , so I have to skip the entire `publish` step in `release-cli.yml`