### PR TITLE
Update crates.io description for cargo-binstall

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-binstall"
-description = "Rust binary package installer for CI integration"
+description = "Binary installation for rust projects"
 repository = "https://github.com/cargo-bins/cargo-binstall"
 documentation = "https://docs.rs/cargo-binstall"
 version = "1.6.0"


### PR DESCRIPTION
Since the one on GitHub has changed.