### PR TITLE
Mark binstalk_manifests::cargo_crates_v1::CratesToml::insert private

### DIFF
--- a/crates/binstalk-manifests/src/cargo_crates_v1.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1.rs
@@ -68,7 +68,7 @@ impl CratesToml<'_> {
 
     /// Only use it when you know that the crate is not in the manifest.
     /// Otherwise, you need to call [`CratesToml::remove`] first.
-    pub fn insert(&mut self, cvs: &CrateVersionSource, bins: Vec<CompactString>) {
+    fn insert(&mut self, cvs: &CrateVersionSource, bins: Vec<CompactString>) {
         self.v1.push((cvs.to_string(), Cow::owned(bins)));
     }
 


### PR DESCRIPTION
It uses a private type so it should not have public visibility.