### PR TITLE
fix(resolve): prefer official binaries

### DIFF
--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -101,9 +101,9 @@ async fn resolve_inner(
     ));
 
     handles.extend(
-        desired_targets
-            .into_iter()
-            .map(|(triple, target)| {
+        resolvers
+            .iter()
+            .cartesian_product(desired_targets.into_iter().map(|(triple, target)| {
                 debug!("Building metadata for target: {target}");
 
                 let target_meta = package_info.meta.merge_overrides(
@@ -117,9 +117,8 @@ async fn resolve_inner(
                     meta: target_meta,
                     target_related_info: triple,
                 })
-            })
-            .cartesian_product(resolvers)
-            .map(|(target_data, f)| {
+            }))
+            .map(|(f, target_data)| {
                 let fetcher = f(
                     opts.client.clone(),
                     opts.gh_api_client.clone(),

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -8,7 +8,7 @@ unset CARGO_INSTALL_ROOT
 #    to find versions matching <= 1.3.3
 #  - `cargo-quickinstall` would test `fetch_crate_cratesio_version_matched` ability
 #    to find latest stable version.
-crates="b3sum@<=1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3 cargo-quickinstall"
+crates="b3sum@<=1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3 cargo-quickinstall jj-cli@0.18.0"
 
 CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
 export CARGO_HOME
@@ -54,3 +54,8 @@ echo "$miniserve_version"
 [ "$miniserve_version" = "miniserve 0.23.0" ]
 
 cargo-quickinstall -V
+
+jj_version="$(jj --version)"
+echo "$jj_version"
+
+[ "$jj_version" = "jj 0.18.0-9fb5307b7886e390c02817af7c31b403f0279144" ]


### PR DESCRIPTION
This is an alternative idea to solve #1721.

It makes much more sense to me to prefer official binaries (i.e. ones resolved from an "earlier strategy") with a secondary target (e.g. `musl` instead of `gnu` on linux) over binaries from a later strategy (quickinstall).

I have only quickly rummaged through the source code and confirmed it works with installing `jj-cli` from the official release page instead of quickinstall, I don't know if this impacts something else.