### PR TITLE
Bump reqwest to 0.12.4 and enable feature zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,9 +3176,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "async-compression",
  "base64 0.22.0",

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -35,8 +35,10 @@ flate2 = { version = "1.0.28", default-features = false }
 futures-util = "0.3.30"
 futures-io = "0.3.30"
 httpdate = "1.0.2"
-reqwest = { version = "0.12.0", features = [
+reqwest = { version = "0.12.4", features = [
+    "http2",
     "stream",
+    "zstd",
     "gzip",
     "brotli",
     "deflate",


### PR DESCRIPTION
to support compression using zstd.

Also enable `http2` (which is now enabled by other deps of this crate).

Fixed #1666