### PR TITLE
Refactor: check --version and $crate@$version conflict in cargo-binstall

### DIFF
--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -38,7 +38,6 @@ pub struct Options {
     pub locked: bool,
     pub no_track: bool,
 
-    pub version_req: Option<VersionReq>,
     pub cargo_toml_fetch_override: Option<CargoTomlFetchOverride>,
     pub cli_overrides: PkgOverride,
 

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -67,12 +67,7 @@ async fn resolve_inner(
 ) -> Result<Resolution, BinstallError> {
     info!("Resolving package: '{}'", crate_name);
 
-    let version_req = match (&crate_name.version_req, &opts.version_req) {
-        (Some(version), None) => MaybeOwned::Borrowed(version),
-        (None, Some(version)) => MaybeOwned::Borrowed(version),
-        (Some(_), Some(_)) => Err(BinstallError::SuperfluousVersionOption)?,
-        (None, None) => MaybeOwned::Owned(VersionReq::STAR),
-    };
+    let version_req = crate_name.version_req.unwrap_or(VersionReq::STAR);
 
     let version_req_str = version_req.to_compact_string();
 


### PR DESCRIPTION
Instead of in binstalk::ops::resolve to simplify the code