### PR TITLE
Fix release-pr.yml: Do not run semver-checks for leon-macros

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -56,7 +56,7 @@ jobs:
           pr-label: release
           pr-release-notes: ${{ inputs.crate == 'bin' }}
           pr-template-file: .github/scripts/release-pr-template.ejs
-          check-semver: ${{ inputs.crate != 'bin' }}
+          check-semver: ${{ inputs.crate != 'bin' && inputs.crate != 'leon-macros' }}
           check-package: true
         env:
           RUSTFLAGS: --cfg reqwest_unstable


### PR DESCRIPTION
leon-macros is a proc-macro crate and cargo-semver-checks cannot perform semver checks on proc-macro crates.