### PR TITLE
docs: mention `quickinstall` telemetry collection in `--help` and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ Extra pre-built packages with a `.full` suffix are available and contain split d
 ## Telemetry collection
 
 Some crate installation strategies may collect anonymized usage statistics by default.
-Currently, only the name of the crate to be installed, its version, and the target platform triple are sent to endpoints under the `https://warehouse-clerk-tmp.vercel.app/api/crate` URL when the `quickinstall` artifact host is used.
+Currently, only the name of the crate to be installed, its version, the target platform triple, and the collecting user agent are sent to endpoints under the `https://warehouse-clerk-tmp.vercel.app/api/crate` URL when the `quickinstall` artifact host is used.
 The maintainers of the `quickinstall` project use this data to determine which crate versions are most worthwhile to build and host.
+The aggregated collected telemetry is publicly accessible at <https://warehouse-clerk-tmp.vercel.app/api/stats>.
+Should you be interested on it, the backend code for these endpoints can be found at <https://github.com/alsuren/warehouse-clerk-tmp/tree/master/pages/api>.
 
 If you prefer not to participate in this data collection, you can opt out by any of the following methods:
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ You can find a full description of errors including exit codes here: <https://do
 Yes!
 Extra pre-built packages with a `.full` suffix are available and contain split debuginfo, documentation files, and extra binaries like the `detect-wasi` utility.
 
+## Telemetry collection
+
+Some crate installation strategies may collect anonymized usage statistics by default.
+Currently, only the name of the crate to be installed, its version, and the target platform triple are sent to endpoints under the `https://warehouse-clerk-tmp.vercel.app/api/crate` URL when the `quickinstall` artifact host is used.
+The maintainers of the `quickinstall` project use this data to determine which crate versions are most worthwhile to build and host.
+
+If you prefer not to participate in this data collection, you can opt out by any of the following methods:
+
+- Setting the `--disable-telemetry` flag in the command line interface.
+- Setting the `BINSTALL_DISABLE_TELEMETRY` environment variable to `true`.
+- Disabling the `quickinstall` strategy with `--disable-strategy quick-install`, or if specifying a list of strategies to use with `--strategy`, avoiding including `quickinstall` in that list.
+- Adding `quick-install` to the `disabled-strategies` configuration key in the crate metadata (refer to [the related support documentation](SUPPORT.md#support-for-cargo-binstall) for more details).
+
 ---
 
 If you have ideas/contributions or anything is not working the way you expect (in which case, please include an output with `--log-level debug`) and feel free to open an issue or PR.

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -25,7 +25,13 @@ use zeroize::Zeroizing;
 #[clap(
     version,
     about = "Install a Rust binary... from binaries!",
-    after_long_help = "License: GPLv3. Source available at https://github.com/cargo-bins/cargo-binstall",
+    after_long_help =
+        "License: GPLv3. Source available at https://github.com/cargo-bins/cargo-binstall\n\n\
+        Some crate installation strategies may collect anonymized usage statistics by default. \
+        If you prefer not to participate on such data collection, you can opt out by using the \
+        `--disable-telemetry` flag or its associated environment variable. For more details \
+        about this data collection, please refer to the mentioned flag or the project's README \
+        file",
     arg_required_else_help(true),
     // Avoid conflict with version_req
     disable_version_flag(true),


### PR DESCRIPTION
These changes describe the usage statistics collected when the `quickinstall` strategy is used by default, according to the discussion and details brought forward on https://github.com/cargo-bins/cargo-binstall/issues/1884. Both the project README and the CLI long help contain clear disclosures of such statistics collection now.