### PR TITLE
Include instruction to install using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Here are one-liners for downloading and installing a pre-compiled `cargo-binstal
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 ```
 
+or of you have homebrew installed:
+
+```
+brew install cargo-binstall
+```
+
 #### Windows
 
 ```


### PR DESCRIPTION
cargo-binstall is now in homebrew-core, so update our REAMDE to reflect that!