### PR TITLE
Raspberry-pi

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -13,6 +13,10 @@ if [ "$os" == "Darwin" ]; then
     unzip cargo-binstall-universal-apple-darwin.zip
 elif [ "$os" == "Linux" ]; then
     machine="$(uname -m)"
+    # `uname -m` retuns 'armv7l' on raspberry pi, but 'armv7' works just fine
+    if [ "$machine" == "armv7l" ]; then
+        machine="armv7"
+    fi
     target="${machine}-unknown-linux-musl"
     if [ "$machine" == "armv7" ]; then
         target="${target}eabihf"

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -13,7 +13,6 @@ if [ "$os" == "Darwin" ]; then
     unzip cargo-binstall-universal-apple-darwin.zip
 elif [ "$os" == "Linux" ]; then
     machine="$(uname -m)"
-    # `uname -m` retuns 'armv7l' on raspberry pi, but 'armv7' works just fine
     if [ "$machine" == "armv7l" ]; then
         machine="armv7"
     fi


### PR DESCRIPTION
`uname -m` returns 'armv7l' on raspberry pi, but 'armv7' works just fine