### PR TITLE
feat: Add strategies environment variable

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -151,7 +151,12 @@ pub struct Args {
     /// binstall will run the strategies specified in order.
     ///
     /// Default value is "crate-meta-data,quick-install,compile".
-    #[clap(help_heading = "Overrides", long, value_delimiter(','))]
+    #[clap(
+        help_heading = "Overrides",
+        long,
+        value_delimiter(','),
+        env = "BINSTALL_STRATEGIES"
+    )]
     pub(crate) strategies: Vec<Strategy>,
 
     /// Disable the strategies specified.


### PR DESCRIPTION
## Overview

Adds an environment variable for the `--strategies` parameter to control strategies on a per environment level, rather than per command.