### PR TITLE
feat: Use `CARGO_BUILD_TARGET` as fallback for `--target`

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -88,7 +88,8 @@ pub struct Args {
         help_heading = "Package selection",
         alias = "target",
         long,
-        value_name = "TRIPLE"
+        value_name = "TRIPLE",
+        env = "CARGO_BUILD_TARGET"
     )]
     pub(crate) targets: Option<Vec<String>>,
 


### PR DESCRIPTION
To resolve first half of https://github.com/cargo-bins/cargo-binstall/issues/1057#issuecomment-2689636131