### PR TITLE
fix: actually check if lock was acquired

### DIFF
--- a/crates/fs-lock/src/lib.rs
+++ b/crates/fs-lock/src/lib.rs
@@ -44,7 +44,8 @@ impl FileLock {
     /// Note that this operation is blocking, and should not be called in async contexts.
     pub fn new_try_exclusive(file: File) -> Result<Self, (File, Option<io::Error>)> {
         match FileExt::try_lock_exclusive(&file) {
-            Ok(_) => Ok(Self::new(file)),
+            Ok(true) => Ok(Self::new(file)),
+            Ok(false) => Err((file, None)),
             Err(e) if e.raw_os_error() == fs4::lock_contended_error().raw_os_error() => {
                 Err((file, None))
             }
@@ -70,7 +71,8 @@ impl FileLock {
     /// Note that this operation is blocking, and should not be called in async contexts.
     pub fn new_try_shared(file: File) -> Result<Self, (File, Option<io::Error>)> {
         match FileExt::try_lock_shared(&file) {
-            Ok(_) => Ok(Self::new(file)),
+            Ok(true) => Ok(Self::new(file)),
+            Ok(false) => Err((file, None)),
             Err(e) if e.raw_os_error() == fs4::lock_contended_error().raw_os_error() => {
                 Err((file, None))
             }


### PR DESCRIPTION
Likely fixes #2090

@dpc noticed in Fedimint that our locking was broken when upgrading from 0.1.8 to 0.1.9 of `fs-lock`. 

Looking at the [diff](https://github.com/cargo-bins/cargo-binstall/compare/f71ab715ab4c375693866343dd9e547e0252555d...b243c176fed21bae9ee5883deae97b7f500e5ae2) I noticed that a [version bump of the underlying `fs4` library](https://github.com/cargo-bins/cargo-binstall/pull/2072/commits/c836f0026a75938282d906b71e2fde0a4d91fc21) likely lead to the regression. The [documentation](https://docs.rs/fs4/latest/fs4/fs_std/trait.FileExt.html#tymethod.try_lock_exclusive) mentions that the `FileExt::try_lock_*` functions now return a `Result<bool, _>` where the `bool` indicates the lock status of the file, which is currently being ignored.

![20250318_22h46m52s_grim](https://github.com/user-attachments/assets/5965d0fb-1574-4a29-87fc-f2b88dcadeab)
