### PR TITLE
fix creation, loading and updating of settings

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -30,6 +30,7 @@ clap-cargo = "0.16.0"
 compact_str = "0.9.0"
 dirs = "6.0.0"
 file-format = { version = "0.28.0", default-features = false }
+fs-lock = { version = "0.1.11", path = "../fs-lock", features = ["tracing"] }
 home = "0.5.9"
 log = { version = "0.4.22", features = ["std"] }
 miette = "7.0.0"

--- a/crates/bin/src/settings.rs
+++ b/crates/bin/src/settings.rs
@@ -141,7 +141,7 @@ pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {
         debug!(?path, "checking if settings file exists");
         if !path.exists() {
             debug!(?path, "trying to create new settings file");
-     
+
             let mut tempfile = NamedTempFile::new_in(parent)
                 .into_diagnostic()
                 .wrap_err("creating new temporary settings file")?;
@@ -150,7 +150,7 @@ pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {
             settings
                 .write(tempfile.as_file_mut())
                 .wrap_err("for new temporary settings file")?;
-            
+
             if tempfile.persist_noclobber(path).is_ok() {
                 return Ok(settings);
             }

--- a/crates/bin/src/settings.rs
+++ b/crates/bin/src/settings.rs
@@ -115,17 +115,17 @@ impl Settings {
         settings.telemetry = self.telemetry.clone();
         settings.write(&mut file)
     }
-}
 
-fn read_from_file(file: &mut File) -> Result<Self> {
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)
-        .into_diagnostic()
-        .wrap_err("read existing settings file")?;
+    fn read_from_file(file: &mut File) -> Result<Self> {
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .into_diagnostic()
+            .wrap_err("read existing settings file")?;
 
-    toml::from_str(&contents)
-        .into_diagnostic()
-        .wrap_err("parse existing settings file")
+        toml::from_str(&contents)
+            .into_diagnostic()
+            .wrap_err("parse existing settings file")
+    }
 }
 
 pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {

--- a/crates/bin/src/settings.rs
+++ b/crates/bin/src/settings.rs
@@ -139,18 +139,19 @@ pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {
             .wrap_err("create settings directory")?;
 
         debug!(?path, "checking if settings file exists");
-        if !path.exists() {    
+        if !path.exists() {
             debug!(?path, "trying to create new settings file");
-            
+     
             let mut tempfile = NamedTempFile::new_in(parent)
                 .into_diagnostic()
                 .wrap_err("creating new temporary settings file")?;
-            
+
             let settings = Settings::default();
-            settings.write(tempfile.as_file_mut())
+            settings
+                .write(tempfile.as_file_mut())
                 .wrap_err("for new temporary settings file")?;
             
-            if tempfile.persist_noclobber(path).is_ok() {    
+            if tempfile.persist_noclobber(path).is_ok() {
                 return Ok(settings);
             }
         }

--- a/crates/bin/src/settings.rs
+++ b/crates/bin/src/settings.rs
@@ -88,7 +88,7 @@ impl Settings {
     }
 
     fn write(&self, file: &mut File) -> Result<()> {
-        let write_all_and_set_len = |data| {
+        let mut write_all_and_set_len = |data| {
             file.write_all(data)?;
             file.set_len(data.len().try_into().unwrap())
         };
@@ -161,7 +161,7 @@ pub fn load(error_if_inaccessible: bool, path: &Path) -> Result<Settings> {
             .into_diagnostic()
             .wrap_err("open existing settings file")?;
 
-        let settings = Self::read_from_file(&mut file)?;
+        let settings = Settings::read_from_file(&mut file)?;
 
         debug!(?settings, "loaded binstall settings");
         Ok(settings)


### PR DESCRIPTION
 - atomically create the settings file using named tempfile
 - use shared file lock when reading it
 - read from the file when updating to prevent overriding previously saved data, and only update the `telemetry` field (since we only update it), plus use exclusive file lock