### PR TITLE
CI: Fix publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,24 +190,9 @@ jobs:
       - run: just avoid-dev-deps
       - run: just lint
 
-  pr-info:
-    outputs:
-      is-release: ${{ steps.meta.outputs.is-release }}
-      crate: ${{ steps.meta.outputs.crates-names }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - id: meta
-        if: github.event_name == 'pull_request'
-        uses: cargo-bins/release-meta@v1
-        with:
-          event-data: ${{ toJSON(github.event) }}
-          extract-notes-under: "### Release notes"
-
   release-dry-run:
-    needs: pr-info
     uses: ./.github/workflows/release-cli.yml
-    if: github.event_name != 'pull_request' || needs.pr-info.outputs.is-release == 'true'
+    if: github.event_name != 'pull_request'
     secrets: inherit
     with:
       info: |

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -83,6 +83,8 @@ jobs:
       with:
         name: minisign.pub
 
+    - run: rustup toolchain install stable --no-self-update --profile minimal
+
     - run: .github/scripts/ephemeral-crate.sh
 
     - if: fromJSON(inputs.info).is-release != 'true' && fromJSON(inputs.info).crate != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Push lib release tag
       if: needs.info.outputs.crate != 'cargo-binstall'
       uses: mathieudutour/github-tag-action@v6.2


### PR DESCRIPTION
Use latest stable Rust toolchain

Also stop running release-dry-run on release PR, it isn't helpful and only waste time.