### PR TITLE
Use $Env:CARGO_HOME in ps1 install script

### DIFF
--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -18,8 +18,9 @@ Write-Host ""
 Invoke-Expression "$tmpdir\cargo-binstall\cargo-binstall.exe -y --force cargo-binstall"
 Remove-Item -Force $tmpdir\cargo-binstall.zip
 Remove-Item -Recurse -Force $tmpdir\cargo-binstall
-if ($Env:Path -split ";" -notcontains "$HOME\.cargo\bin") {
+$cargo_home = if ($Env:CARGO_HOME -ne $null) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
+if ($Env:Path -split ";" -notcontains "$cargo_home\bin") {
 	Write-Host ""
-	Write-Host "Your path is missing $HOME\.cargo\bin, you might want to add it." -ForegroundColor Red
+	Write-Host "Your path is missing $cargo_home\bin, you might want to add it." -ForegroundColor Red
 	Write-Host ""
 }


### PR DESCRIPTION
I have `$env:CARGO_HOME` set and just had this warning tell me I was missing the wrong path from my path. This makes the ps1 script do the same thing as the sh script and look in `$env:CARGO_HOME` if present.

I originally used `??` to null coalesce, but switched to just an `if` expression since `??` was only added in pwsh 7 (PowerShell Core, the cross platform one you need to install), thus isn't available in Windows Powershell. The `if` works in Windows PowerShell as well.