### PR TITLE
feat: respect socks5 in `https_proxy`

### DIFF
--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { version = "0.12.17", features = [
     "gzip",
     "brotli",
     "deflate",
+    "socks",
 ], default-features = false }
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 serde_json = { version = "1.0.107", optional = true }


### PR DESCRIPTION
#2303

After the change, https requests sent using `reqwest` will respect socks5 proxy defined in the `https_proxy` environment variable, e.g.,

```bash
https_proxy=socks5://127.0.0.1:1086
```
