### PR TITLE
Speedup Linux CI

### DIFF
--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -123,3 +123,11 @@ runs:
 
   - run: make -v
     shell: bash
+
+  - name: Enable transparent huge page
+    if: runner.os == 'Linux'
+    run: echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+
+  - name: Configure jemalloc (used by rustc) to use transparent huge page
+    if: runner.os == 'Linux'
+    run: echo "MALLOC_CONF=thp:always,metadata_thp:always" >> "$GITHUB_ENV"

--- a/.github/actions/just-setup/action.yml
+++ b/.github/actions/just-setup/action.yml
@@ -127,7 +127,9 @@ runs:
   - name: Enable transparent huge page
     if: runner.os == 'Linux'
     run: echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+    shell: bash
 
   - name: Configure jemalloc (used by rustc) to use transparent huge page
     if: runner.os == 'Linux'
     run: echo "MALLOC_CONF=thp:always,metadata_thp:always" >> "$GITHUB_ENV"
+    shell: bash


### PR DESCRIPTION
Use transparent huge page, according to https://kobzol.github.io/rust/rustc/2023/10/21/make-rust-compiler-5percent-faster.html it gives a nice 5% speedup