### PR TITLE
reduce default for maximum_resolution_timeout to 15s

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -206,7 +206,7 @@ pub struct Args {
         help_heading = "Overrides",
         long,
         env = "BINSTALL_MAXIMUM_RESOLUTION_TIMEOUT",
-        default_value_t = NonZeroU16::new(180).unwrap(),
+        default_value_t = NonZeroU16::new(15).unwrap(),
     )]
     pub(crate) maximum_resolution_timeout: NonZeroU16,
 


### PR DESCRIPTION
If then default is too long, then users would still have to wait a long time if they hit rate limit.