### PR TITLE
fix: remove a trailing slash in registry index URL

### DIFF
--- a/crates/binstalk-registry/src/lib.rs
+++ b/crates/binstalk-registry/src/lib.rs
@@ -152,7 +152,7 @@ impl Registry {
 
     fn from_str_inner(s: &str) -> Result<Self, InvalidRegistryErrorInner> {
         if let Some(s) = s.strip_prefix("sparse+") {
-            let url = Url::parse(s)?;
+            let url = Url::parse(s.trim_end_matches('/'))?;
 
             let scheme = url.scheme();
             if scheme != "http" && scheme != "https" {


### PR DESCRIPTION
This is a minor nit, but `cargo` itself tolerates a trailing slash at the end of the registry index URL, automatically trimming it before building URLs for sparse interaction. `cargo-binstall` does not, and thus, if a registry index URL includes a trailing slash, it sends queries to a URL with a double slash. For JFrog Artifactory, this results in an error being returned:

```console
❯ cargo binstall --locked --registry private my-tool
 INFO resolve: Resolving package: 'my-tool'
ERROR Fatal error:
  × For crate mytool: could not GET https://example.com/artifactory/api/cargo/cargo-local/index//config.json: HTTP status client
  │ error (400 Bad Request) for url (https://example.com/artifactory/api/cargo/cargo-local/index//config.json)
  ├─▶ could not GET https://example.com/artifactory/api/cargo/cargo-local/index//config.json: HTTP status client error (400 Bad Request) for
  │   url (https://example.com/artifactory/api/cargo/cargo-local/index//config.json)
  ╰─▶ HTTP status client error (400 Bad Request) for url (https://example.com/artifactory/api/cargo/cargo-local/index//config.json)
```

When using `cargo install`, cargo successfully builds the URL without the double slash, and is thus able to install the binary without issue. Of note, the [embedded definition](https://github.com/rust-lang/cargo/blob/6982b443cf438732f6652c798bff9244d77f753c/src/cargo/sources/registry/mod.rs#L223C41-L223C72) of the sparse index URL inside of `cargo` is `"sparse+https://index.crates.io/"`. I think that this means that `cargo-binstall`'s requests to crates.io likely look like: `https://index.crates.io//config.json` (I haven't confirmed this), with an empty path segment in there, but that crates.io, as more of a static webserver, is more tolerant of the double slashes.

This PR adds a small change to parsing of the registry in the case of a sparse index which removes a trailing `/`, if present, enabling install to proceed similarly to `cargo install`.