### PR TITLE
Use git credential helper

### DIFF
--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -8,12 +8,15 @@ use tokio::process::Command;
 use zeroize::Zeroizing;
 
 pub(super) async fn get() -> io::Result<Zeroizing<Box<str>>> {
-    let Output { status, stdout, .. } = Command::new("gh")
-        .args(["auth", "token"])
-        .stdin(Stdio::null())
+    // Prepare the input for the git credential fill command
+    let input = "host=github.com\nprotocol=https";
+
+    let Output { status, stdout, .. } = Command::new("git")
+        .args(["credential", "fill"])
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .output()
+        .output_async_with_stdin(input.as_bytes())
         .await?;
 
     let stdout = Zeroizing::new(stdout);
@@ -25,12 +28,46 @@ pub(super) async fn get() -> io::Result<Zeroizing<Box<str>>> {
         ));
     }
 
-    let s = str::from_utf8(&stdout).map_err(|err| {
+    // Assuming the password field is what's needed
+    let output_str = str::from_utf8(&stdout).map_err(|err| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             format!("Invalid output, expected utf8: {err}"),
         )
     })?;
 
-    Ok(Zeroizing::new(s.trim().into()))
+    // Extract the password from the output
+    let password = output_str
+        .lines()
+        .find_map(|line| {
+            if line.starts_with("password=") {
+                Some(line.trim_start_matches("password=").to_owned())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "Password not found in the credential output",
+            )
+        })?;
+
+    Ok(Zeroizing::new(password.into()))
+}
+
+// Helper function to execute a command with input
+async fn output_async_with_stdin(
+    cmd: &mut Command,
+    input: &[u8],
+) -> io::Result<Output> {
+    let mut child = cmd.spawn()?;
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let _ = stdin.write_all(input).await;
+    });
+
+    child.wait_with_output().await
 }

--- a/crates/bin/src/gh_token.rs
+++ b/crates/bin/src/gh_token.rs
@@ -59,12 +59,7 @@ impl CommandExt for Command {
         let mut child = self.spawn()?;
 
         if let Some(input) = input {
-            child
-                .stdin
-                .take()
-                .expect("Failed to open stdin")
-                .write_all(input)
-                .await?;
+            child.stdin.take().unwrap().write_all(input).await?;
         }
 
         let Output { status, stdout, .. } = child.wait_with_output().await?;


### PR DESCRIPTION
Instead of using `gh` we should use the built in `git` credential helper to get a valid token. I think we could even get rid of reading the credentials files manually as git should be able to just do this for us.

What we're essentially doing is 

```
> printf "host=github.com\nprotocol=https" | git credential fill
protocol=https
host=github.com
username=3799140
password=TOKEN
```

Ideally we would even hand down a path so the token could be scoped to a single repository.

https://git-scm.com/docs/gitcredentials