### PR TITLE
Fix: Load system-wide native cert on rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,6 +3172,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3274,6 +3275,18 @@ dependencies = [
  "ring 0.17.7",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -66,6 +66,8 @@ rustls = [
     "__tls",
 
     "reqwest/rustls-tls",
+    "reqwest/rustls-tls-webpki-roots",
+    "reqwest/rustls-tls-native-roots",
 
     # Enable the following features only if hickory-resolver is enabled.
     "hickory-resolver?/dns-over-rustls",


### PR DESCRIPTION
Related: https://github.com/nabijaczleweli/cargo-update/issues/250