### PR TITLE
Fix install-from-binstall-release.sh for Git Bash users on Windows

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -82,3 +82,32 @@ jobs:
 
     - name: Verify `cargo-binstall` installation
       run: cargo binstall -vV
+
+  windows-bash:
+    strategy:
+      fail-fast: false
+      matrix:
+        set_cargo_home: [t, f]
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set `CARGO_HOME`
+      if: matrix.set_cargo_home == 't'
+      shell: bash
+      run: |
+        CARGO_HOME="$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')"
+        mkdir -p "${CARGO_HOME}/bin"
+        echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
+        echo "${CARGO_HOME}/bin" >> $GITHUB_PATH
+
+    - name: Install `cargo-binstall` using scripts
+      shell: bash
+      run: ./install-from-binstall-release.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Verify `cargo-binstall` installation
+      run: cargo binstall -vV

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -110,4 +110,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Verify `cargo-binstall` installation
+      shell: bash
       run: cargo binstall -vV

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-if [ "$OS" = "Windows_NT" ]; then
+if [ "${OS-}" = "Windows_NT" ]; then
     # https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1
     # shellcheck disable=SC2016
     powershell -c '$ErrorActionPreference = "Stop"

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 if [ "$OS" = "Windows_NT" ]; then
     # https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1
+    # shellcheck disable=SC2016
     powershell -c '$ErrorActionPreference = "Stop"
 Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -2,38 +2,6 @@
 
 set -euxo pipefail
 
-if [ "${OS-}" = "Windows_NT" ]; then
-    # https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1
-    # shellcheck disable=SC2016
-    powershell -c '$ErrorActionPreference = "Stop"
-Set-PSDebug -Trace 1
-$tmpdir = $Env:TEMP
-$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
-$proc_arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
-if ($proc_arch -eq "AMD64") {
-	$arch = "x86_64"
-} elseif ($proc_arch -eq "ARM64") {
-	$arch = "aarch64"
-} else {
-	Write-Host "Unsupported Architecture: $type" -ForegroundColor Red
-	[Environment]::Exit(1)
-}
-$url = "$base_url$arch-pc-windows-msvc.zip"
-Invoke-WebRequest $url -OutFile $tmpdir\cargo-binstall.zip
-Expand-Archive -Force $tmpdir\cargo-binstall.zip $tmpdir\cargo-binstall
-Write-Host ""
-Invoke-Expression "$tmpdir\cargo-binstall\cargo-binstall.exe -y --force cargo-binstall"
-Remove-Item -Force $tmpdir\cargo-binstall.zip
-Remove-Item -Recurse -Force $tmpdir\cargo-binstall
-$cargo_home = if ($Env:CARGO_HOME -ne $null) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
-if ($Env:Path -split ";" -notcontains "$cargo_home\bin") {
-	Write-Host ""
-	Write-Host "Your path is missing $cargo_home\bin, you might want to add it." -ForegroundColor Red
-	Write-Host ""
-}'
-    exit
-fi
-
 cd "$(mktemp -d)"
 
 base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
@@ -52,6 +20,12 @@ elif [ "$os" == "Linux" ]; then
 
     url="${base_url}${target}.tgz"
     curl -L --proto '=https' --tlsv1.2 -sSf "$url" | tar -xvzf -
+elif [ "${OS-}" = "Windows_NT" ]; then
+    machine="$(uname -m)"
+    target="${machine}-pc-windows-msvc"
+    url="${base_url}${target}.zip"
+    curl -LO --proto '=https' --tlsv1.2 -sSf "$url"
+    unzip "cargo-binstall-${target}.zip"
 else
     echo "Unsupported OS ${os}"
     exit 1

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 if [ "$OS" = "Windows_NT" ]; then
     # https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1
-    pwsh -c '$ErrorActionPreference = "Stop"
+    powershell -c '$ErrorActionPreference = "Stop"
 Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP
 $base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -2,6 +2,37 @@
 
 set -euxo pipefail
 
+if [ "$OS" = "Windows_NT" ]; then
+    # https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1
+    pwsh -c '$ErrorActionPreference = "Stop"
+Set-PSDebug -Trace 1
+$tmpdir = $Env:TEMP
+$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+$proc_arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
+if ($proc_arch -eq "AMD64") {
+	$arch = "x86_64"
+} elseif ($proc_arch -eq "ARM64") {
+	$arch = "aarch64"
+} else {
+	Write-Host "Unsupported Architecture: $type" -ForegroundColor Red
+	[Environment]::Exit(1)
+}
+$url = "$base_url$arch-pc-windows-msvc.zip"
+Invoke-WebRequest $url -OutFile $tmpdir\cargo-binstall.zip
+Expand-Archive -Force $tmpdir\cargo-binstall.zip $tmpdir\cargo-binstall
+Write-Host ""
+Invoke-Expression "$tmpdir\cargo-binstall\cargo-binstall.exe -y --force cargo-binstall"
+Remove-Item -Force $tmpdir\cargo-binstall.zip
+Remove-Item -Recurse -Force $tmpdir\cargo-binstall
+$cargo_home = if ($Env:CARGO_HOME -ne $null) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
+if ($Env:Path -split ";" -notcontains "$cargo_home\bin") {
+	Write-Host ""
+	Write-Host "Your path is missing $cargo_home\bin, you might want to add it." -ForegroundColor Red
+	Write-Host ""
+}'
+    exit
+fi
+
 cd "$(mktemp -d)"
 
 base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"


### PR DESCRIPTION
Adds an additional `elif [ "$OS" = "Windows_NT" ]` check to then use the Windows binaries.

<details><summary>OLD</summary>

Now this works on Windows:

```sh
jcbhm@PIG-2016 MINGW64 ~
$ curl -L --proto '=https' --tlsv1.2 -sSf https://github.com/jcbhmr/cargo-binstall/raw/patch-1/install-from-binstall-release.sh | bash
```

It uses `powershell -c` to directly run the code that I copied from https://github.com/cargo-bins/cargo-binstall/blob/main/install-from-binstall-release.ps1. You could also do this:

```sh
powershell -c 'Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content'
```

if you so choose.

Previously when using Git Bash it wouldn't work:

```sh
jcbhm@PIG-2016 MINGW64 ~
$ curl -L --proto '=https' --tlsv1.2 -sSf https://github.com/cargo-bins/cargo-binstall/raw/main/install-from-binstall-release.sh | bash                             ++ mktemp -d
+ cd /tmp/tmp.1O4sd8oAjU
+ base_url=https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-
++ uname -s
+ os=MINGW64_NT-10.0-19045
+ '[' MINGW64_NT-10.0-19045 == Darwin ']'
+ '[' MINGW64_NT-10.0-19045 == Linux ']'
+ echo 'Unsupported OS MINGW64_NT-10.0-19045'
Unsupported OS MINGW64_NT-10.0-19045
+ exit 1
```

</details>