### PR TITLE
Fix installer downloads for specific releases

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         set_cargo_home: [t, f]
+        set_binstall_version: ['no', 'with-v', 'without-v']
 
     runs-on: ${{ matrix.os }}
 
@@ -43,6 +44,18 @@ jobs:
           CARGO_HOME="$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')"
           mkdir -p "${CARGO_HOME}/bin"
           echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
+
+      - name: Set `BINSTALL_VERSION`
+        if: matrix.set_binstall_version != 'no'
+        env:
+          STRIP_V: ${{ matrix.set_cargo_home }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # fetch most recent release tag.
+          BINSTALL_VERSION="$(gh release list --json name --jq '[.[] | select(.name | startswith("v")) | .name] | first')"
+          if [[ $STRIP_V == 'without-v' ]]; then BINSTALL_VERSION="${BINSTALL_VERSION#v*}"; fi
+          echo "Setting BINSTALL_VERSION=$BINSTALL_VERSION"
+          echo "BINSTALL_VERSION=$BINSTALL_VERSION" >> "$GITHUB_ENV"
 
       - name: Install `cargo-binstall` using scripts
         run: ./install-from-binstall-release.sh
@@ -59,6 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         set_cargo_home: [t, f]
+        set_binstall_version: ['no', 'with-v', 'without-v']
 
     runs-on: windows-latest
 
@@ -72,6 +86,19 @@ jobs:
           CARGO_HOME="$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')"
           mkdir -p "${CARGO_HOME}/bin"
           echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
+
+      - name: Set `BINSTALL_VERSION`
+        if: matrix.set_binstall_version != 'no'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STRIP_V: ${{ matrix.set_cargo_home }}
+        run: |
+          # fetch most recent release name.
+          BINSTALL_VERSION="$(gh release list --json name --jq '[.[] | select(.name | startswith("v")) | .name] | first')"
+          if [[ $STRIP_V == 'without-v' ]]; then BINSTALL_VERSION="${BINSTALL_VERSION#v*}"; fi
+          echo "Setting BINSTALL_VERSION=$BINSTALL_VERSION"
+          echo "BINSTALL_VERSION=$BINSTALL_VERSION" >> "$GITHUB_ENV"
 
       - name: Install `cargo-binstall` using scripts
         run: ./install-from-binstall-release.ps1
@@ -86,6 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         set_cargo_home: [t, f]
+        set_binstall_version: ['no', 'with-v', 'without-v']
 
     runs-on: windows-latest
 
@@ -99,6 +127,19 @@ jobs:
           CARGO_HOME="$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-home')"
           mkdir -p "${CARGO_HOME}/bin"
           echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
+
+      - name: Set `BINSTALL_VERSION`
+        if: matrix.set_binstall_version != 'no'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STRIP_V: ${{ matrix.set_cargo_home }}
+        run: |
+          # fetch most recent release name.
+          BINSTALL_VERSION="$(gh release list --json name --jq '[.[] | select(.name | startswith("v")) | .name] | first')"
+          if [[ $STRIP_V == 'without-v' ]]; then BINSTALL_VERSION="${BINSTALL_VERSION#v*}"; fi
+          echo "Setting BINSTALL_VERSION=$BINSTALL_VERSION"
+          echo "BINSTALL_VERSION=$BINSTALL_VERSION" >> "$GITHUB_ENV"
 
       - name: Install `cargo-binstall` using scripts
         shell: bash

--- a/install-from-binstall-release.ps1
+++ b/install-from-binstall-release.ps1
@@ -2,10 +2,19 @@ $ErrorActionPreference = "Stop"
 Set-PSDebug -Trace 1
 $tmpdir = $Env:TEMP
 $BINSTALL_VERSION = $Env:BINSTALL_VERSION
-if (-not $BINSTALL_VERSION) {
-    $BINSTALL_VERSION = 'latest'
+if ($BINSTALL_VERSION -and $BINSTALL_VERSION -notlike 'v*') {
+    # prefix version with v
+    $BINSTALL_VERSION = "v$BINSTALL_VERSION"
 }
-$base_url = "https://github.com/cargo-bins/cargo-binstall/releases/$BINSTALL_VERSION/download/cargo-binstall-"
+# Fetch binaries from `[..]/releases/latest/download/[..]` if _no_ version is
+# given, otherwise from `[..]/releases/download/VERSION/[..]`. Note the shifted
+# location of '/download'.
+$base_url = if (-not $BINSTALL_VERSION) {
+    "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+} else {
+    "https://github.com/cargo-bins/cargo-binstall/releases/download/$BINSTALL_VERSION/cargo-binstall-"
+}
+
 $proc_arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
 if ($proc_arch -eq "AMD64") {
 	$arch = "x86_64"

--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -2,11 +2,21 @@
 
 set -euxo pipefail
 
-BINSTALL_VERSION="${BINSTALL_VERSION:-latest}"
+if [[ -n "${BINSTALL_VERSION:-}" && "$BINSTALL_VERSION" != v* ]]; then
+    # prefix version with v
+    BINSTALL_VERSION="v$BINSTALL_VERSION"
+fi
 
 cd "$(mktemp -d)"
 
-base_url="https://github.com/cargo-bins/cargo-binstall/releases/${BINSTALL_VERSION}/download/cargo-binstall-"
+# Fetch binaries from `[..]/releases/latest/download/[..]` if _no_ version is
+# given, otherwise from `[..]/releases/download/VERSION/[..]`. Note the shifted
+# location of '/download'.
+if [[ -z "${BINSTALL_VERSION:-}" ]]; then
+    base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
+else
+    base_url="https://github.com/cargo-bins/cargo-binstall/releases/download/${BINSTALL_VERSION}/cargo-binstall-"
+fi
 
 os="$(uname -s)"
 if [ "$os" == "Darwin" ]; then


### PR DESCRIPTION
Github download urls for a specific release uses the pattern `../releases/download/[RELEASE]/..`, which differs from the latest release URL which uses `../releases/latest/download/..`.

For convenience, if `BINSTALL_VERSION` is set but doesn't start with `v`, the v is prefixed.

Fixes #1974
