### PR TITLE
Run ci.yml every Monday

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - opened
       - reopened
       - synchronize
+  schedule:
+    - cron: "0 3 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.event.pull_request.number || github.sha }}-${{ inputs.additional_key }}


### PR DESCRIPTION
Just to keep the cache hot while making sure cargo-binstall can compile on latest stable/nightly rust