### PR TITLE
Enable linker-plugin-lto for x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -34,6 +34,7 @@ jobs:
               t: x86_64-unknown-linux-gnu,
               g: 2.17,
               c: true,
+              r: true,
             }
           - {
               o: ubuntu-latest,

--- a/justfile
+++ b/justfile
@@ -134,8 +134,12 @@ rustc-icf := if for-release != "" {
 # Temporarily disable this on linux due to mismatch llvm version
 # } else if target-os == "linux" {
 #     "-C linker-plugin-lto "
-linker-plugin-lto := if for-release == "" {
-    ""
+linker-plugin-lto := if for-release != "" {
+    if target == "x86_64-unknown-linux-gnu" {
+        "-C linker-plugin-lto "
+    } else {
+        ""
+    }
 } else {
     ""
 }


### PR DESCRIPTION
Rust now uses rust-lld for it by default, so we can use cross lang LTO