### PR TITLE
CI: Add sccache caching for external C/C++ libraries

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -22,6 +22,11 @@ runs:
     run: echo "tools=just" >>"$GITHUB_ENV"
     shell: bash
 
+  - name: Add scccahe to list of tools to install
+    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    run: echo "tools=$tools,sccache" >>"$GITHUB_ENV"
+    shell: bash
+
   - name: Add inputs.tools to tools to install
     if: inputs.tools != ''
     env:
@@ -63,6 +68,12 @@ runs:
     env:
       RUSTFLAGS: ${{ steps.retrieve-rustflags.outputs.RUSTFLAGS }}
 
+  - name: Calculate sys crate hashsum
+    run: |
+      HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | sha1sum | sed 's/[ -]*//g')
+      echo "SYS_CRATE_HASHSUM=$HASHSUM" >> "$GITHUB_ENV"
+    shell: bash
+
   - name: Find zig location and create symlink to it in ~/.local/bin
     if: env.JUST_USE_CARGO_ZIGBUILD
     run: |
@@ -74,7 +85,6 @@ runs:
     if: env.JUST_USE_CARGO_ZIGBUILD
     run: |
       ZIG_VERSION=$(zig version)
-      SYS_CRATE_HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | sha1sum | sed 's/[ -]*//g')
       PREFIX=v0-${JOB_ID}-zig-${ZIG_VERSION}-${CARGO_BUILD_TARGET}-
       echo "ZIG_CACHE_KEY=${PREFIX}${SYS_CRATE_HASHSUM}" >> "$GITHUB_ENV"
       echo -e "ZIG_CACHE_RESTORE_KEY=$PREFIX" >> "$GITHUB_ENV"
@@ -99,3 +109,24 @@ runs:
       key: ${{ env.ZIG_CACHE_KEY }}
       restore-keys: |
         ${{ env.ZIG_CACHE_RESTORE_KEY }}
+
+  - name: Create symlink to sccache for C/C++ compiler
+    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    run: ./github/scripts/install-sccache-symlinks.sh
+    shell: bash
+
+  - name: Configure sccache caching behavior
+    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    run: |
+      echo "SCCACHE_CACHE_SIZE=300M" >> "$GITHUB_ENV"
+      echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
+    shell: bash
+
+  - name: Cache sccache C/C++ cache
+    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    uses: actions/cache@v3
+    with:
+      path: ~/.cache/sccache
+      key: v0-${{ github.job }}-sccache-${{ env.CARGO_BUILD_TARGET }}-${{ env.SYS_CRATE_HASHSUM }}
+      restore-keys: |
+        v0-${{ github.job }}-sccache-${{ env.CARGO_BUILD_TARGET }}-

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -70,7 +70,7 @@ runs:
 
   - name: Calculate sys crate hashsum
     run: |
-      HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | sha1sum | sed 's/[ -]*//g')
+      HASHSUM=$(cargo tree --all-features --prefix none --no-dedupe --target "$CARGO_BUILD_TARGET" | grep -e '-sys' -e '^ring' | sort -u | .github/scripts/sha1sum.sh | sed 's/[ -]*//g')
       echo "SYS_CRATE_HASHSUM=$HASHSUM" >> "$GITHUB_ENV"
     shell: bash
 

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -112,7 +112,7 @@ runs:
 
   - name: Create symlink to sccache for C/C++ compiler
     if: "! env.JUST_USE_CARGO_ZIGBUILD"
-    run: ./github/scripts/install-sccache-symlinks.sh
+    run: .github/scripts/install-sccache-symlinks.sh
     shell: bash
 
   - name: Configure sccache caching behavior

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -23,7 +23,7 @@ runs:
     shell: bash
 
   - name: Add scccahe to list of tools to install
-    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    if: "! env.JUST_USE_CARGO_ZIGBUILD"
     run: echo "tools=$tools,sccache" >>"$GITHUB_ENV"
     shell: bash
 
@@ -111,19 +111,19 @@ runs:
         ${{ env.ZIG_CACHE_RESTORE_KEY }}
 
   - name: Create symlink to sccache for C/C++ compiler
-    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    if: "! env.JUST_USE_CARGO_ZIGBUILD"
     run: ./github/scripts/install-sccache-symlinks.sh
     shell: bash
 
   - name: Configure sccache caching behavior
-    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    if: "! env.JUST_USE_CARGO_ZIGBUILD"
     run: |
       echo "SCCACHE_CACHE_SIZE=300M" >> "$GITHUB_ENV"
       echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
     shell: bash
 
   - name: Cache sccache C/C++ cache
-    if: ! env.JUST_USE_CARGO_ZIGBUILD
+    if: "! env.JUST_USE_CARGO_ZIGBUILD"
     uses: actions/cache@v3
     with:
       path: ~/.cache/sccache

--- a/.github/scripts/install-sccache-symlinks.sh
+++ b/.github/scripts/install-sccache-symlinks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+sccache_path=$(command -v sccache)
+
+mkdir -p ~/.local/bin/
+
+for each in cl.exe g++ c++ clang++ gcc cc clang clang-cl ; do
+    if command -v $each &> /dev/null; then
+        ln -s "$sccache_path" ~/.local/bin/$each
+    fi
+done

--- a/.github/scripts/sha1sum.sh
+++ b/.github/scripts/sha1sum.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v sha1sum &>/dev/null; then
+    exec sha1sum
+else
+    exec shasum
+fi


### PR DESCRIPTION
In case where crates like `cc`, `zstd-sys`, `lzma-sys`, `bzip-sys`, `libz-ng-sys` and `ring` is updated and the `build.rs`s for external C/C++ libraries are rebuilt, haivng sccache caching for them will save a lot of time with a little bit cache compared to caching in Rust.