### PR TITLE
PkgFmt: support tbz

### DIFF
--- a/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall/package_formats.rs
@@ -75,7 +75,7 @@ impl PkgFmt {
             "tar" => Some(PkgFmt::Tar),
 
             "tbz2" | "tbz" => Some(PkgFmt::Tbz2),
-            "bz2" if it.next() == Some("tar") => Some(PkgFmt::Tbz2),
+            "bz2" | "bz" if it.next() == Some("tar") => Some(PkgFmt::Tbz2),
 
             "tgz" => Some(PkgFmt::Tgz),
             "gz" if it.next() == Some("tar") => Some(PkgFmt::Tgz),


### PR DESCRIPTION
Some libraries use .tbz extension. For libraries that use binstalk_downloader, PkgFmt may need to add support for the .tbz format.

https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz