### PR TITLE
Use flate2/zlib-rs for dev/release build

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -63,6 +63,7 @@ static = ["binstalk/static"]
 pkg-config = ["binstalk/pkg-config"]
 
 zlib-ng = ["binstalk/zlib-ng"]
+zlib-rs = ["binstalk/zlib-rs"]
 
 rustls = ["binstalk/rustls"]
 native-tls = ["binstalk/native-tls"]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -88,6 +88,7 @@ static = ["bzip2/static", "xz2/static", "native-tls-crate?/vendored"]
 pkg-config = ["zstd/pkg-config"]
 
 zlib-ng = ["flate2/zlib-ng"]
+zlib-rs = ["flate2/zlib-rs"]
 
 # Dummy feature, enabled if rustls or native-tls is enabled.
 # Used to avoid compilation error when no feature is enabled.

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -56,6 +56,7 @@ static = ["binstalk-downloader/static"]
 pkg-config = ["binstalk-downloader/pkg-config"]
 
 zlib-ng = ["binstalk-downloader/zlib-ng"]
+zlib-rs = ["binstalk-downloader/zlib-rs"]
 
 rustls = ["binstalk-downloader/rustls", "binstalk-registry/rustls"]
 native-tls = ["binstalk-downloader/native-tls", "binstalk-registry/native-tls"]

--- a/justfile
+++ b/justfile
@@ -79,30 +79,10 @@ support-pkg-config := if target == target-host {
     if target-os == "linux" { "true" } else { "" }
 } else { "" }
 
-#} else if target == "aarch64-unknown-linux-gnu" {
-#    ",zlib-ng"
-#} else if target == "aarch64-unknown-linux-musl" {
-#    ",zlib-ng"
-git-max-perf-feature := if target == "x86_64-apple-darwin" {
-    ",zlib-ng"
-} else if target == "x86_64h-apple-darwin" {
-    ",zlib-ng"
-} else if target == "aarch64-apple-darwin" {
-    ",zlib-ng"
-} else if target-os == "windows" {
-    ",zlib-ng"
-} else if target == "x86_64-unknown-linux-gnu" {
-    ",zlib-ng"
-} else if target == "x86_64-unknown-linux-musl" {
-    ",zlib-ng"
-} else {
-    ""
-}
-
 h3-features := if enable-h3 != "" { ",http3" } else { "" }
 cargo-features := trim_end_match(if override-features != "" { override-features + h3-features
-    } else if (cargo-profile / ci-or-no) == "dev/ci" { "git,rustls,fancy-with-backtrace,zstd-thin,log_max_level_debug" + git-max-perf-feature + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + h3-features + extra-features
-    } else if (cargo-profile / ci-or-no) == "release/ci" { "git,static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto"  + git-max-perf-feature + h3-features + extra-features
+    } else if (cargo-profile / ci-or-no) == "dev/ci" { "git,rustls,fancy-with-backtrace,zstd-thin,log_max_level_debug,zlib-rs" + (if support-pkg-config != "" { ",pkg-config" } else { "" }) + h3-features + extra-features
+    } else if (cargo-profile / ci-or-no) == "release/ci" { "git,static,rustls,trust-dns,fancy-no-backtrace,zstd-thin,log_release_max_level_debug,cross-lang-fat-lto,zlib-rs" + h3-features + extra-features
     } else if extra-features != "" { extra-features + h3-features
     } else if enable-h3 != "" { "http3"
     } else { ""


### PR DESCRIPTION
Finally we don't need the external C codebase zlib-ng which is hard to cross compile