### PR TITLE
fix: normalize GitHub URLs ending in .git to not ending in .git

### DIFF
--- a/crates/binstalk-fetchers/src/lib.rs
+++ b/crates/binstalk-fetchers/src/lib.rs
@@ -205,16 +205,13 @@ impl Data {
             repo: &str,
             client: &GhApiClient,
         ) -> Result<RepoInfo, FetchError> {
-            let mut repo = Url::parse(repo)?;
-            let mut repository_host = RepositoryHost::guess_git_hosting_services(&repo);
-
-            if repository_host == RepositoryHost::Unknown {
-                repo = client
-                    .remote_client()
-                    .get_redirected_final_url(repo)
-                    .await?;
-                repository_host = RepositoryHost::guess_git_hosting_services(&repo);
-            }
+            let repo = Url::parse(repo)?;
+            let mut repo = client
+                .remote_client()
+                .get_redirected_final_url(repo.clone())
+                .await
+                .unwrap_or(repo);
+            let repository_host = RepositoryHost::guess_git_hosting_services(&repo);
 
             let subcrate = RepoInfo::detect_subcrate(&mut repo, repository_host);
 

--- a/e2e-tests/manifests/github-test-Cargo2.toml
+++ b/e2e-tests/manifests/github-test-Cargo2.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-binstall"
 description = "Rust binary package installer for CI integration"
-repository = "https://github.com/cargo-bins/cargo-binstall"
+repository = "https://github.com/cargo-bins/cargo-binstall.git"
 version = "0.12.0"
 rust-version = "1.61.0"
 authors = ["ryan <ryan@kurte.nz>"]

--- a/e2e-tests/manifests/gitlab-test-Cargo.toml
+++ b/e2e-tests/manifests/gitlab-test-Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-binstall"
 description = "Rust binary package installer for CI integration"
-repository = "https://gitlab.kitware.com/NobodyXu/hello-world"
+repository = "https://gitlab.kitware.com/NobodyXu/hello-world.git"
 version = "0.2.0"
 rust-version = "1.61.0"
 authors = ["ryan <ryan@kurte.nz>"]

--- a/e2e-tests/manifests/private-github-repo-test-Cargo.toml
+++ b/e2e-tests/manifests/private-github-repo-test-Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-binstall"
 description = "Rust binary package installer for CI integration"
-repository = "https://github.com/cargo-bins/private-repo-for-testing"
+repository = "https://github.com/cargo-bins/private-repo-for-testing.git"
 version = "0.12.0"
 rust-version = "1.61.0"
 authors = ["ryan <ryan@kurte.nz>"]


### PR DESCRIPTION
Closes #1801, see #1803 for a more generic version.

Here I can add the test as the `GhApiClient` is never invoked.