### PR TITLE
fix: Don't send reports when telemetry is disabled

### DIFF
--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -199,7 +199,9 @@ async fn resolve_inner(
                     {
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
-                                fetcher.clone().report_to_upstream();
+                                if !opts.disable_telemetry {
+                                    fetcher.clone().report_to_upstream();
+                                }
                                 return Ok(Resolution::Fetch(Box::new(ResolutionFetch {
                                     fetcher: fetcher.clone(),
                                     new_version: package_info.version,


### PR DESCRIPTION
I noticed telemetry reporting attempts in a restrictive environment even though I had telemetry properly disabled.

I traced it to this section of code which was missing a check against the telemetry options.