### PR TITLE
fix CVE-2025-62518

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +278,7 @@ dependencies = [
 name = "binstalk-downloader"
 version = "0.13.24"
 dependencies = [
+ "astral-tokio-tar",
  "async-compression",
  "async-trait",
  "binstalk-types",
@@ -287,7 +304,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "tokio-tar",
  "tokio-util",
  "tracing",
  "url",
@@ -2874,7 +2890,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3337,7 +3353,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3593,15 +3609,6 @@ dependencies = [
  "positioned-io",
  "rc-zip",
  "tracing",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4438,21 +4445,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ strip = "symbols"
 [profile.release.build-override]
 inherits = "dev.build-override"
 
-[profile.release.package."tokio-tar"]
+[profile.release.package."astral-tokio-tar"]
 opt-level = "z"
 
 [profile.release.package."binstall-tar"]
@@ -46,7 +46,7 @@ codegen-units = 32
 [profile.dev.package."*"]
 opt-level = 3
 
-[profile.dev.package."tokio-tar"]
+[profile.dev.package."astral-tokio-tar"]
 opt-level = "z"
 
 [profile.dev.package."binstall-tar"]

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -59,7 +59,7 @@ tokio = { version = "1.46.1", features = [
     "time",
     "fs",
 ], default-features = false }
-tokio-tar = "0.3.0"
+astral-tokio-tar = "0.5.6"
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.39"
 hickory-resolver = { version = "0.25.1", optional = true, features = [


### PR DESCRIPTION
Swaps out the unmaintained tokio-tar with astral-tokio-tar. Profile settings continue to be respected.