### PR TITLE
fix(gh_api_client): remote client should never being shared everywhere bacause the underlying connection pool will be reused.

### DIFF
--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -327,7 +327,6 @@ impl GhApiClient {
 mod test {
     use super::*;
     use compact_str::{CompactString, ToCompactString};
-    use once_cell::sync::OnceCell;
     use std::{env, num::NonZeroU16, time::Duration};
     use tokio::time::sleep;
     use tracing::subscriber::set_global_default;
@@ -506,20 +505,14 @@ mod test {
     }
 
     fn create_remote_client() -> remote::Client {
-        static CLIENT: OnceCell<remote::Client> = OnceCell::new();
-
-        CLIENT
-            .get_or_init(|| {
-                remote::Client::new(
-                    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                    None,
-                    NonZeroU16::new(300).unwrap(),
-                    1.try_into().unwrap(),
-                    [],
-                )
-                .unwrap()
-            })
-            .clone()
+        remote::Client::new(
+            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+            None,
+            NonZeroU16::new(300).unwrap(),
+            1.try_into().unwrap(),
+            [],
+        )
+        .unwrap()
     }
 
     /// Mark this as an async fn so that you won't accidentally use it in


### PR DESCRIPTION
The client pool contains connections associated with a runtime when the runtime closes, the client may panic at seeing the connection disappear "abruptly".

Reported-by: https://archriscv.felixc.at/.status/log.htm?url=logs/cargo-binstall/cargo-binstall-1.8.0-1.log
Link: https://github.com/seanmonstar/reqwest/issues/1148