### PR TITLE
dep: Replace vergen with vergen-gitcl

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -49,7 +49,7 @@ zeroize = "1.8.1"
 
 [build-dependencies]
 embed-resource = "3.0.1"
-vergen = { version = "8.2.7", features = ["build", "cargo", "git", "gitcl", "rustc"] }
+vergen = { version = "9.0.6", features = ["build", "cargo", "git", "gitcl", "rustc"] }
 
 [features]
 default = ["static", "rustls", "trust-dns", "fancy-no-backtrace", "zstd-thin", "git"]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -49,7 +49,7 @@ zeroize = "1.8.1"
 
 [build-dependencies]
 embed-resource = "3.0.1"
-vergen-gitcl = { version = "9.0.6", features = ["build", "cargo", "rustc"] }
+vergen-gitcl = { version = "1.0.8", features = ["build", "cargo", "rustc"] }
 
 [features]
 default = ["static", "rustls", "trust-dns", "fancy-no-backtrace", "zstd-thin", "git"]

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -49,7 +49,7 @@ zeroize = "1.8.1"
 
 [build-dependencies]
 embed-resource = "3.0.1"
-vergen = { version = "9.0.6", features = ["build", "cargo", "git", "gitcl", "rustc"] }
+vergen-gitcl = { version = "9.0.6", features = ["build", "cargo", "rustc"] }
 
 [features]
 default = ["static", "rustls", "trust-dns", "fancy-no-backtrace", "zstd-thin", "git"]

--- a/crates/bin/build.rs
+++ b/crates/bin/build.rs
@@ -50,6 +50,7 @@ fn emit_vergen_info() {
             }
             gitcl_builder.build().unwrap()
         })
+        .unwrap()
         .emit()
         .unwrap();
 }

--- a/crates/bin/build.rs
+++ b/crates/bin/build.rs
@@ -35,7 +35,7 @@ fn emit_vergen_info() {
                 .commit_hash(true)
                 .llvm_version(true)
                 .build()
-                .unwrap()
+                .unwrap(),
         )
         .unwrap()
         .add_instructions(&{

--- a/crates/bin/build.rs
+++ b/crates/bin/build.rs
@@ -25,22 +25,18 @@ fn emit_vergen_info() {
 
     Emitter::default()
         .fail_on_error()
-        .add_instructions(&{
-            BuildBuilder::default().build_date(true).build().unwrap()
-        })
+        .add_instructions(&BuildBuilder::default().build_date(true).build().unwrap())
         .unwrap()
-        .add_instructions(&{
-            CargoBuilder::default().features(true).build().unwrap()
-        })
+        .add_instructions(&CargoBuilder::default().features(true).build().unwrap())
         .unwrap()
-        .add_instructions(&{
-            RustcBuilder::default()
+        .add_instructions(
+            &RustcBuilder::default()
                 .semver(true)
                 .commit_hash(true)
-            .llvm_version(true)
-            .build()
-            .unwrap()
-        })
+                .llvm_version(true)
+                .build()
+                .unwrap()
+        )
         .unwrap()
         .add_instructions(&{
             let mut gitcl_builder = GitclBuilder::default();

--- a/e2e-tests/self-install.sh
+++ b/e2e-tests/self-install.sh
@@ -10,5 +10,5 @@ export PATH="$CARGO_HOME/bin:$PATH"
 
 "./$1" --self-install
 
-cargo binstall --help
+cargo binstall -vV
 cargo install --list


### PR DESCRIPTION
In v9 vergen is split into multiple crates with different git implementations.