### PR TITLE
Fix missing spaces in error log

### DIFF
--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -250,8 +250,8 @@ async fn download_extract_and_verify(
 
                     if required_features.is_empty() {
                         error!(
-                            "When resolving {name} bin {bin_name} is not found.\
-This binary is not optional so it must be included in the archive, please contact with\
+                            "When resolving {name} bin {bin_name} is not found. \
+This binary is not optional so it must be included in the archive, please contact with \
 upstream to fix this issue."
                         );
                         // This bin is not optional, error


### PR DESCRIPTION
Ran into this randomly, and got hung up for a second trying to understand the word `withupstream`