### PR TITLE
Speedup ci by using personal access token for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     - run: just test
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CI_TEST_GITHUB_TOKEN }}
 
   cross-check:
     strategy:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -83,7 +83,7 @@ jobs:
       if: "matrix.r"
       run: just e2e-tests
       env:
-        GITHUB_TOKEN: ${{ secrets.CI_TEST_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN }}
 
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -83,7 +83,7 @@ jobs:
       if: "matrix.r"
       run: just e2e-tests
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CI_TEST_GITHUB_TOKEN }}
 
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
According to [GitHub Rate limits for the REST API doc](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users), personal access token has rate-limit of 5,000 requests per hour, the builtin `secrets.GITHUB_TOKEN` only has 1,000 requests per hour per repository.

So I setup `secrets.CI_TEST_GITHUB_TOKEN` and use it for all testing in `ci.yml` to avoid hitting the rate limit of `secrets.GITHUB_TOKEN`, once the rate limit is hit the CI would become either very slow or straight up fail.

I also setup `secrets.CI_RELEASE_TEST_GITHUB_TOKEN` for e2e-test run in `release-packages.yml`.

Other tasks (taiki-e/install-action, creating new releases/tags/prs, etc) would still use the `secrets.GITHUB_TOKEN`, since that should be quite enough for them, and it would increase the maximum API hits per hour by using 3 tokens instead of one.