### PR TITLE
Add new option to `--disable-telemetry` to disable quickinstall statistics collection

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -224,7 +224,7 @@ pub struct Args {
     /// Strategy quick-install (can be disabled via --disable-strategies) collects
     /// statistics of popular crates by default, by sending the crate, version and
     /// target to https://warehouse-clerk-tmp.vercel.app/api/crate
-    #[clap(help_heading = "Options", long)]
+    #[clap(help_heading = "Options", long, env = "BINSTALL_DISABLE_TELEMETRY")]
     pub(crate) disable_telemetry: bool,
 
     /// Install binaries in a custom location.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -219,6 +219,14 @@ pub struct Args {
     #[clap(help_heading = "Options", long)]
     pub(crate) no_track: bool,
 
+    /// Disable statistics collection on popular crates.
+    ///
+    /// Strategy quick-install (can be disabled via --disable-strategies) collects
+    /// statistics of popular crates by default, by sending the crate, version and
+    /// target to https://warehouse-clerk-tmp.vercel.app/api/crate
+    #[clap(help_heading = "Options", long)]
+    pub(crate) disable_quick_install_stats: bool,
+
     /// Install binaries in a custom location.
     ///
     /// By default, binaries are installed to the global location `$CARGO_HOME/bin`, and global
@@ -609,6 +617,22 @@ mod test {
     #[test]
     fn verify_cli() {
         Args::command().debug_assert()
+    }
+
+    #[test]
+    fn quickinstall_url_matches() {
+        let long_help = Args::command()
+            .get_opts()
+            .find(|opt| opt.get_long() == Some("disable-quick-install-stats"))
+            .unwrap()
+            .get_long_help()
+            .unwrap()
+            .to_string();
+        assert!(
+            long_help.ends_with(binstalk::QUICK_INSTALL_STATS_URL),
+            "{}",
+            long_help
+        );
     }
 
     const _: () = assert!(Strategy::VARIANTS.len() == StrategyWrapped::VARIANTS.len());

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -623,7 +623,7 @@ mod test {
     fn quickinstall_url_matches() {
         let long_help = Args::command()
             .get_opts()
-            .find(|opt| opt.get_long() == Some("disable-quick-install-stats"))
+            .find(|opt| opt.get_long() == Some("disable-telemetry"))
             .unwrap()
             .get_long_help()
             .unwrap()

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -225,7 +225,7 @@ pub struct Args {
     /// statistics of popular crates by default, by sending the crate, version and
     /// target to https://warehouse-clerk-tmp.vercel.app/api/crate
     #[clap(help_heading = "Options", long)]
-    pub(crate) disable_quick_install_stats: bool,
+    pub(crate) disable_telemetry: bool,
 
     /// Install binaries in a custom location.
     ///

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -207,6 +207,7 @@ pub fn install_crates(
         } else {
             SignaturePolicy::IfPresent
         },
+        disable_quick_install_stats: args.disable_quick_install_stats,
     });
 
     // Destruct args before any async function to reduce size of the future

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -207,7 +207,7 @@ pub fn install_crates(
         } else {
             SignaturePolicy::IfPresent
         },
-        disable_quick_install_stats: args.disable_quick_install_stats,
+        disable_telemetry: args.disable_telemetry,
     });
 
     // Destruct args before any async function to reduce size of the future

--- a/crates/binstalk-fetchers/src/quickinstall.rs
+++ b/crates/binstalk-fetchers/src/quickinstall.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 const BASE_URL: &str = "https://github.com/cargo-bins/cargo-quickinstall/releases/download";
-const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
+pub const QUICK_INSTALL_STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
 
 const QUICKINSTALL_SIGN_KEY: Cow<'static, str> =
     Cow::Borrowed("RWTdnnab2pAka9OdwgCMYyOE66M/BlQoFWaJ/JjwcPV+f3n24IRTj97t");
@@ -144,7 +144,7 @@ impl super::Fetcher for QuickInstall {
                 .expect("package_url is pre-generated and should never be invalid url"),
             signature_url: Url::parse(&format!("{url}.sig"))
                 .expect("signature_url is pre-generated and should never be invalid url"),
-            stats_url: Url::parse(&format!("{STATS_URL}/{package}.tar.gz",))
+            stats_url: Url::parse(&format!("{QUICK_INSTALL_STATS_URL}/{package}.tar.gz",))
                 .expect("stats_url is pre-generated and should never be invalid url"),
             package,
             signature_policy,

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -9,3 +9,5 @@ pub use binstalk_fetchers as fetchers;
 pub use binstalk_registry as registry;
 pub use binstalk_types as manifests;
 pub use detect_targets::{get_desired_targets, DesiredTargets, TARGET};
+
+pub use fetchers::QUICK_INSTALL_STATS_URL;

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -55,5 +55,5 @@ pub struct Options {
     pub registry: Registry,
 
     pub signature_policy: SignaturePolicy,
-    pub disable_quick_install_stats: bool,
+    pub disable_telemetry: bool,
 }

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -55,4 +55,5 @@ pub struct Options {
     pub registry: Registry,
 
     pub signature_policy: SignaturePolicy,
+    pub disable_quick_install_stats: bool,
 }

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -176,7 +176,9 @@ async fn resolve_inner(
     }
 
     for fetcher in handles {
-        fetcher.clone().report_to_upstream();
+        if !opts.disable_quick_install_stats {
+            fetcher.clone().report_to_upstream();
+        }
         match AutoAbortJoinHandle::new(fetcher.clone().find())
             .flattened_join()
             .await

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -175,10 +175,13 @@ async fn resolve_inner(
         );
     }
 
-    for fetcher in handles {
-        if !opts.disable_quick_install_stats {
+    if !opts.disable_quick_install_stats {
+        for fetcher in &handles {
             fetcher.clone().report_to_upstream();
         }
+    }
+
+    for fetcher in handles {
         match AutoAbortJoinHandle::new(fetcher.clone().find())
             .flattened_join()
             .await

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -175,7 +175,7 @@ async fn resolve_inner(
         );
     }
 
-    if !opts.disable_quick_install_stats {
+    if !opts.disable_telemetry {
         for fetcher in &handles {
             fetcher.clone().report_to_upstream();
         }


### PR DESCRIPTION
Fixed  #1822