### PR TITLE
Bump dep reqwest in binstalk-downloader from 0.11.26 to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,11 +294,10 @@ dependencies = [
  "futures-util",
  "hickory-resolver",
  "httpdate",
- "hyper",
  "ipconfig",
  "once_cell",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.2",
  "serde",
  "serde-tuple-vec-map",
  "serde_json",
@@ -1894,7 +1893,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest",
+ "reqwest 0.11.27",
  "thiserror",
 ]
 
@@ -2015,7 +2014,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -2032,22 +2031,7 @@ dependencies = [
  "bytes",
  "fastrand 1.9.0",
  "futures-util",
- "http",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "h3"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83e1915177ea624b5bbbdb16bc54f0c106c9664892c695f995e53f5c6793b80"
-dependencies = [
- "bytes",
- "fastrand 2.0.2",
- "futures-util",
- "http",
- "pin-project-lite",
+ "http 0.2.12",
  "tokio",
  "tracing",
 ]
@@ -2060,24 +2044,9 @@ checksum = "2d4a1a1763e4f3e82ee9f1ecf2cf862b22cc7316ebe14684e42f94532b5ec64d"
 dependencies = [
  "bytes",
  "futures",
- "h3 0.0.2",
+ "h3",
  "quinn",
  "quinn-proto",
- "tokio-util",
-]
-
-[[package]]
-name = "h3-quinn"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9675014d703c3d516a121757bbc02e53f1ee838e0729fc7534b35024a81ae4"
-dependencies = [
- "bytes",
- "futures",
- "h3 0.0.3",
- "quinn",
- "quinn-proto",
- "tokio",
  "tokio-util",
 ]
 
@@ -2124,9 +2093,9 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "h3 0.0.2",
- "h3-quinn 0.0.3",
- "http",
+ "h3",
+ "h3-quinn",
+ "http 0.2.12",
  "idna 0.4.0",
  "ipnet",
  "native-tls",
@@ -2134,13 +2103,13 @@ dependencies = [
  "quinn",
  "rand",
  "ring 0.16.20",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "thiserror",
  "tinyvec",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -2160,12 +2129,12 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "rustls",
+ "rustls 0.21.10",
  "smallvec",
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
 ]
 
@@ -2201,13 +2170,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2240,8 +2243,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2254,30 +2257,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2978,12 +3026,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
  "bytes",
- "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -2999,7 +3046,7 @@ dependencies = [
  "rand",
  "ring 0.16.20",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "slab",
  "thiserror",
  "tinyvec",
@@ -3153,21 +3200,54 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "h3 0.0.3",
- "h3-quinn 0.0.4",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
  "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3176,18 +3256,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
+ "rustls 0.22.3",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -3281,18 +3360,33 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
+name = "rustls"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -3307,12 +3401,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3606,6 +3727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "supports-color"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,7 +3964,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3926,6 +4064,28 @@ dependencies = [
  "toml_datetime",
  "winnow 0.6.5",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -4261,9 +4421,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "widestring"
@@ -4625,6 +4788,12 @@ dependencies = [
  "quote",
  "syn 2.0.55",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "gix-worktree-state",
  "once_cell",
  "parking_lot",
+ "reqwest 0.11.27",
  "smallvec",
  "thiserror",
 ]
@@ -2277,6 +2278,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "rustls 0.21.10",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
@@ -2290,6 +2305,19 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3209,24 +3237,32 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -3245,8 +3281,8 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "hyper-rustls",
- "hyper-tls",
+ "hyper-rustls 0.26.0",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3274,7 +3310,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.1",
  "winreg 0.50.0",
 ]
 
@@ -4418,6 +4454,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -11,8 +11,22 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 async-trait = "0.1.68"
-async-compression = { version = "0.4.4", features = ["gzip", "zstd", "xz", "bzip2", "tokio"] }
-async_zip = { version = "0.0.16", features = ["deflate", "deflate64", "bzip2", "lzma", "zstd", "xz", "tokio"] }
+async-compression = { version = "0.4.4", features = [
+    "gzip",
+    "zstd",
+    "xz",
+    "bzip2",
+    "tokio",
+] }
+async_zip = { version = "0.0.16", features = [
+    "deflate",
+    "deflate64",
+    "bzip2",
+    "lzma",
+    "zstd",
+    "xz",
+    "tokio",
+] }
 binstalk-types = { version = "0.7.0", path = "../binstalk-types" }
 bytes = "1.4.0"
 bzip2 = "0.4.4"
@@ -21,7 +35,12 @@ flate2 = { version = "1.0.28", default-features = false }
 futures-util = "0.3.30"
 futures-io = "0.3.30"
 httpdate = "1.0.2"
-reqwest = { version = "0.11.25", features = ["stream", "gzip", "brotli", "deflate"], default-features = false }
+reqwest = { version = "0.12.0", features = [
+    "stream",
+    "gzip",
+    "brotli",
+    "deflate",
+], default-features = false }
 percent-encoding = "2.2.0"
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 serde-tuple-vec-map = "1.0.1"
@@ -33,12 +52,19 @@ serde_json = { version = "1.0.107", optional = true }
 tar = { package = "binstall-tar", version = "0.4.39" }
 tempfile = "3.5.0"
 thiserror = "1.0.52"
-tokio = { version = "1.35.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs"], default-features = false }
+tokio = { version = "1.35.0", features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "fs",
+], default-features = false }
 tokio-tar = "0.3.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.39"
-hickory-resolver = { version = "0.24.0", optional = true, features = ["dnssec-ring"] }
-hyper = { version = "0.14.27", optional = true }
+hickory-resolver = { version = "0.24.0", optional = true, features = [
+    "dnssec-ring",
+] }
 once_cell = { version = "1.18.0", optional = true }
 url = "2.3.1"
 
@@ -83,14 +109,17 @@ native-tls = [
 ]
 
 # Enable hickory-resolver so that features on it will also be enabled.
-hickory-dns = ["hickory-resolver", "default-net", "ipconfig", "hyper", "once_cell"]
+hickory-dns = ["hickory-resolver", "default-net", "ipconfig", "once_cell"]
 
 # Deprecated alias for hickory-dns, since trust-dns is renamed to hickory-dns
 trust-dns = ["hickory-dns"]
 
+# HTTP3 is temporarily disabled by reqwest.
+#
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.
-http3 = ["reqwest/http3"]
+#http3 = ["reqwest/http3"]
+http3 = []
 
 zstd-thin = ["zstd/thin"]
 

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -1,9 +1,8 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use hickory_resolver::TokioAsyncResolver;
-use hyper::client::connect::dns::Name;
 use once_cell::sync::OnceCell;
-use reqwest::dns::{Addrs, Resolve};
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tracing::{debug, instrument, warn};
 
 #[cfg(windows)]
@@ -15,7 +14,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 pub struct TrustDnsResolver(Arc<OnceCell<TokioAsyncResolver>>);
 
 impl Resolve for TrustDnsResolver {
-    fn resolve(&self, name: Name) -> reqwest::dns::Resolving {
+    fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
         Box::pin(async move {
             let resolver = resolver.0.get_or_try_init(new_resolver)?;

--- a/crates/binstalk-registry/Cargo.toml
+++ b/crates/binstalk-registry/Cargo.toml
@@ -13,7 +13,9 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 async-trait = "0.1.68"
 base16 = "0.2.1"
-binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = ["json"] }
+binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = [
+    "json",
+] }
 binstalk-types = { version = "0.7.0", path = "../binstalk-types" }
 cargo-toml-workspace = { version = "5.0.0", path = "../cargo-toml-workspace" }
 compact_str = { version = "0.7.0", features = ["serde"] }
@@ -28,17 +30,25 @@ sha2 = "0.10.7"
 simple-git = { version = "0.2.4", optional = true }
 tempfile = "3.5.0"
 thiserror = "1.0.52"
-tokio = { version = "1.35.0", features = ["rt", "sync"], default-features = false }
+tokio = { version = "1.35.0", features = [
+    "rt",
+    "sync",
+], default-features = false }
 tracing = "0.1.39"
 url = "2.3.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml_edit = { version = "0.22.4", features = ["serde"] }
-binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = ["rustls"] }
+binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = [
+    "rustls",
+] }
 
 [features]
 git = ["simple-git"]
+
+rustls = ["simple-git?/rustls"]
+native-tls = ["simple-git?/native-tls"]
 
 crates_io_api = []
 

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -11,14 +11,20 @@ license = "GPL-3.0-only"
 
 [dependencies]
 binstalk-bins = { version = "0.4.0", path = "../binstalk-bins" }
-binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = ["gh-api-client"] }
-binstalk-fetchers = { version = "0.4.0", path = "../binstalk-fetchers", features = ["quickinstall"] }
+binstalk-downloader = { version = "0.10.1", path = "../binstalk-downloader", default-features = false, features = [
+    "gh-api-client",
+] }
+binstalk-fetchers = { version = "0.4.0", path = "../binstalk-fetchers", features = [
+    "quickinstall",
+] }
 binstalk-registry = { version = "0.7.0", path = "../binstalk-registry" }
 binstalk-types = { version = "0.7.0", path = "../binstalk-types" }
 cargo-toml-workspace = { version = "5.0.0", path = "../cargo-toml-workspace" }
 command-group = { version = "5.0.1", features = ["with-tokio"] }
 compact_str = { version = "0.7.0", features = ["serde"] }
-detect-targets = { version = "0.1.15", path = "../detect-targets", features = ["tracing"] }
+detect-targets = { version = "0.1.15", path = "../detect-targets", features = [
+    "tracing",
+] }
 either = "1.8.1"
 itertools = "0.12.0"
 jobslot = { version = "0.2.11", features = ["tokio"] }
@@ -31,7 +37,11 @@ strum = "0.26.1"
 target-lexicon = { version = "0.12.11", features = ["std"] }
 tempfile = "3.5.0"
 thiserror = "1.0.52"
-tokio = { version = "1.35.0", features = ["rt", "process", "sync"], default-features = false }
+tokio = { version = "1.35.0", features = [
+    "rt",
+    "process",
+    "sync",
+], default-features = false }
 tracing = "0.1.39"
 url = { version = "2.3.1", features = ["serde"] }
 
@@ -46,8 +56,8 @@ pkg-config = ["binstalk-downloader/pkg-config"]
 
 zlib-ng = ["binstalk-downloader/zlib-ng"]
 
-rustls = ["binstalk-downloader/rustls"]
-native-tls = ["binstalk-downloader/native-tls"]
+rustls = ["binstalk-downloader/rustls", "binstalk-registry/rustls"]
+native-tls = ["binstalk-downloader/native-tls", "binstalk-registry/native-tls"]
 
 trust-dns = ["binstalk-downloader/trust-dns"]
 


### PR DESCRIPTION
reqwest 0.11.27 is still used in gix, but it will be upgraded in next gix release.