### PR TITLE
Do not run ci.yml on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ on:
       - opened
       - reopened
       - synchronize
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
-      - SUPPORT.md
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}-${{ inputs.additional_key }}


### PR DESCRIPTION
All commits should be submit via PR, and merge_queue already run ci.yml, with up-to-date source code.