### PR TITLE
Safer GH action execution for sh shells

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ runs:
       if: runner.os != 'Windows'
       shell: sh
       run: |
-        set -euo pipefail
+        set -eu
         curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - name: Install cargo-binstall
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: sh
       run: |
         set -eu
-        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | sh
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       run: Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: sh
       run: |
         set -eu
-        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        (curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh || echo 'exit 1') | bash
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       run: Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,9 @@ runs:
     - name: Install cargo-binstall
       if: runner.os != 'Windows'
       shell: sh
-      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+      run: |
+        set -euo pipefail
+        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       run: Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: sh
       run: |
         set -eu
-        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | sh
+        curl --retry 10 -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       run: Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content


### PR DESCRIPTION
Properly fixes #2157. The fix proposed in #2158 doesn't solve the problem.

The default command used by composite actions is `bash --noprofile --norc -eo pipefail {0}`, but if you change the shell to `sh`, the command is `sh -e {0}`, which does not catch the failing commands. See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

Also added `--retry 10` to the `curl` command to make it safer.
