### PR TITLE
Reduce log version requirements back to 0.4.22

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -30,7 +30,7 @@ compact_str = "0.8.0"
 dirs = "5.0.1"
 file-format = { version = "0.26.0", default-features = false }
 home = "0.5.9"
-log = { version = "0.4.24", features = ["std"] }
+log = { version = "0.4.22", features = ["std"] }
 miette = "7.0.0"
 mimalloc = { version = "0.1.39", default-features = false, optional = true }
 once_cell = "1.18.0"


### PR DESCRIPTION
Since new versions are yanked