### PR TITLE
Fix clippy warnings for detect-targets and binstalk-downloader

### DIFF
--- a/crates/binstalk-downloader/src/download/zip_extraction.rs
+++ b/crates/binstalk-downloader/src/download/zip_extraction.rs
@@ -1,6 +1,6 @@
 use std::{
-    fs::{self, create_dir_all, File},
-    io::{self, Read},
+    fs::{create_dir_all, File},
+    io,
     path::Path,
 };
 
@@ -38,6 +38,8 @@ pub(super) fn do_extract_zip(f: File, dir: &Path) -> Result<ExtractedFiles, Down
                     if #[cfg(windows)] {
                         do_extract_file()?;
                     } else {
+                        use std::{fs, io::Read};
+
                         match fs::symlink_metadata(&path) {
                             Ok(metadata) if metadata.is_file() => fs::remove_file(&path)?,
                             _ => (),

--- a/crates/detect-targets/src/detect/linux.rs
+++ b/crates/detect-targets/src/detect/linux.rs
@@ -8,7 +8,7 @@ use tokio::{process::Command, task};
 use tracing::debug;
 
 pub(super) async fn detect_targets(target: String) -> Vec<String> {
-    let (prefix, postfix) = target
+    let (_, postfix) = target
         .rsplit_once('-')
         .expect("unwrap: target always has a -");
 


### PR DESCRIPTION
binstalk-downloader clippy warning is specific to windows