### PR TITLE
CI: Use runner `macos-14` which uses M1 machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
@@ -78,7 +78,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: aarch64-pc-windows-msvc
             os: windows-latest
     runs-on: ${{ matrix.os }}
@@ -108,7 +108,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/gh-action.yml
+++ b/.github/workflows/gh-action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-14, ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-14, ubuntu-latest]
         set_cargo_home: [t, f]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { o: macos-latest,   t: x86_64-apple-darwin,                    r: true          }
-          - { o: macos-latest,   t: x86_64h-apple-darwin,                                    }
-          - { o: macos-latest,   t: aarch64-apple-darwin                                     }
+          - { o: macos-14,   t: x86_64-apple-darwin,                    r: true          }
+          - { o: macos-14,   t: x86_64h-apple-darwin,                                    }
+          - { o: macos-14,   t: aarch64-apple-darwin                                     }
           - { o: ubuntu-latest,  t: x86_64-unknown-linux-gnu,      g: 2.17, r: true, c: true }
           - { o: ubuntu-latest,  t: armv7-unknown-linux-gnueabihf, g: 2.17,          c: true }
           - { o: ubuntu-latest,  t: aarch64-unknown-linux-gnu,     g: 2.17,          c: true }
@@ -125,7 +125,7 @@ jobs:
     name: universal-apple-darwin
     permissions:
       contents: write
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       JUST_FOR_RELEASE: true
 

--- a/e2e-tests/subcrate.sh
+++ b/e2e-tests/subcrate.sh
@@ -14,9 +14,9 @@ mkdir -p "$othertmpdir/bin"
 cp "./$1" "$othertmpdir/bin/"
 
 # cargo-audit
-cargo binstall --no-confirm cargo-audit@0.17.5 --strategies crate-meta-data
+cargo binstall --no-confirm cargo-audit@0.18.3 --strategies crate-meta-data
 
 cargo_audit_version="$(cargo audit --version)"
 echo "$cargo_audit_version"
 
-[ "$cargo_audit_version" = "cargo-audit 0.17.5" ]
+[ "$cargo_audit_version" = "cargo-audit 0.18.3" ]


### PR DESCRIPTION
`macos-14` provides 3-core M1, 7G mem and 14G stroage, while `macos-latest` (`macos-13` as of writing) provides 4-core intel, 14G mem and 14G storage.

While the memory is cut by half and core count reduce by 1, I believe that it would still speedup the CI since M1 is much more powerful than previous Intel CPU used in `macos-13`.

It would also allow us to run tests on aarch64-apple-darwin and on universal-apple-darwin, if necessary.