### PR TITLE
Log when FileLock::drop fails to unlock file

### DIFF
--- a/crates/binstalk-manifests/Cargo.toml
+++ b/crates/binstalk-manifests/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0 OR MIT"
 beef = { version = "0.5.2", features = ["impl_serde"] }
 binstalk-types = { version = "0.9.3", path = "../binstalk-types" }
 compact_str = { version = "0.8.0", features = ["serde"] }
-fs-lock = { version = "0.1.7", path = "../fs-lock" }
+fs-lock = { version = "0.1.7", path = "../fs-lock", features = ["tracing"] }
 home = "0.5.9"
 miette = "7.0.0"
 semver = { version = "1.0.17", features = ["serde"] }

--- a/crates/binstalk-manifests/src/binstall_crates_v1.rs
+++ b/crates/binstalk-manifests/src/binstall_crates_v1.rs
@@ -43,7 +43,8 @@ where
     Iter: IntoIterator<Item = T>,
     Data: From<T>,
 {
-    let mut file = FileLock::new_exclusive(create_if_not_exist(path.as_ref())?)?;
+    let path = path.as_ref();
+    let mut file = create_if_not_exist(path)?;
     // Move the cursor to EOF
     file.seek(io::SeekFrom::End(0))?;
 
@@ -166,7 +167,7 @@ impl Records {
 
     pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let mut this = Self {
-            file: FileLock::new_exclusive(create_if_not_exist(path.as_ref())?)?,
+            file: create_if_not_exist(path.as_ref())?,
             data: BTreeSet::default(),
         };
         this.load_impl()?;

--- a/crates/binstalk-manifests/src/cargo_config.rs
+++ b/crates/binstalk-manifests/src/cargo_config.rs
@@ -138,7 +138,7 @@ impl Config {
         fn inner(path: &Path) -> Result<Config, ConfigLoadError> {
             match File::open(path) {
                 Ok(file) => {
-                    let file = FileLock::new_shared(file)?;
+                    let file = FileLock::new_shared(file)?.set_file_path(path);
                     // Any regular file must have a parent dir
                     Config::load_from_reader(file, path.parent().unwrap())
                 }

--- a/crates/binstalk-manifests/src/cargo_crates_v1.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1.rs
@@ -62,7 +62,8 @@ impl CratesToml<'_> {
     }
 
     pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, CratesTomlParseError> {
-        let file = FileLock::new_shared(File::open(path)?)?;
+        let path = path.as_ref();
+        let file = FileLock::new_shared(File::open(path)?)?.set_file_path(path);
         Self::load_from_reader(file)
     }
 
@@ -100,7 +101,8 @@ impl CratesToml<'_> {
     }
 
     pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<(), CratesTomlParseError> {
-        let mut file = FileLock::new_exclusive(File::create(path)?)?;
+        let path = path.as_ref();
+        let mut file = FileLock::new_exclusive(File::create(path)?)?.set_file_path(path);
         self.write_to_file(&mut file)
     }
 
@@ -142,7 +144,7 @@ impl CratesToml<'_> {
     where
         Iter: IntoIterator<Item = &'a CrateInfo>,
     {
-        let mut file = FileLock::new_exclusive(create_if_not_exist(path.as_ref())?)?;
+        let mut file = create_if_not_exist(path.as_ref())?;
         Self::append_to_file(&mut file, iter)
     }
 

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -12,7 +12,9 @@ use thiserror::Error as ThisError;
 use crate::{
     binstall_crates_v1::{Error as BinstallCratesV1Error, Records as BinstallCratesV1Records},
     cargo_crates_v1::{CratesToml, CratesTomlParseError},
-    crate_info::CrateInfo, helpers::create_if_not_exist, CompactString, Version,
+    crate_info::CrateInfo,
+    helpers::create_if_not_exist,
+    CompactString, Version,
 };
 
 #[derive(Debug, Diagnostic, ThisError)]

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -46,7 +46,7 @@ impl Manifests {
         // Read cargo_install_v1_metadata
         let manifest_path = cargo_roots.join(".crates.toml");
 
-        let cargo_crates_v1 = create_file_if_not_exist(manifest_path)?;
+        let cargo_crates_v1 = create_if_not_exist(manifest_path)?;
 
         Ok(Self {
             binstall,

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -46,7 +46,7 @@ impl Manifests {
         // Read cargo_install_v1_metadata
         let manifest_path = cargo_roots.join(".crates.toml");
 
-        let cargo_crates_v1 = create_if_not_exist(manifest_path)?;
+        let cargo_crates_v1 = create_if_not_exist(&manifest_path)?;
 
         Ok(Self {
             binstall,

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -12,8 +12,7 @@ use thiserror::Error as ThisError;
 use crate::{
     binstall_crates_v1::{Error as BinstallCratesV1Error, Records as BinstallCratesV1Records},
     cargo_crates_v1::{CratesToml, CratesTomlParseError},
-    crate_info::CrateInfo,
-    CompactString, Version,
+    crate_info::CrateInfo, helpers::create_if_not_exist, CompactString, Version,
 };
 
 #[derive(Debug, Diagnostic, ThisError)]
@@ -47,13 +46,7 @@ impl Manifests {
         // Read cargo_install_v1_metadata
         let manifest_path = cargo_roots.join(".crates.toml");
 
-        let cargo_crates_v1 = fs::File::options()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(manifest_path)
-            .and_then(FileLock::new_exclusive)?;
+        let cargo_crates_v1 = create_file_if_not_exist(manifest_path)?;
 
         Ok(Self {
             binstall,

--- a/crates/binstalk-manifests/src/helpers.rs
+++ b/crates/binstalk-manifests/src/helpers.rs
@@ -1,7 +1,9 @@
 use std::{fs, io, path::Path};
 
-/// Returned file is readable and writable.
-pub(crate) fn create_if_not_exist(path: &Path) -> io::Result<fs::File> {
+use fs_lock::FileLock;
+
+/// Return exclusively locked file that is readable and writable.
+pub(crate) fn create_if_not_exist(path: &Path) -> io::Result<FileLock> {
     let mut options = fs::File::options();
     options.read(true).write(true);
 
@@ -10,4 +12,6 @@ pub(crate) fn create_if_not_exist(path: &Path) -> io::Result<fs::File> {
         .create_new(true)
         .open(path)
         .or_else(|_| options.open(path))
+        .and_then(FileLock::new_exclusive)
+        .map(|file_lock| file_lock.set_file_path(path))
 }

--- a/crates/binstalk-manifests/src/helpers.rs
+++ b/crates/binstalk-manifests/src/helpers.rs
@@ -4,14 +4,12 @@ use fs_lock::FileLock;
 
 /// Return exclusively locked file that is readable and writable.
 pub(crate) fn create_if_not_exist(path: &Path) -> io::Result<FileLock> {
-    let mut options = fs::File::options();
-    options.read(true).write(true);
-
-    options
-        .clone()
-        .create_new(true)
+    fs::File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
         .open(path)
-        .or_else(|_| options.open(path))
         .and_then(FileLock::new_exclusive)
         .map(|file_lock| file_lock.set_file_path(path))
 }

--- a/crates/fs-lock/Cargo.toml
+++ b/crates/fs-lock/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 fs4 = "0.12.0"
+tracing = { version = "0.1", optional = true }

--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -3,7 +3,7 @@
 //! These use the same mechanisms as, and are interoperable with, Cargo.
 
 use std::{
-    fs::File.
+    fs::File,
     io::{self, IoSlice, IoSliceMut, SeekFrom},
     ops, path::Path,
 };
@@ -19,10 +19,13 @@ pub struct FileLock(
 );
 
 impl FileLock {
+    #[cfg(not(feature = "tracing"))]
     fn new(file: File) -> Self {
-        #[cfg(not(feature = "tracing"))]
         Self(file)
-        #[cfg(feature = "tracing")]
+    }
+
+    #[cfg(feature = "tracing")]
+    fn new(file: File) -> Self {
         Self(file, None)
     }
 

--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -20,11 +20,10 @@ pub struct FileLock(
 
 impl FileLock {
     fn new(file: File) -> Self {
-        Self(
-            file,
-            #[cfg(feature = "tracing")]
-            None,
-        )
+        #[cfg(not(feature = "tracing"))]
+        Self(file)
+        #[cfg(feature = "tracing")]
+        Self(file, None)
     }
 
     /// Take an exclusive lock on a [`File`].
@@ -33,7 +32,7 @@ impl FileLock {
     pub fn new_exclusive(file: File) -> io::Result<Self> {
         FileExt::lock_exclusive(&file)?;
 
-        Ok(Self:new(file))
+        Ok(Self::new(file))
     }
 
     /// Try to take an exclusive lock on a [`File`].

--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -84,7 +84,9 @@ impl FileLock {
     /// Set path to the file for logging on unlock error, if feature tracing is enabled
     pub fn set_file_path(mut self, path: impl Into<Box<Path>>) -> Self {
         #[cfg(feature = "tracing")]
-        self.1 = Some(path.into());
+        {
+            self.1 = Some(path.into());
+        }
         self
     }
 }

--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -5,18 +5,15 @@
 use std::{
     fs::File,
     io::{self, IoSlice, IoSliceMut, SeekFrom},
-    ops, path::Path,
+    ops,
+    path::Path,
 };
 
 use fs4::fs_std::FileExt;
 
 /// A locked file.
 #[derive(Debug)]
-pub struct FileLock(
-    File,
-    #[cfg(feature = "tracing")]
-    Option<Box<Path>>,
-);
+pub struct FileLock(File, #[cfg(feature = "tracing")] Option<Box<Path>>);
 
 impl FileLock {
     #[cfg(not(feature = "tracing"))]

--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -3,9 +3,9 @@
 //! These use the same mechanisms as, and are interoperable with, Cargo.
 
 use std::{
-    fs::File,
+    fs::File.
     io::{self, IoSlice, IoSliceMut, SeekFrom},
-    ops,
+    ops, path::Path,
 };
 
 use fs4::fs_std::FileExt;


### PR DESCRIPTION
In case the unlock file, it might block cargo/cargo-binstall until the file is removed or kernel is rebooted.

So we should have logging for it.