### PR TITLE
CI: Add release-plz to release library crates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install stable --no-self-update --profile minimal
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[[package]] # the double square brackets define a TOML table array
+name = "cargo-binstall"
+release = false # don't process this package

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,3 @@
-[[package]] # the double square brackets define a TOML table array
+[[package]]
 name = "cargo-binstall"
 release = false # don't process this package


### PR DESCRIPTION
This PR adds release-plz to release library crates automatically.

The existing release-system would require one PR for every release of library crates, which is very time consuming and waste a lot of energy on running CI.

It'd also require careful picking of order, as dependencies has to be released before dependents and the release PRs could also have merge conflicts.

It turns out that release-plz is the perfect solution for library crates, while as for cargo-binstall binary crate we'd continue to use our existing system, with manual triggering and manual changelog writing.