### PR TITLE
install-from-binstall-release: Add BINSTALL_VERSION

### DIFF
--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -1,7 +1,11 @@
 $ErrorActionPreference = "Stop"
 Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP
-$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+$BINSTALL_VERSION = $Env:BINSTALL_VERSION
+if (-not $BINSTALL_VERSION) {
+    $BINSTALL_VERSION = 'latest'
+}
+$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/$BINSTALL_VERSION/download/cargo-binstall-"
 $proc_arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
 if ($proc_arch -eq "AMD64") {
 	$arch = "x86_64"

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -2,9 +2,11 @@
 
 set -euxo pipefail
 
+BINSTALL_VERSION="${BINSTALL_VERSION:-latest}"
+
 cd "$(mktemp -d)"
 
-base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+base_url="https://github.com/cargo-bins/cargo-binstall/releases/${BINSTALL_VERSION}/download/cargo-binstall-"
 
 os="$(uname -s)"
 if [ "$os" == "Darwin" ]; then


### PR DESCRIPTION
This allow the users to choose different versions of cargo-binstall