### PR TITLE
Run artifact discover in sequential instead of in parallel

### DIFF
--- a/crates/binstalk-fetchers/Cargo.toml
+++ b/crates/binstalk-fetchers/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "The binstall fetchers"
 repository = "https://github.com/cargo-bins/cargo-binstall"
 documentation = "https://docs.rs/binstalk-fetchers"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
 license = "GPL-3.0-only"
 

--- a/crates/binstalk-fetchers/src/futures_resolver.rs
+++ b/crates/binstalk-fetchers/src/futures_resolver.rs
@@ -1,7 +1,7 @@
-use std::{future::Future, pin::Pin, fmt::Debug};
+use std::{fmt::Debug, future::Future, pin::Pin};
 
-use tracing::warn;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 /// Given multiple futures with output = `Result<Option<T>, E>`,
 /// returns the the first one that returns either `Err(_)` or
@@ -73,7 +73,7 @@ impl<T: Send + 'static, E: Send + Debug + 'static> FuturesResolver<T, E> {
         let mut rx = self.rx;
         drop(self.tx);
 
-        async move { 
+        async move {
             while let Some(res) = rx.recv().await {
                 match res {
                     Ok(ret) => return Some(ret),

--- a/crates/binstalk-fetchers/src/futures_resolver.rs
+++ b/crates/binstalk-fetchers/src/futures_resolver.rs
@@ -74,13 +74,13 @@ impl<T: Send + 'static, E: Send + Debug + 'static> FuturesResolver<T, E> {
         drop(self.tx);
 
         async move {
-            while let Some(res) = rx.recv().await {
-                match res {
-                    Ok(ret) => return Some(ret),
-                    Err(err) => warn!(?err, "Fail to resolve the future"),
-                }
+            loop {
+	            match rx.recv().await {
+	                Some(Ok(ret)) => return Some(ret),
+	                Some(Err(err)) => warn!(?err, "Fail to resolve the future"),
+	                None => return None,
+	            }
             }
-            None
         }
     }
 }

--- a/crates/binstalk-fetchers/src/futures_resolver.rs
+++ b/crates/binstalk-fetchers/src/futures_resolver.rs
@@ -75,11 +75,11 @@ impl<T: Send + 'static, E: Send + Debug + 'static> FuturesResolver<T, E> {
 
         async move {
             loop {
-	            match rx.recv().await {
-	                Some(Ok(ret)) => return Some(ret),
-	                Some(Err(err)) => warn!(?err, "Fail to resolve the future"),
-	                None => return None,
-	            }
+                match rx.recv().await {
+                    Some(Ok(ret)) => return Some(ret),
+                    Some(Err(err)) => warn!(?err, "Fail to resolve the future"),
+                    None => return None,
+                }
             }
         }
     }

--- a/crates/binstalk-fetchers/src/futures_resolver.rs
+++ b/crates/binstalk-fetchers/src/futures_resolver.rs
@@ -77,7 +77,7 @@ impl<T: Send + 'static, E: Send + Debug + 'static> FuturesResolver<T, E> {
             while let Some(res) = rx.recv().await {
                 match res {
                     Ok(ret) => return Some(ret),
-                    Err(err) => warn!(?err, "Faile to resolve the future"),
+                    Err(err) => warn!(?err, "Fail to resolve the future"),
                 }
             }
             None

--- a/crates/binstalk-fetchers/src/gh_crate_meta.rs
+++ b/crates/binstalk-fetchers/src/gh_crate_meta.rs
@@ -278,7 +278,7 @@ impl super::Fetcher for GhCrateMeta {
                 }
             }
 
-            if let Some(resolved) = resolver.resolve().await? {
+            if let Some(resolved) = resolver.resolve().await {
                 debug!(?resolved, "Winning URL found!");
                 self.resolution
                     .set(resolved)

--- a/crates/binstalk-fetchers/src/lib.rs
+++ b/crates/binstalk-fetchers/src/lib.rs
@@ -6,7 +6,7 @@ use binstalk_downloader::{download::DownloadError, remote::Error as RemoteError}
 use binstalk_git_repo_api::gh_api_client::{GhApiError, GhRepo};
 use binstalk_types::cargo_toml_binstall::SigningAlgorithm;
 use thiserror::Error as ThisError;
-use tokio::{sync::OnceCell, time::sleep};
+use tokio::{sync::OnceCell, task::JoinError, time::sleep};
 pub use url::ParseError as UrlParseError;
 
 mod gh_crate_meta;
@@ -70,6 +70,9 @@ pub enum FetchError {
 
     #[error("Failed to verify signature")]
     InvalidSignature,
+
+    #[error("Failed to wait for task: {0}")]
+    TaskJoinError(#[from] JoinError),
 }
 
 impl From<RemoteError> for FetchError {

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -139,8 +139,7 @@ async fn resolve_inner(
                             target_data,
                             opts.signature_policy,
                         );
-                        filter_fetcher_by_name_predicate(fetcher.fetcher_name())
-                            .then_some(fetcher)
+                        filter_fetcher_by_name_predicate(fetcher.fetcher_name()).then_some(fetcher)
                     }),
             )
         };
@@ -167,7 +166,10 @@ async fn resolve_inner(
 
     for fetcher in handles {
         fetcher.clone().report_to_upstream();
-        match AutoAbortJoinHandle::new(fetcher.clone().find()).flattened_join().await {
+        match AutoAbortJoinHandle::new(fetcher.clone().find())
+            .flattened_join()
+            .await
+        {
             Ok(true) => {
                 // Generate temporary binary path
                 let bin_path = opts.temp_dir.join(format!(


### PR DESCRIPTION
Creating too many requests is slower since cargo-binstall is very likely to be rate limited, and cargo-binstall actually has a preference on artifact discovery resolution, so many requests are just wasted/not used but slow down the one cargo-binstall want.