### PR TITLE
Refactor and fix settings file creation

### DIFF
--- a/crates/bin/src/settings.rs
+++ b/crates/bin/src/settings.rs
@@ -121,9 +121,7 @@ pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {
         debug!(?path, "checking if settings file exists");
         if path.exists() {
             debug!(?path, "loading binstall settings");
-            let mut file = File::options()
-                .read(true)
-                .open(path)
+            let mut file = File::open(path)
                 .into_diagnostic()
                 .wrap_err("open existing settings file")?;
 


### PR DESCRIPTION
Closes #2268
* Cleans up `settings::load` to use `if path.exists()` instead of `match` with assumption about the error.
  * This changes the warning from ` WARN   × open existing settings file ╰─▶ No such file or directory (os error 2)` to ` WARN   × creating new settings file ╰─▶ Invalid argument (os error 22)` which better represents the actual error
* Adds missing `.write(true)` to resolve said error

Passes `cargo test`
Passes `cargo clippy`
Passes `cargo fmt`