### PR TITLE
fix: Rm uninstalled crates from binstall/crates-v1.json

### DIFF
--- a/crates/binstalk-manifests/src/binstall_crates_v1.rs
+++ b/crates/binstalk-manifests/src/binstall_crates_v1.rs
@@ -214,6 +214,11 @@ impl Records {
         self.data.remove(value.as_ref())
     }
 
+    /// Remove crates that `f(&data.crate_info)` returns `false`.
+    pub fn retain(&mut self, f: impl FnMut(&CrateInfo)) {
+        self.dat.retain(|data| f(&data.crate_info))
+    }
+
     pub fn take(&mut self, value: impl AsRef<str>) -> Option<CrateInfo> {
         self.data.take(value.as_ref()).map(CrateInfo::from)
     }

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -35,6 +35,7 @@ pub enum ManifestsError {
 pub struct Manifests {
     binstall: BinstallCratesV1Records,
     cargo_crates_v1: FileLock,
+    installed_crates: BTreeMap<CompactString, Version>,
 }
 
 impl Manifests {
@@ -43,16 +44,22 @@ impl Manifests {
         let metadata_path = cargo_roots.join("binstall/crates-v1.json");
         fs::create_dir_all(metadata_path.parent().unwrap())?;
 
-        let binstall = BinstallCratesV1Records::load_from_path(&metadata_path)?;
+        let mut binstall = BinstallCratesV1Records::load_from_path(&metadata_path)?;
 
         // Read cargo_install_v1_metadata
         let manifest_path = cargo_roots.join(".crates.toml");
 
-        let cargo_crates_v1 = create_if_not_exist(&manifest_path)?;
+        let mut cargo_crates_v1 = create_if_not_exist(&manifest_path)?;
 
+        let installed_crates = CratesToml::load_from_reader(&mut cargo_crates_v1)
+            .and_then(CratesToml::collect_into_crates_versions)?;
+
+        binstall.retain(|crate_info| installed_crates.contains_key(&crate_info.name));
+        
         Ok(Self {
             binstall,
             cargo_crates_v1,
+            installed_crates,
         })
     }
 
@@ -64,14 +71,10 @@ impl Manifests {
     /// but it only updates .crates.toml.
     ///
     /// So here we will honour .crates.toml only.
-    pub fn load_installed_crates(
-        &mut self,
-    ) -> Result<BTreeMap<CompactString, Version>, ManifestsError> {
-        self.rewind_cargo_crates_v1()?;
-
-        CratesToml::load_from_reader(&mut self.cargo_crates_v1)
-            .and_then(CratesToml::collect_into_crates_versions)
-            .map_err(ManifestsError::from)
+    pub fn installed_crates(
+        &self,
+    ) -> BTreeMap<CompactString, Version> {
+        &self.installed_crates
     }
 
     pub fn update(mut self, metadata_vec: Vec<CrateInfo>) -> Result<(), ManifestsError> {

--- a/e2e-tests/live.sh
+++ b/e2e-tests/live.sh
@@ -66,3 +66,8 @@ git_mob_version="$(git-mob --version)"
 echo "$git_mob_version"
 
 [ "$git_mob_version" = "git-mob-tool 1.6.1" ]
+
+cargo uninstall b3sum cargo-binstall
+
+"./$1" binstall -y cargo-binstall@0.20.1
+jq <"$CARGO_HOME/binstall/crates-v1.json" | grep -v b3sum


### PR DESCRIPTION
When updating the manifest, remove any crates that are uninstalled (not present in `$CARGO_HOME/.crates.toml`