### PR TITLE
report to new stats server (with status)

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -250,8 +250,8 @@ pub struct Args {
     /// Disable statistics collection on popular crates.
     ///
     /// Strategy quick-install (can be disabled via --disable-strategies) collects
-    /// statistics of popular crates by default, by sending the crate, version and
-    /// target to https://warehouse-clerk-tmp.vercel.app/api/crate
+    /// statistics of popular crates by default, by sending the crate, version, target
+    /// and status to https://cargo-quickinstall-stats-server.fly.dev/record-install
     #[clap(help_heading = "Options", long, env = "BINSTALL_DISABLE_TELEMETRY")]
     pub(crate) disable_telemetry: bool,
 

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -675,7 +675,7 @@ mod test {
             .unwrap()
             .to_string();
         assert!(
-            long_help.ends_with(binstalk::QUICK_INSTALL_STATS_URL),
+            long_help.ends_with(binstalk::QUICKINSTALL_STATS_URL),
             "{}",
             long_help
         );

--- a/crates/binstalk-fetchers/src/common.rs
+++ b/crates/binstalk-fetchers/src/common.rs
@@ -25,7 +25,7 @@ static WARN_RATE_LIMIT_ONCE: Once = Once::new();
 static WARN_UNAUTHORIZED_ONCE: Once = Once::new();
 
 /// Return Ok(Some(api_artifact_url)) if exists, or Ok(None) if it doesn't.
-/// 
+///
 /// Caches info on all artifacts matching (repo, tag).
 pub(super) async fn get_gh_release_artifact_url(
     gh_api_client: GhApiClient,
@@ -58,7 +58,7 @@ pub(super) async fn get_gh_release_artifact_url(
 }
 
 /// Check if the URL exists by querying the GitHub API.
-/// 
+///
 /// Caches info on all artifacts matching (repo, tag).
 ///
 /// This function returns a future where its size should be at most size of

--- a/crates/binstalk-fetchers/src/common.rs
+++ b/crates/binstalk-fetchers/src/common.rs
@@ -24,6 +24,9 @@ use crate::FetchError;
 static WARN_RATE_LIMIT_ONCE: Once = Once::new();
 static WARN_UNAUTHORIZED_ONCE: Once = Once::new();
 
+/// Return Ok(Some(api_artifact_url)) if exists, or Ok(None) if it doesn't.
+/// 
+/// Caches info on all artifacts matching (repo, tag).
 pub(super) async fn get_gh_release_artifact_url(
     gh_api_client: GhApiClient,
     artifact: GhReleaseArtifact,
@@ -54,6 +57,10 @@ pub(super) async fn get_gh_release_artifact_url(
     }
 }
 
+/// Check if the URL exists by querying the GitHub API.
+/// 
+/// Caches info on all artifacts matching (repo, tag).
+///
 /// This function returns a future where its size should be at most size of
 /// 2-4 pointers.
 pub(super) async fn does_url_exist(

--- a/crates/binstalk-fetchers/src/quickinstall.rs
+++ b/crates/binstalk-fetchers/src/quickinstall.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 const BASE_URL: &str = "https://github.com/cargo-bins/cargo-quickinstall/releases/download";
-pub const QUICK_INSTALL_STATS_URL: &str =
+pub const QUICKINSTALL_STATS_URL: &str =
     "https://cargo-quickinstall-stats-server.fly.dev/record-install";
 
 const QUICKINSTALL_SIGN_KEY: Cow<'static, str> =
@@ -63,7 +63,6 @@ pub struct QuickInstall {
     package: String,
     package_url: Url,
     signature_url: Url,
-    stats_url: Url,
     signature_policy: SignaturePolicy,
 
     target_data: Arc<TargetDataErased>,
@@ -179,8 +178,6 @@ impl super::Fetcher for QuickInstall {
                 .expect("package_url is pre-generated and should never be invalid url"),
             signature_url: Url::parse(&format!("{url}.sig"))
                 .expect("signature_url is pre-generated and should never be invalid url"),
-            stats_url: Url::parse("{QUICK_INSTALL_STATS_URL}")
-                .expect("stats_url is pre-generated and should never be invalid url"),
             package,
             signature_policy,
 
@@ -321,7 +318,8 @@ impl QuickInstall {
             return Ok(());
         }
 
-        let mut url = self.stats_url.clone();
+        let mut url = Url::parse(QUICKINSTALL_STATS_URL)
+            .expect("stats_url is pre-generated and should never be invalid url");
         url.query_pairs_mut()
             .append_pair("crate", &self.data.name)
             .append_pair("version", &self.data.version)

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -247,6 +247,8 @@ pub struct GhReleaseArtifactUrl(Url);
 
 impl GhApiClient {
     /// Return `Ok(Some(api_artifact_url))` if exists.
+    /// 
+    /// Caches info on all artifacts matching (repo, tag).
     ///
     /// The returned future is guaranteed to be pointer size.
     #[instrument(skip(self), ret(level = Level::DEBUG))]

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -247,7 +247,7 @@ pub struct GhReleaseArtifactUrl(Url);
 
 impl GhApiClient {
     /// Return `Ok(Some(api_artifact_url))` if exists.
-    /// 
+    ///
     /// Caches info on all artifacts matching (repo, tag).
     ///
     /// The returned future is guaranteed to be pointer size.

--- a/crates/binstalk/src/lib.rs
+++ b/crates/binstalk/src/lib.rs
@@ -10,4 +10,4 @@ pub use binstalk_registry as registry;
 pub use binstalk_types as manifests;
 pub use detect_targets::{get_desired_targets, DesiredTargets, TARGET};
 
-pub use fetchers::QUICK_INSTALL_STATS_URL;
+pub use fetchers::QUICKINSTALL_STATS_URL;

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -203,6 +203,7 @@ async fn resolve_inner(
                     {
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
+                                fetcher.report_to_upstream();
                                 return Ok(Resolution::Fetch(Box::new(ResolutionFetch {
                                     fetcher: fetcher.clone(),
                                     new_version: package_info.version,
@@ -250,6 +251,8 @@ async fn resolve_inner(
         }
     }
 
+    // At this point, we don't know whether fallback to cargo install is allowed, or whether it will
+    // succeed, but things start to get convoluted when try to include that data, so this will do.
     if !opts.disable_telemetry {
         for fetcher in handles {
             fetcher.report_to_upstream();

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -203,7 +203,7 @@ async fn resolve_inner(
                     {
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
-                                fetcher.report_to_upstream();
+                                fetcher.clone().report_to_upstream();
                                 return Ok(Resolution::Fetch(Box::new(ResolutionFetch {
                                     fetcher: fetcher.clone(),
                                     new_version: package_info.version,


### PR DESCRIPTION
similar to https://github.com/cargo-bins/cargo-binstall/pull/1905/files . I suspect that the discussions will be similar, but I won't push back on any changes you suggest.

* reports about all architectures on failure
  * doesn't report whether the build-from-source fallback worked or not, because that seems basically impossible
  * reports about how far each of the fetchers got (it does the fetch() -> bool for everything in parallel, and then tries the downloads sequentially. Knowing which ones were tried when they fail seems interesting to me.
* only reports about the winning architecture on success (I think this is fine: we can kind-of infer the status of architectures higher in the preference list, and we don't really care about things lower down)

Also it turns out this is my first pull request to cargo-binstall. It took me a while to work out how things fit together. I added some comments in places where I had to dig down through too many layers of abstraction to find out the information that I was after.