### PR TITLE
Fix CI: Dry-run `cargo-publish` on crate to be published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,30 @@ jobs:
     - run: just avoid-dev-deps
     - run: just lint
 
+  pr-info:
+    outputs:
+      is-release: ${{ steps.meta.outputs.is-release }}
+      crate: ${{ steps.meta.outputs.crates-names }}
+
+    runs-on: ubuntu-latest
+    steps:
+    - id: meta
+      if: github.event_name == 'pull_request'
+      uses: cargo-bins/release-meta@v1
+      with:
+        event-data: ${{ toJSON(github.event) }}
+        extract-notes-under: '### Release notes'
+
   release-dry-run:
+    needs: pr-info
     uses: ./.github/workflows/release-cli.yml
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' || needs.pr-info.outputs.is-release
     secrets: inherit
     with:
       info: |
         {
           "is-release": false,
-          "crate": "cargo-binstall",
+          "crate": needs.pr-info.outputs.crate,
           "version": "0.0.0",
           "notes": ""
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
   release-dry-run:
     needs: pr-info
     uses: ./.github/workflows/release-cli.yml
-    if: github.event_name != 'pull_request' || needs.pr-info.outputs.is-release
+    if: github.event_name != 'pull_request' || needs.pr-info.outputs.is-release == 'true'
     secrets: inherit
     with:
       info: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       info: |
         {
           "is-release": false,
-          "crate": ${{ needs.pr-info.outputs.crate }},
+          "crate": "${{ needs.pr-info.outputs.crate }}",
           "version": "0.0.0",
           "notes": ""
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       info: |
         {
           "is-release": false,
-          "crate": needs.pr-info.outputs.crate,
+          "crate": needs.pr-info.outputs.crate || "",
           "version": "0.0.0",
           "notes": ""
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       info: |
         {
           "is-release": false,
-          "crate": needs.pr-info.outputs.crate || "",
+          "crate": ${{ needs.pr-info.outputs.crate }},
           "version": "0.0.0",
           "notes": ""
         }

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -87,13 +87,13 @@ jobs:
 
     - run: .github/scripts/ephemeral-crate.sh
 
-    - if: fromJSON(inputs.info).is-release != 'true'
+    - if: fromJSON(inputs.info).is-release != 'true' && fromJSON(inputs.info).crate != ''
       name: DRY-RUN Publish to crates.io
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo package -p "$crate" --allow-dirty --no-default-features
-    - if: fromJSON(inputs.info).is-release != 'true'
+      run: cargo publish -p "$crate" --allow-dirty --no-default-features
+    - if: fromJSON(inputs.info).is-release != 'true' && fromJSON(inputs.info).crate != ''
       name: Upload crate package as artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -90,7 +90,7 @@ jobs:
       env:
         crate: ${{ fromJSON(inputs.info).crate }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish -p "$crate" --allow-dirty --no-default-features
+      run: cargo publish --dry-run -p "$crate" --allow-dirty --no-default-features
     - if: fromJSON(inputs.info).is-release != 'true' && fromJSON(inputs.info).crate != ''
       name: Upload crate package as artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -83,8 +83,6 @@ jobs:
       with:
         name: minisign.pub
 
-    - uses: ./.github/actions/just-setup
-
     - run: .github/scripts/ephemeral-crate.sh
 
     - if: fromJSON(inputs.info).is-release != 'true' && fromJSON(inputs.info).crate != ''


### PR DESCRIPTION
If there's no crate to publish, do not dry-run `cargo-publish`.

Only dry-run `cargo-publish` on crate to be published to avoid `cargo-publish` error on `cargo-binstall` when one of its direct dependencies is bumped.