### PR TITLE
Send telemetry report to quickinstall if no pre-built is found

### DIFF
--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -204,7 +204,7 @@ async fn resolve_inner(
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
                                 return Ok(Resolution::Fetch(Box::new(ResolutionFetch {
-                                    fetcher.clone(),
+                                    fetcher: fetcher.clone(),
                                     new_version: package_info.version,
                                     name: package_info.name,
                                     version_req: version_req_str,
@@ -251,8 +251,8 @@ async fn resolve_inner(
     }
 
     if !opts.disable_telemetry {
-        for fetcher in &handles {
-            fetcher.clone().report_to_upstream();
+        for fetcher in handles {
+            fetcher.report_to_upstream();
         }
     }
 

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -175,13 +175,7 @@ async fn resolve_inner(
         );
     }
 
-    if !opts.disable_telemetry {
-        for fetcher in &handles {
-            fetcher.clone().report_to_upstream();
-        }
-    }
-
-    for fetcher in handles {
+    for fetcher in &handles {
         match timeout(
             opts.maximum_resolution_timeout,
             AutoAbortJoinHandle::new(fetcher.clone().find()).flattened_join(),
@@ -210,7 +204,7 @@ async fn resolve_inner(
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
                                 return Ok(Resolution::Fetch(Box::new(ResolutionFetch {
-                                    fetcher,
+                                    fetcher.clone(),
                                     new_version: package_info.version,
                                     name: package_info.name,
                                     version_req: version_req_str,
@@ -255,6 +249,13 @@ async fn resolve_inner(
             }
         }
     }
+
+    if !opts.disable_telemetry {
+        for fetcher in &handles {
+            fetcher.clone().report_to_upstream();
+        }
+    }
+
 
     if !opts.cargo_install_fallback {
         return Err(BinstallError::NoFallbackToCargoInstall);

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -256,7 +256,6 @@ async fn resolve_inner(
         }
     }
 
-
     if !opts.cargo_install_fallback {
         return Err(BinstallError::NoFallbackToCargoInstall);
     }


### PR DESCRIPTION
quickinstall telemtry is overloaded cargo-bins/cargo-quickinstall#268, it only needs report when the pre-built is not available in upstream.