### PR TITLE
Fix detect-targets on android targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,34 @@ jobs:
           --mount src="$PWD/detect-targets",dst=/detect-targets,type=bind \
           nixos/nix /detect-targets )" = x86_64-unknown-linux-musl ]
 
+  detect-targets-android-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-linux-android
+
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add ${{ matrix.target }}
+      run: rustup target add ${{ matrix.target }}
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-all-crates: true
+    - name: Build detect-targets
+      run: |
+        cargo check --target ${{ matrix.target }}
+      # Set working directory here, otherwise `cargo-check` would download
+      # and build quite a few unused dependencies.
+      working-directory: crates/detect-targets
+
+
   # Dummy job to have a stable name for the "all tests pass" requirement
   tests-pass:
     name: Tests pass

--- a/crates/detect-targets/src/detect.rs
+++ b/crates/detect-targets/src/detect.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 use tracing::debug;
 
 cfg_if! {
-    if #[cfg(target_os = "linux")] {
+    if #[cfg(any(target_os = "linux",  target_os = "android"))] {
         mod linux;
     } else if #[cfg(target_os = "macos")] {
         mod macos;
@@ -53,7 +53,7 @@ pub async fn detect_targets() -> Vec<String> {
             let mut targets = vec![target];
             targets.extend(windows::detect_alternative_targets(&targets[0]));
             targets
-        } else if #[cfg(target_os = "linux")] {
+        } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
             // Linux is a bit special, since the result from `guess_host_triple`
             // might be wrong about whether glibc or musl is used.
             linux::detect_targets(target).await


### PR DESCRIPTION
#1573

By enabling linux fallback on Android.

Also add CI regression test for aarch64-linux-android target.