### PR TITLE
Fix binstalk_fetchers::FetchError definition

### DIFF
--- a/crates/binstalk-fetchers/src/lib.rs
+++ b/crates/binstalk-fetchers/src/lib.rs
@@ -40,7 +40,6 @@ pub struct InvalidPkgFmtError {
 
 #[derive(Debug, ThisError, miette::Diagnostic)]
 #[non_exhaustive]
-#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum FetchError {
     #[error(transparent)]
     Download(#[from] DownloadError),


### PR DESCRIPTION
Rm useless cfg on it