### PR TITLE
Fix CI blocked due to cargo-binstall rate-limit

### DIFF
--- a/.github/workflows/gh-action.yml
+++ b/.github/workflows/gh-action.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Verify successful installation - install example binary using cargo-binstall
         run: cargo binstall -y ripgrep
         env:
-          # just-setup use binstall to install sccache,
-          # which works better when we provide it with GITHUB_TOKEN.
           GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify successful installation - display help of installed binary

--- a/.github/workflows/gh-action.yml
+++ b/.github/workflows/gh-action.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install cargo-binstall
         uses: ./ # uses action.yml from root of the repo
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify successful installation - display cargo-binstall's help
         run: cargo binstall --help
@@ -34,7 +34,9 @@ jobs:
       - name: Verify successful installation - install example binary using cargo-binstall
         run: cargo binstall -y ripgrep
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # just-setup use binstall to install sccache,
+          # which works better when we provide it with GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify successful installation - display help of installed binary
         run: rg --help

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install `cargo-binstall` using scripts
         run: ./install-from-binstall-release.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify `cargo-binstall` installation
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Install `cargo-binstall` using scripts
         run: ./install-from-binstall-release.ps1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify `cargo-binstall` installation
         run: cargo binstall -vV
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         run: ./install-from-binstall-release.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Verify `cargo-binstall` installation
         shell: bash

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -36,10 +36,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: cargo-bins/cargo-binstall@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
     - name: Install binaries required
       run: cargo binstall -y --force rsign2 rage
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
     - name: Create ephemeral keypair
       id: keypair

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -51,6 +51,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-release,cargo-semver-checks
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_RELEASE_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - run: rustup toolchain install stable --no-self-update --profile minimal
       - uses: cargo-bins/release-pr@v2.1.3


### PR DESCRIPTION
Pass GITHUB_TOKEN to whereever `cargo-binstall` is invoked, and prefer `CI_RELEASE_TEST_GITHUB_TOKEN`