### PR TITLE
Re enable h3 in reqwest and remove impl `Sync` on returned Future in `binstalk-git-repo-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5069de1c2ac82d9e361b07f2b8a2c582ec071750e063530fc7f3b5197e24805"
+dependencies = [
+ "bytes",
+ "fastrand 2.1.0",
+ "futures-util",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "h3-quinn"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,9 +2127,23 @@ checksum = "2d4a1a1763e4f3e82ee9f1ecf2cf862b22cc7316ebe14684e42f94532b5ec64d"
 dependencies = [
  "bytes",
  "futures",
- "h3",
+ "h3 0.0.2",
  "quinn 0.10.2",
  "quinn-proto 0.10.6",
+ "tokio-util",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c01d99d7cf812fd34ddf135e6c940df9e24f2e759dbc7179fb0e54d4bd6551"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3 0.0.5",
+ "quinn 0.11.2",
+ "tokio",
  "tokio-util",
 ]
 
@@ -2161,8 +2190,8 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2 0.3.26",
- "h3",
- "h3-quinn",
+ "h3 0.0.2",
+ "h3-quinn 0.0.3",
  "http 0.2.12",
  "idna 0.4.0",
  "ipnet",
@@ -3199,6 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
 dependencies = [
  "bytes",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto 0.11.3",
  "quinn-udp 0.5.2",
@@ -3420,6 +3450,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.5",
+ "h3 0.0.5",
+ "h3-quinn 0.0.6",
  "http 1.1.0",
  "http-body",
  "http-body-util",
@@ -3443,6 +3475,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "slab",
  "sync_wrapper",
  "system-configuration",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cb1d556b8b8f36e5ca74938008be3ac102f5dcb5b68a0477e4249ae2291cd3"
+checksum = "4895c018bb228aa6b3ba1a0285543fcb4b704734c3fb1f72afaa75aa769500c1"
 dependencies = [
  "serde",
  "toml",
@@ -2113,8 +2113,8 @@ dependencies = [
  "bytes",
  "futures",
  "h3",
- "quinn",
- "quinn-proto",
+ "quinn 0.10.2",
+ "quinn-proto 0.10.6",
  "tokio-util",
 ]
 
@@ -2168,7 +2168,7 @@ dependencies = [
  "ipnet",
  "native-tls",
  "once_cell",
- "quinn",
+ "quinn 0.10.2",
  "rand",
  "ring 0.16.20",
  "rustls 0.21.12",
@@ -2273,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2311,19 +2311,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2847,9 +2849,9 @@ checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -3081,7 +3083,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -3181,10 +3183,27 @@ checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.10.6",
+ "quinn-udp 0.4.1",
  "rustc-hash",
  "rustls 0.21.12",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto 0.11.3",
+ "quinn-udp 0.5.2",
+ "rustc-hash",
+ "rustls 0.23.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -3208,6 +3227,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
 name = "quinn-udp"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,6 +3254,19 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3299,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3359,9 +3408,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -3386,7 +3435,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn 0.11.2",
+ "rustls 0.23.10",
  "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -3397,7 +3447,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -3497,11 +3547,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
@@ -3903,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -4117,11 +4167,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4569,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4988,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -35,7 +35,7 @@ flate2 = { version = "1.0.28", default-features = false }
 futures-util = "0.3.30"
 futures-io = "0.3.30"
 httpdate = "1.0.2"
-reqwest = { version = "0.12.4", features = [
+reqwest = { version = "0.12.5", features = [
     "http2",
     "stream",
     "zstd",
@@ -118,8 +118,7 @@ trust-dns = ["hickory-dns"]
 #
 # Experimental HTTP/3 client, this would require `--cfg reqwest_unstable`
 # to be passed to `rustc`.
-#http3 = ["reqwest/http3"]
-http3 = []
+http3 = ["reqwest/http3"]
 
 zstd-thin = ["zstd/thin"]
 

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -204,8 +204,8 @@ impl GhApiClient {
     where
         GraphQLFn: Fn(&remote::Client, &T, &str) -> GraphQLFut,
         RestfulFn: Fn(&remote::Client, &T, Option<&str>) -> RestfulFut,
-        GraphQLFut: Future<Output = Result<U, GhApiError>> + Send + Sync + 'static,
-        RestfulFut: Future<Output = Result<U, GhApiError>> + Send + Sync + 'static,
+        GraphQLFut: Future<Output = Result<U, GhApiError>> + Send + 'static,
+        RestfulFut: Future<Output = Result<U, GhApiError>> + Send + 'static,
     {
         self.check_retry_after()?;
 

--- a/crates/binstalk-git-repo-api/src/gh_api_client/common.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client/common.rs
@@ -39,7 +39,7 @@ pub(super) fn issue_restful_api<T>(
     client: &remote::Client,
     path: &[&str],
     auth_token: Option<&str>,
-) -> impl Future<Output = Result<T, GhApiError>> + Send + Sync + 'static
+) -> impl Future<Output = Result<T, GhApiError>> + Send + 'static
 where
     T: DeserializeOwned,
 {
@@ -95,7 +95,7 @@ pub(super) fn issue_graphql_query<T>(
     client: &remote::Client,
     query: String,
     auth_token: &str,
-) -> impl Future<Output = Result<T, GhApiError>> + Send + Sync + 'static
+) -> impl Future<Output = Result<T, GhApiError>> + Send + 'static
 where
     T: DeserializeOwned + Debug,
 {

--- a/crates/binstalk-git-repo-api/src/gh_api_client/release_artifacts.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client/release_artifacts.rs
@@ -74,7 +74,7 @@ pub(super) fn fetch_release_artifacts_restful_api(
         tag,
     }: &GhRelease,
     auth_token: Option<&str>,
-) -> impl Future<Output = Result<Artifacts, GhApiError>> + Send + Sync + 'static {
+) -> impl Future<Output = Result<Artifacts, GhApiError>> + Send + 'static {
     issue_restful_api(
         client,
         &["repos", owner, repo, "releases", "tags", tag],
@@ -135,7 +135,7 @@ pub(super) fn fetch_release_artifacts_graphql_api(
         tag,
     }: &GhRelease,
     auth_token: &str,
-) -> impl Future<Output = Result<Artifacts, GhApiError>> + Send + Sync + 'static {
+) -> impl Future<Output = Result<Artifacts, GhApiError>> + Send + 'static {
     let client = client.clone();
     let auth_token = auth_token.to_compact_string();
 

--- a/crates/binstalk-git-repo-api/src/gh_api_client/repo_info.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client/repo_info.rs
@@ -55,7 +55,7 @@ pub(super) fn fetch_repo_info_restful_api(
     client: &remote::Client,
     GhRepo { owner, repo }: &GhRepo,
     auth_token: Option<&str>,
-) -> impl Future<Output = Result<Option<RepoInfo>, GhApiError>> + Send + Sync + 'static {
+) -> impl Future<Output = Result<Option<RepoInfo>, GhApiError>> + Send + 'static {
     issue_restful_api(client, &["repos", owner, repo], auth_token)
 }
 
@@ -68,7 +68,7 @@ pub(super) fn fetch_repo_info_graphql_api(
     client: &remote::Client,
     GhRepo { owner, repo }: &GhRepo,
     auth_token: &str,
-) -> impl Future<Output = Result<Option<RepoInfo>, GhApiError>> + Send + Sync + 'static {
+) -> impl Future<Output = Result<Option<RepoInfo>, GhApiError>> + Send + 'static {
     let query = format!(
         r#"
 query {{


### PR DESCRIPTION
reqwest 0.12.5 re-enabled http3 support, however with http3 support the future returnd from `reqwest` no longer implements `Sync`.

SInce `tokio::spawn` does not requore `Sync`, it's removed from the return future in `binstalk-git-repo-api`, however since it is breaking behavior I will report this to upstream.