### PR TITLE
Make `install-from-binstall-release` work with POSIX sh

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -1,35 +1,40 @@
-#!/bin/bash
+#!/bin/sh
 
-set -euxo pipefail
+set -eux
 
-if [[ -n "${BINSTALL_VERSION:-}" && "$BINSTALL_VERSION" != v* ]]; then
-    # prefix version with v
-    BINSTALL_VERSION="v$BINSTALL_VERSION"
-fi
+# Set pipefail if it works in a subshell, disregard if unsupported
+# shellcheck disable=SC3040
+(set -o pipefail 2> /dev/null) && set -o pipefail
+
+case "${BINSTALL_VERSION:-}" in
+    "") ;; # unset
+    v*) ;; # already includes the `v`
+    *) BINSTALL_VERSION="v$BINSTALL_VERSION" ;; # Add a leading `v`
+esac
 
 cd "$(mktemp -d)"
 
 # Fetch binaries from `[..]/releases/latest/download/[..]` if _no_ version is
 # given, otherwise from `[..]/releases/download/VERSION/[..]`. Note the shifted
 # location of '/download'.
-if [[ -z "${BINSTALL_VERSION:-}" ]]; then
+if [ -z "${BINSTALL_VERSION:-}" ]; then
     base_url="https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-"
 else
     base_url="https://github.com/cargo-bins/cargo-binstall/releases/download/${BINSTALL_VERSION}/cargo-binstall-"
 fi
 
 os="$(uname -s)"
-if [ "$os" == "Darwin" ]; then
+if [ "$os" = "Darwin" ]; then
     url="${base_url}universal-apple-darwin.zip"
     curl -A "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0" -LO --proto '=https' --tlsv1.2 -sSf "$url"
     unzip cargo-binstall-universal-apple-darwin.zip
-elif [ "$os" == "Linux" ]; then
+elif [ "$os" = "Linux" ]; then
     machine="$(uname -m)"
-    if [ "$machine" == "armv7l" ]; then
+    if [ "$machine" = "armv7l" ]; then
         machine="armv7"
     fi
     target="${machine}-unknown-linux-musl"
-    if [ "$machine" == "armv7" ]; then
+    if [ "$machine" = "armv7" ]; then
         target="${target}eabihf"
     fi
 
@@ -50,7 +55,12 @@ fi
 
 CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 
-if ! [[ ":$PATH:" == *":$CARGO_HOME/bin:"* ]]; then
+case ":$PATH:" in
+    *":$CARGO_HOME/bin:"*) ;; # Cargo home is already in path
+    *) needs_cargo_home=1 ;;
+esac
+
+if [ -n "${needs_cargo_home:-}" ]; then
     if [ -n "${CI:-}" ] && [ -n "${GITHUB_PATH:-}" ]; then
         echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
     else


### PR DESCRIPTION
This script would be useful to run in Docker containers, which don't always have `bash` available (e.g. Alpine). It just needs a few small adjustments to make this work, so apply those changes here.

Tested this script in an Alpine container.