### PR TITLE
Disable zlib-ng for aarch64 linux and re-enable it for x64 linux

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,9 +78,9 @@ support-pkg-config := if target == target-host {
     if target-os == "linux" { "true" } else { "" }
 } else { "" }
 
-#} else if target == "x86_64-unknown-linux-gnu" {
+#} else if target == "aarch64-unknown-linux-gnu" {
 #    ",zlib-ng"
-#} else if target == "x86_64-unknown-linux-musl" {
+#} else if target == "aarch64-unknown-linux-musl" {
 #    ",zlib-ng"
 git-max-perf-feature := if target == "x86_64-apple-darwin" {
     ",zlib-ng"
@@ -90,9 +90,9 @@ git-max-perf-feature := if target == "x86_64-apple-darwin" {
     ",zlib-ng"
 } else if target-os == "windows" {
     ",zlib-ng"
-} else if target == "aarch64-unknown-linux-gnu" {
+} else if target == "x86_64-unknown-linux-gnu" {
     ",zlib-ng"
-} else if target == "aarch64-unknown-linux-musl" {
+} else if target == "x86_64-unknown-linux-musl" {
     ",zlib-ng"
 } else {
     ""


### PR DESCRIPTION
To fix the error in #1563 CI and also re-enable zlib-ng for x86_64 linux to improve its performance since it is one of the most used targets.