### PR TITLE
fix: use the GhApiClient to normalize GitHub URLs

### DIFF
--- a/crates/binstalk-fetchers/src/lib.rs
+++ b/crates/binstalk-fetchers/src/lib.rs
@@ -195,7 +195,11 @@ impl Data {
                     let mut repo = Url::parse(repo)?;
                     let mut repository_host = RepositoryHost::guess_git_hosting_services(&repo);
 
-                    if repository_host == RepositoryHost::Unknown {
+                    // gettting the redirected final url for GitHub URLs removes any trailing .git,
+                    // this is needed for the GitHub API which doesn't consider the .git version the same
+                    if repository_host == RepositoryHost::Unknown
+                        || repository_host == RepositoryHost::GitHub
+                    {
                         repo = client
                             .remote_client()
                             .get_redirected_final_url(repo)


### PR DESCRIPTION
Closes #1801, see #1804 for alternative. 

Test below: not added as it requires an internet connection, and it didn't seem sensible to mock out GhApiClient for this (or make it a trait):

```rust
    #[tokio::test]
    async fn test_ignore_dot_git_for_github_repos() {
        let url_without_git = "https://github.com/cargo-bins/cargo-binstall";
        let url_with_git = format!("{}.git", url_without_git);

        let data = Data::new("cargo-binstall".into(), "v1.2.3".into(), Some(url_with_git));

        let gh_client = GhApiClient::new(
            Client::new(
                "user-agent",
                None,
                NonZeroU16::new(1000).unwrap(),
                NonZeroU64::new(1000).unwrap(),
                [],
            )
            .unwrap(),
            None,
        );

        let repo_info = data.get_repo_info(&gh_client).await.unwrap().unwrap();

        assert_eq!(url_without_git, repo_info.repo.as_str());
    }
```