### PR TITLE
Use binary name when searching for artifacts

### DIFF
--- a/crates/binstalk-fetchers/src/gh_crate_meta.rs
+++ b/crates/binstalk-fetchers/src/gh_crate_meta.rs
@@ -15,6 +15,8 @@ use crate::{
     SignaturePolicy, SignatureVerifier, TargetDataErased, DEFAULT_GH_API_RETRY_DURATION,
 };
 
+pub const FETCHER_GH_CRATE_META: &str = "GhCrateMeta";
+
 pub(crate) mod hosting;
 
 pub struct GhCrateMeta {
@@ -391,7 +393,7 @@ impl super::Fetcher for GhCrateMeta {
     }
 
     fn fetcher_name(&self) -> &'static str {
-        "GhCrateMeta"
+        FETCHER_GH_CRATE_META
     }
 
     fn is_third_party(&self) -> bool {

--- a/crates/binstalk-registry/src/visitor.rs
+++ b/crates/binstalk-registry/src/visitor.rs
@@ -71,7 +71,7 @@ impl ManifestVisitor {
 
         // Load and parse manifest
         let mut manifest = Manifest::from_slice_with_metadata(&self.cargo_toml_content)?;
-
+        debug!("Manifest: {manifest:?}");
         // Checks vfs for binary output names
         manifest.complete_from_abstract_filesystem::<Value, _>(&self.vfs, None)?;
 

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use binstalk_fetchers::FETCHER_GH_CRATE_META;
 use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use leon::Template;
@@ -100,50 +101,61 @@ async fn resolve_inner(
         desired_targets.len() * resolvers.len() * if binary_name.is_some() { 2 } else { 1 },
     );
 
-    let mut handles_fn = |data: Arc<Data>| {
-        handles.extend(
-            resolvers
-                .iter()
-                .cartesian_product(desired_targets.clone().into_iter().map(|(triple, target)| {
-                    debug!("Building metadata for target: {target}");
+    let mut handles_fn =
+        |data: Arc<Data>, filter_fetcher_by_name_predicate: fn(&'static str) -> bool| {
+            handles.extend(
+                resolvers
+                    .iter()
+                    .cartesian_product(desired_targets.clone().into_iter().map(
+                        |(triple, target)| {
+                            debug!("Building metadata for target: {target}");
 
-                    let target_meta = package_info.meta.merge_overrides(
-                        iter::once(&opts.cli_overrides).chain(package_info.overrides.get(target)),
-                    );
+                            let target_meta = package_info.meta.merge_overrides(
+                                iter::once(&opts.cli_overrides)
+                                    .chain(package_info.overrides.get(target)),
+                            );
 
-                    debug!("Found metadata: {target_meta:?}");
+                            debug!("Found metadata: {target_meta:?}");
 
-                    Arc::new(TargetData {
-                        target: target.clone(),
-                        meta: target_meta,
-                        target_related_info: triple,
-                    })
-                }))
-                .map(|(f, target_data)| {
-                    let fetcher = f(
-                        opts.client.clone(),
-                        opts.gh_api_client.clone(),
-                        data.clone(),
-                        target_data,
-                        opts.signature_policy,
-                    );
-                    (fetcher.clone(), AutoAbortJoinHandle::new(fetcher.find()))
-                }),
-        )
-    };
+                            Arc::new(TargetData {
+                                target: target.clone(),
+                                meta: target_meta,
+                                target_related_info: triple,
+                            })
+                        },
+                    ))
+                    .filter_map(|(f, target_data)| {
+                        let fetcher = f(
+                            opts.client.clone(),
+                            opts.gh_api_client.clone(),
+                            data.clone(),
+                            target_data,
+                            opts.signature_policy,
+                        );
+                        filter_fetcher_by_name_predicate(fetcher.fetcher_name())
+                            .then_some((fetcher.clone(), AutoAbortJoinHandle::new(fetcher.find())))
+                    }),
+            )
+        };
 
-    handles_fn(Arc::new(Data::new(
-        package_info.name.clone(),
-        package_info.version_str.clone(),
-        package_info.repo.clone(),
-    )));
-
-    if let Some(binary_name) = binary_name {
-        handles_fn(Arc::new(Data::new(
-            binary_name,
+    handles_fn(
+        Arc::new(Data::new(
+            package_info.name.clone(),
             package_info.version_str.clone(),
             package_info.repo.clone(),
-        )));
+        )),
+        |_| true,
+    );
+
+    if let Some(binary_name) = binary_name {
+        handles_fn(
+            Arc::new(Data::new(
+                binary_name,
+                package_info.version_str.clone(),
+                package_info.repo.clone(),
+            )),
+            |name| name == FETCHER_GH_CRATE_META,
+        );
     }
 
     for (fetcher, handle) in handles {

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -91,13 +91,10 @@ async fn resolve_inner(
         .collect::<Result<Vec<_>, _>>()?;
     let resolvers = &opts.resolvers;
 
-    let mut binary_name = None;
-    if package_info.binaries.len() == 1 {
-        let name = package_info.binaries.first().unwrap().name.as_str();
-        if name != package_info.name {
-            binary_name = Some(CompactString::from(name))
-        }
-    }
+    let binary_name = match package_info.binaries.as_slice() {
+        [bin] if bin.name != package_info.name => Some(CompactString::from(bin.name.as_str())),
+        _ => None,
+    };
 
     let mut handles: Vec<(Arc<dyn Fetcher>, _)> = Vec::with_capacity(
         desired_targets.len() * resolvers.len() * if binary_name.is_some() { 2 } else { 1 },

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -98,7 +98,12 @@ async fn resolve_inner(
     };
 
     let mut handles: Vec<(Arc<dyn Fetcher>, _)> = Vec::with_capacity(
-        desired_targets.len() * resolvers.len() + if binary_name.is_some() { desired_targets.len() } else { 0 },
+        desired_targets.len() * resolvers.len()
+            + if binary_name.is_some() {
+                desired_targets.len()
+            } else {
+                0
+            },
     );
 
     let mut handles_fn =

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -98,7 +98,7 @@ async fn resolve_inner(
     };
 
     let mut handles: Vec<(Arc<dyn Fetcher>, _)> = Vec::with_capacity(
-        desired_targets.len() * resolvers.len() * if binary_name.is_some() { 2 } else { 1 },
+        desired_targets.len() * resolvers.len() + if binary_name.is_some() { desired_targets.len() } else { 0 },
     );
 
     let mut handles_fn =

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -8,7 +8,9 @@ unset CARGO_INSTALL_ROOT
 #    to find versions matching <= 1.3.3
 #  - `cargo-quickinstall` would test `fetch_crate_cratesio_version_matched` ability
 #    to find latest stable version.
-crates="b3sum@<=1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3 cargo-quickinstall jj-cli@0.18.0"
+#  - `git-mob-tool tests the using of using a binary name (`git-mob`) different
+#    from the package name.
+crates="b3sum@<=1.3.3 cargo-release@0.24.9 cargo-binstall@0.20.1 cargo-watch@8.4.0 miniserve@0.23.0 sccache@0.3.3 cargo-quickinstall jj-cli@0.18.0 git-mob-tool@1.6.1"
 
 CARGO_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')
 export CARGO_HOME
@@ -59,3 +61,8 @@ jj_version="$(jj --version)"
 echo "$jj_version"
 
 [ "$jj_version" = "jj 0.18.0-9fb5307b7886e390c02817af7c31b403f0279144" ]
+
+git_mob_version="$(git-mob --version)"
+echo "$git_mob_version"
+
+[ "$git_mob_version" = "git-mob-tool 1.6.1" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "stable"
 profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
When there is a single binary declared in the manifest and it differs from the package name, add it to the list of handles used for pre-built artifact fetching.
Fixes #988 