### PR TITLE
dep: Upgrade compression libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,18 +123,20 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "5bee399cc3a623ec5a2db2c5b90ee0190a2260241fbe0c023ac8f7bab426aaf8"
 dependencies = [
  "brotli",
  "bzip2",
+ "compression-codecs",
+ "compression-core",
  "flate2",
  "futures-core",
+ "liblzma",
  "memchr",
  "pin-project-lite",
  "tokio",
- "xz2",
  "zstd",
  "zstd-safe",
 ]
@@ -282,6 +284,7 @@ dependencies = [
  "hickory-resolver",
  "httpdate",
  "ipconfig",
+ "liblzma",
  "native-tls",
  "once_cell",
  "rc-zip-sync",
@@ -295,7 +298,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "xz2",
  "zstd",
 ]
 
@@ -439,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -450,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -495,9 +497,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
  "bzip2-sys",
  "libbz2-rs-sys",
@@ -754,6 +756,30 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7eea68f0e02c2b0aa8856e9a9478444206d4b6828728e7b0697c0f8cca265cb"
+dependencies = [
+ "brotli",
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "futures-core",
+ "liblzma",
+ "memchr",
+ "pin-project-lite",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "core-foundation"
@@ -2786,15 +2812,35 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "liblzma"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bf66f4598dc77ff96677c8e763655494f00ff9c1cf79e2eb5bb07bc31f807d"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2891,17 +2937,6 @@ checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
  "byteorder",
  "crc",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3628,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "rc-zip"
-version = "5.3.1"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebde715984a68b306e5b41884cbcb8158e0e1dbe6e2841212983333b1662c416"
+checksum = "6fd15972184edbcbe29420dd4a06006c6e2d975cba3d2e8a5f3f3a93d19ee1ae"
 dependencies = [
  "bzip2",
  "chardetng",
@@ -3652,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-sync"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9658d8ace392ab7f2b149ae6c40bea7a3d70ebc39aaa6c7076ddc3f11c9c32"
+checksum = "b02124be8e1da76aa2ee3b32c93fe3a0090a41084fba8b9e8551ebd13f3cce87"
 dependencies = [
  "oval",
  "positioned-io",
@@ -5492,15 +5527,6 @@ checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
 ]
 
 [[package]]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 async-trait = "0.1.88"
-async-compression = { version = "0.4.4", features = [
+async-compression = { version = "0.4.29", features = [
     "gzip",
     "zstd",
     "xz",
@@ -20,9 +20,7 @@ async-compression = { version = "0.4.4", features = [
 ] }
 binstalk-types = { version = "0.10.0", path = "../binstalk-types" }
 bytes = "1.4.0"
-bzip2 = { version = "0.5.2", default-features = false, features = [
-    "libbz2-rs-sys",
-] }
+bzip2 = "0.6.0"
 cfg-if = "1"
 compact_str = "0.9.0"
 flate2 = { version = "1.0.28", default-features = false }
@@ -69,7 +67,7 @@ hickory-resolver = { version = "0.25.1", optional = true, features = [
 once_cell = { version = "1.18.0", optional = true }
 url = "2.5.4"
 
-xz2 = "0.1.7"
+liblzma = "0.4"
 
 # zstd is also depended by zip.
 # Since zip 0.6.3 depends on zstd 0.11, we can use 0.12.0 here
@@ -86,7 +84,7 @@ version = "0.2.10"
 [features]
 default = ["static", "rustls"]
 
-static = ["bzip2/static", "xz2/static", "native-tls-crate?/vendored"]
+static = ["bzip2/static", "liblzma/static", "native-tls-crate?/vendored"]
 pkg-config = ["zstd/pkg-config"]
 
 zlib-ng = ["flate2/zlib-ng"]

--- a/crates/binstalk-downloader/src/download/extracter.rs
+++ b/crates/binstalk-downloader/src/download/extracter.rs
@@ -2,8 +2,8 @@ use std::io::{self, BufRead, Read};
 
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
+use liblzma::bufread::XzDecoder;
 use tar::Archive;
-use xz2::bufread::XzDecoder;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use super::TarBasedFmt;


### PR DESCRIPTION
 - async-compression 0.4.19 => v0.4.29
 - brotli 7.0.0 => 8.0.2
 - bzip2 0.5.2 => 0.6.0
 - xz 0.1.7 => liblzma 0.4.4 (a fork that is maintained)