### PR TITLE
CI: Fix binstalk-git-repo-api on PR of forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         if: env.CARGO_NEXTEST_ADDITIONAL_ARGS != ''
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          CI_UNIT_TEST_GITHUB_TOKEN: ${{ secrets.CI_UNIT_TEST_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          CI_UNIT_TEST_GITHUB_TOKEN: ${{ secrets.CI_UNIT_TEST_GITHUB_TOKEN }}
 
   e2e-tests:
     if: github.event_name != 'pull_request'

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -528,7 +528,9 @@ mod test {
         let client = create_remote_client();
 
         let auth_token = match env::var("CI_UNIT_TEST_GITHUB_TOKEN") {
-            Ok(auth_token) if !auth_token.is_empty() => zeroize::Zeroizing::new(auth_token.into_boxed_str()),
+            Ok(auth_token) if !auth_token.is_empty() => {
+                zeroize::Zeroizing::new(auth_token.into_boxed_str())
+            }
             _ => None,
         };
 

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -529,7 +529,7 @@ mod test {
 
         let auth_token = match env::var("CI_UNIT_TEST_GITHUB_TOKEN") {
             Ok(auth_token) if !auth_token.is_empty() => {
-                zeroize::Zeroizing::new(auth_token.into_boxed_str())
+                Some(zeroize::Zeroizing::new(auth_token.into_boxed_str()))
             }
             _ => None,
         };

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -527,10 +527,10 @@ mod test {
     fn create_client() -> Vec<GhApiClient> {
         let client = create_remote_client();
 
-        let auth_token = env::var("CI_UNIT_TEST_GITHUB_TOKEN")
-            .ok()
-            .map(Box::<str>::from)
-            .map(zeroize::Zeroizing::new);
+        let auth_token = match env::var("CI_UNIT_TEST_GITHUB_TOKEN") {
+            Ok(auth_token) if !auth_token.is_empty() => zeroize::Zeroizing::new(auth_token.into_boxed_str()),
+            _ => None,
+        };
 
         let gh_client = GhApiClient::new(client.clone(), auth_token.clone());
         gh_client.set_only_use_restful_api();


### PR DESCRIPTION
Fork cannot access secrets, so if that case that the token to empty and ignore it in tests.