### PR TITLE
feat: Support `cfg` expressions for overrides.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "semver",
  "simple-git",
  "strum",
- "target-lexicon",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -422,7 +421,9 @@ dependencies = [
 name = "binstalk-types"
 version = "0.10.3"
 dependencies = [
+ "cargo-platform",
  "compact_str",
+ "indexmap",
  "maybe-owned",
  "once_cell",
  "semver",
@@ -430,6 +431,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "target-lexicon",
  "url",
 ]
 
@@ -2685,6 +2687,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -59,6 +59,51 @@ with the following variables available:
 pkg-fmt = "zip"
 ```
 
+#### Using `cfg` expressions
+
+In addition to exact target names, you can use Cargo-style `cfg(...)` expressions to match multiple targets at once. This avoids having to list each target individually:
+
+```toml
+# Apply to all Linux targets.
+[package.metadata.binstall.overrides.'cfg(target_os = "linux")']
+pkg-fmt = "tgz"
+
+# Apply to all Windows targets.
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-fmt = "zip"
+
+# Apply to all Unix-like systems.
+[package.metadata.binstall.overrides.'cfg(unix)']
+bin-dir = "{ bin }"
+```
+
+The following `cfg` predicates are available:
+
+- `target_os`: Operating system (e.g., `"linux"`, `"windows"`, `"macos"`)
+- `target_arch`: Architecture (e.g., `"x86_64"`, `"aarch64"`, `"universal"`)
+- `target_env`: ABI environment (e.g., `"gnu"`, `"msvc"`, `"musl"`)
+- `target_vendor`: Vendor (e.g., `"unknown"`, `"apple"`, `"pc"`)
+- `target_family`: Operating system family (`"unix"` or `"windows"`)
+
+You can also use:
+
+- `cfg(unix)` as shorthand for Unix-like systems
+- `cfg(windows)` as shorthand for Windows
+
+Finally, you can combine predicates using `all()`, `any()`, and `not()`:
+
+```toml
+# Match ARM Linux with the GNU C Library.
+[package.metadata.binstall.overrides.'cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))']
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-arm64-linux{ archive-suffix }"
+
+# Match any non-Windows system.
+[package.metadata.binstall.overrides.'cfg(not(target_os = "windows"))']
+pkg-fmt = "tgz"
+```
+
+**Precedence:** Exact target names take precedence over `cfg` expressions. When multiple `cfg` expressions match, they're evaluated in the order they appear in `Cargo.toml`.
+
 ### Defaults
 
 By default, `binstall` will try all supported package formats and would do the same for `bin-dir`.

--- a/crates/binstalk-types/Cargo.toml
+++ b/crates/binstalk-types/Cargo.toml
@@ -10,13 +10,16 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+cargo-platform = "0.3.2"
 compact_str = { version = "0.9.0", features = ["serde"] }
+indexmap = { version = "2.13.0", features = ["serde"] }
 maybe-owned = { version = "0.3.4", features = ["serde"] }
 once_cell = "1.18.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.163", features = ["derive"] }
 strum = "0.27.0"
 strum_macros = "0.27.0"
+target-lexicon = { version = "0.13.0", features = ["std"] }
 url = { version = "2.5.8", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/binstalk-types/src/cargo_toml_binstall/target_triple.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall/target_triple.rs
@@ -1,0 +1,416 @@
+use std::{borrow::Cow, fmt::Display, str::FromStr};
+
+use cargo_platform::{Cfg, Ident};
+use target_lexicon::{Architecture, Environment, OperatingSystem, Triple, Vendor};
+
+pub use target_lexicon::ParseError as TargetTripleParseError;
+
+/// A representation of a `rustc` target triple. This is related to,
+/// but different than, the LLVM target triple.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TargetTriple {
+    pub os: OperatingSystem,
+    pub arch: ArchOr,
+    pub env: Environment,
+    pub vendor: Vendor,
+    pub family: Option<Family>,
+}
+
+impl TargetTriple {
+    /// Returns a list of all the `cfg(...)` options that apply to this triple.
+    pub fn cfgs(&self) -> Vec<Cfg> {
+        let mut options = vec![
+            CfgOption::Os(self.os),
+            CfgOption::Arch(self.arch),
+            CfgOption::Env(self.env),
+            CfgOption::Vendor(&self.vendor),
+        ];
+        if let Some(family) = self.family {
+            options.push(CfgOption::Family(family));
+        }
+        options.into_iter().flat_map(CfgOption::into_cfgs).collect()
+    }
+}
+
+impl FromStr for TargetTriple {
+    type Err = TargetTripleParseError;
+
+    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        let is_universal_macos = is_universal_macos(s);
+
+        if is_universal_macos {
+            s = "x86_64-apple-darwin";
+        }
+
+        let triple = Triple::from_str(s)?;
+        Ok(Self {
+            os: triple.operating_system,
+            arch: if is_universal_macos {
+                ArchOr::Universal
+            } else {
+                ArchOr::Arch(triple.architecture)
+            },
+            env: triple.environment,
+            vendor: triple.vendor,
+            family: Family::from_os(triple.operating_system),
+        })
+    }
+}
+
+/// A `cfg(...)` option.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CfgOption<'a> {
+    Os(OperatingSystem),
+    Arch(ArchOr),
+    Env(Environment),
+    Vendor(&'a Vendor),
+    Family(Family),
+}
+
+impl<'a> CfgOption<'a> {
+    pub fn key(&self) -> &'static str {
+        match self {
+            Self::Os(_) => "target_os",
+            Self::Arch(_) => "target_arch",
+            Self::Env(_) => "target_env",
+            Self::Vendor(_) => "target_vendor",
+            Self::Family(_) => "target_family",
+        }
+    }
+
+    pub fn value(&self) -> Cow<'a, str> {
+        match self {
+            Self::Os(OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_)) => {
+                // `rustc` uses `macos` for both; match its behavior.
+                Cow::Borrowed("macos")
+            }
+            Self::Os(os) => os.into_str(),
+            Self::Arch(arch) => arch.into_str(),
+            Self::Env(env) => env.into_str(),
+            Self::Vendor(vendor) => vendor.as_str().into(),
+            Self::Family(family) => family.to_string().into(),
+        }
+    }
+
+    pub fn into_cfgs(self) -> Vec<Cfg> {
+        let pair = Cfg::KeyPair(
+            Ident {
+                name: self.key().to_owned(),
+                raw: false,
+            },
+            self.value().into_owned(),
+        );
+        match self {
+            // For `cfg(target_family = unix | windows)`, also include
+            // `cfg(unix | windows)`, matching `rustc`.
+            Self::Family(family @ (Family::Unix | Family::Windows)) => vec![
+                Cfg::Name(Ident {
+                    name: family.to_string(),
+                    raw: false,
+                }),
+                pair,
+            ],
+            // For other configuration options, including other target families,
+            // just set `cfg(name = value)`.
+            _ => vec![pair],
+        }
+    }
+}
+
+/// Either an [`Architecture`] from an LLVM target triple, or "universal",
+/// which is an Apple multi-architecture binary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchOr {
+    Arch(Architecture),
+    Universal,
+}
+
+impl ArchOr {
+    pub fn into_str(self) -> Cow<'static, str> {
+        match self {
+            Self::Arch(arch) => arch.into_str(),
+            Self::Universal => Cow::Borrowed("universal"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Family {
+    Unix,
+    Windows,
+}
+
+impl Family {
+    /// Converts an [`OperatingSystem`] from an LLVM target triple into
+    /// a `rustc` target family.
+    pub fn from_os(os: OperatingSystem) -> Option<Self> {
+        // `rustc +nightly -Z unstable-options --print all-target-specs-json`
+        // prints the mapping of each LLVM target triple to `target-family`.
+        match os {
+            OperatingSystem::Linux
+            | OperatingSystem::Darwin(_)
+            | OperatingSystem::MacOSX(_)
+            | OperatingSystem::IOS(_)
+            | OperatingSystem::Freebsd
+            | OperatingSystem::Dragonfly
+            | OperatingSystem::Openbsd
+            | OperatingSystem::Netbsd
+            | OperatingSystem::Solaris
+            | OperatingSystem::Illumos
+            | OperatingSystem::Fuchsia
+            | OperatingSystem::Redox
+            | OperatingSystem::Haiku
+            | OperatingSystem::Aix
+            | OperatingSystem::Cygwin
+            | OperatingSystem::Emscripten
+            | OperatingSystem::Espidf
+            | OperatingSystem::Hurd
+            | OperatingSystem::L4re
+            | OperatingSystem::TvOS(_)
+            | OperatingSystem::VisionOS(_)
+            | OperatingSystem::VxWorks
+            | OperatingSystem::WatchOS(_)
+            | OperatingSystem::XROS(_) => Some(Self::Unix),
+            OperatingSystem::Windows => Some(Self::Windows),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Family {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Unix => "unix",
+            Self::Windows => "windows",
+        })
+    }
+}
+
+fn is_universal_macos(target: &str) -> bool {
+    ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use target_lexicon::Aarch64Architecture;
+
+    #[test]
+    fn test_parse_linux_target() {
+        let triple: TargetTriple = "x86_64-unknown-linux-gnu".parse().unwrap();
+
+        assert_eq!(triple.os, OperatingSystem::Linux);
+        assert_eq!(triple.arch, ArchOr::Arch(Architecture::X86_64));
+        assert_eq!(triple.env, Environment::Gnu);
+        assert_eq!(triple.vendor, Vendor::Unknown);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_linux_musl_target() {
+        let triple: TargetTriple = "aarch64-unknown-linux-musl".parse().unwrap();
+
+        assert_eq!(triple.os, OperatingSystem::Linux);
+        assert_eq!(
+            triple.arch,
+            ArchOr::Arch(Architecture::Aarch64(Aarch64Architecture::Aarch64)),
+        );
+        assert_eq!(triple.env, Environment::Musl);
+        assert_eq!(triple.vendor, Vendor::Unknown);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_macos_target() {
+        let triple: TargetTriple = "x86_64-apple-darwin".parse().unwrap();
+
+        assert!(matches!(triple.os, OperatingSystem::Darwin(_)));
+        assert_eq!(triple.arch, ArchOr::Arch(Architecture::X86_64));
+        assert_eq!(triple.env, Environment::Unknown);
+        assert_eq!(triple.vendor, Vendor::Apple);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_macos_aarch64_target() {
+        let triple: TargetTriple = "aarch64-apple-darwin".parse().unwrap();
+
+        assert!(matches!(triple.os, OperatingSystem::Darwin(_)));
+        assert_eq!(
+            triple.arch,
+            ArchOr::Arch(Architecture::Aarch64(Aarch64Architecture::Aarch64))
+        );
+        assert_eq!(triple.vendor, Vendor::Apple);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_universal_apple_darwin() {
+        let triple: TargetTriple = "universal-apple-darwin".parse().unwrap();
+
+        assert!(matches!(triple.os, OperatingSystem::Darwin(_)));
+        assert_eq!(triple.arch, ArchOr::Universal);
+        assert_eq!(triple.vendor, Vendor::Apple);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_universal2_apple_darwin() {
+        let triple: TargetTriple = "universal2-apple-darwin".parse().unwrap();
+
+        assert!(matches!(triple.os, OperatingSystem::Darwin(_)));
+        assert_eq!(triple.arch, ArchOr::Universal);
+        assert_eq!(triple.vendor, Vendor::Apple);
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_windows_target() {
+        let triple: TargetTriple = "x86_64-pc-windows-msvc".parse().unwrap();
+
+        assert_eq!(triple.os, OperatingSystem::Windows);
+        assert_eq!(triple.arch, ArchOr::Arch(Architecture::X86_64));
+        assert_eq!(triple.env, Environment::Msvc);
+        assert_eq!(triple.vendor, Vendor::Pc);
+        assert_eq!(triple.family, Some(Family::Windows));
+    }
+
+    #[test]
+    fn test_parse_windows_gnu_target() {
+        let triple: TargetTriple = "x86_64-pc-windows-gnu".parse().unwrap();
+
+        assert_eq!(triple.os, OperatingSystem::Windows);
+        assert_eq!(triple.arch, ArchOr::Arch(Architecture::X86_64));
+        assert_eq!(triple.env, Environment::Gnu);
+        assert_eq!(triple.vendor, Vendor::Pc);
+        assert_eq!(triple.family, Some(Family::Windows));
+    }
+
+    #[test]
+    fn test_parse_freebsd_target() {
+        let triple: TargetTriple = "x86_64-unknown-freebsd".parse().unwrap();
+
+        assert_eq!(triple.os, OperatingSystem::Freebsd);
+        assert_eq!(triple.arch, ArchOr::Arch(Architecture::X86_64));
+        assert_eq!(triple.family, Some(Family::Unix));
+    }
+
+    #[test]
+    fn test_parse_invalid_target() {
+        let result: Result<TargetTriple, _> = "bad-target-triple-foo".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cfg_option_key() {
+        assert_eq!(CfgOption::Os(OperatingSystem::Linux).key(), "target_os");
+        assert_eq!(
+            CfgOption::Arch(ArchOr::Arch(Architecture::X86_64)).key(),
+            "target_arch"
+        );
+        assert_eq!(CfgOption::Env(Environment::Gnu).key(), "target_env");
+        assert_eq!(CfgOption::Vendor(&Vendor::Unknown).key(), "target_vendor");
+        assert_eq!(CfgOption::Family(Family::Unix).key(), "target_family");
+    }
+
+    #[test]
+    fn test_cfg_option_value() {
+        assert_eq!(CfgOption::Os(OperatingSystem::Linux).value(), "linux");
+        assert_eq!(
+            CfgOption::Arch(ArchOr::Arch(Architecture::X86_64)).value(),
+            "x86_64"
+        );
+        assert_eq!(CfgOption::Arch(ArchOr::Universal).value(), "universal");
+        assert_eq!(CfgOption::Env(Environment::Gnu).value(), "gnu");
+        assert_eq!(CfgOption::Env(Environment::Msvc).value(), "msvc");
+        assert_eq!(CfgOption::Vendor(&Vendor::Unknown).value(), "unknown");
+        assert_eq!(CfgOption::Vendor(&Vendor::Apple).value(), "apple");
+        assert_eq!(CfgOption::Family(Family::Unix).value(), "unix");
+        assert_eq!(CfgOption::Family(Family::Windows).value(), "windows");
+    }
+
+    #[test]
+    fn test_cfg_option_into_cfgs_os() {
+        let cfgs = CfgOption::Os(OperatingSystem::Linux).into_cfgs();
+
+        assert_eq!(cfgs.len(), 1);
+        assert!(
+            matches!(&cfgs[0], Cfg::KeyPair(ident, value) if ident.name == "target_os" && value == "linux")
+        );
+    }
+
+    #[test]
+    fn test_cfg_option_into_cfgs_family_unix() {
+        let cfgs = CfgOption::Family(Family::Unix).into_cfgs();
+
+        // `unix` should produce both `cfg(unix)` and
+        // `cfg(target_family = "unix")`.
+        assert_eq!(cfgs.len(), 2);
+        assert!(matches!(&cfgs[0], Cfg::Name(ident) if ident.name == "unix"));
+        assert!(
+            matches!(&cfgs[1], Cfg::KeyPair(ident, value) if ident.name == "target_family" && value == "unix")
+        );
+    }
+
+    #[test]
+    fn test_cfg_option_into_cfgs_family_windows() {
+        let cfgs = CfgOption::Family(Family::Windows).into_cfgs();
+
+        // `windows` should produce both `cfg(windows)` and
+        // `cfg(target_family = "windows")`.
+        assert_eq!(cfgs.len(), 2);
+        assert!(matches!(&cfgs[0], Cfg::Name(ident) if ident.name == "windows"));
+        assert!(
+            matches!(&cfgs[1], Cfg::KeyPair(ident, value) if ident.name == "target_family" && value == "windows")
+        );
+    }
+
+    #[test]
+    fn test_target_triple_cfgs_linux() {
+        let triple: TargetTriple = "x86_64-unknown-linux-gnu".parse().unwrap();
+        let cfgs = triple.cfgs();
+
+        assert_eq!(cfgs.len(), 6);
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_os" && value == "linux")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_arch" && value == "x86_64")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_env" && value == "gnu")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_vendor" && value == "unknown")));
+        assert!(cfgs
+            .iter()
+            .any(|c| matches!(c, Cfg::Name(ident) if ident.name == "unix")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_family" && value == "unix")));
+    }
+
+    #[test]
+    fn test_target_triple_cfgs_windows() {
+        let triple: TargetTriple = "x86_64-pc-windows-msvc".parse().unwrap();
+        let cfgs = triple.cfgs();
+
+        assert_eq!(cfgs.len(), 6);
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_os" && value == "windows")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_arch" && value == "x86_64")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_env" && value == "msvc")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_vendor" && value == "pc")));
+        assert!(cfgs
+            .iter()
+            .any(|c| matches!(c, Cfg::Name(ident) if ident.name == "windows")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_family" && value == "windows")));
+    }
+
+    #[test]
+    fn test_target_triple_cfgs_universal_macos() {
+        let triple: TargetTriple = "universal-apple-darwin".parse().unwrap();
+        let cfgs = triple.cfgs();
+
+        assert_eq!(cfgs.len(), 6);
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_os" && value == "macos")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_arch" && value == "universal")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_env" && value == "unknown")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_vendor" && value == "apple")));
+        assert!(cfgs
+            .iter()
+            .any(|c| matches!(c, Cfg::Name(ident) if ident.name == "unix")));
+        assert!(cfgs.iter().any(|c| matches!(c, Cfg::KeyPair(ident, value) if ident.name == "target_family" && value == "unix")));
+    }
+}

--- a/crates/binstalk/Cargo.toml
+++ b/crates/binstalk/Cargo.toml
@@ -33,7 +33,6 @@ miette = "7.0.0"
 semver = { version = "1.0.17", features = ["serde"] }
 simple-git = { version = "0.2.18", optional = true }
 strum = "0.27.0"
-target-lexicon = { version = "0.13.0", features = ["std"] }
 tempfile = "3.5.0"
 thiserror = "2.0.11"
 tokio = { version = "1.49.0", features = [

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -6,10 +6,10 @@ use std::{
 
 use binstalk_downloader::{download::DownloadError, remote::Error as RemoteError};
 use binstalk_fetchers::FetchError;
+use binstalk_types::cargo_toml_binstall::TargetTripleParseError;
 use compact_str::CompactString;
 use itertools::Itertools;
 use miette::{Diagnostic, Report};
-use target_lexicon::ParseError as TargetTripleParseError;
 use thiserror::Error;
 use tokio::task;
 use tracing::{error, warn};
@@ -580,8 +580,8 @@ impl From<GhApiError> for BinstallError {
     }
 }
 
-impl From<target_lexicon::ParseError> for BinstallError {
-    fn from(e: target_lexicon::ParseError) -> Self {
+impl From<TargetTripleParseError> for BinstallError {
+    fn from(e: TargetTripleParseError) -> Self {
         BinstallError::TargetTripleParseError(Box::new(e))
     }
 }

--- a/crates/binstalk/src/helpers.rs
+++ b/crates/binstalk/src/helpers.rs
@@ -13,7 +13,3 @@ pub use binstalk_git_repo_api::gh_api_client;
 pub(crate) use cargo_toml_workspace::{self, cargo_toml};
 #[cfg(feature = "git")]
 pub(crate) use simple_git as git;
-
-pub(crate) fn is_universal_macos(target: &str) -> bool {
-    ["universal-apple-darwin", "universal2-apple-darwin"].contains(&target)
-}

--- a/crates/binstalk/src/helpers/target_triple.rs
+++ b/crates/binstalk/src/helpers/target_triple.rs
@@ -1,50 +1,37 @@
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, ops::Deref, str::FromStr};
 
-use compact_str::{CompactString, ToCompactString};
-use target_lexicon::Triple;
+use binstalk_types::cargo_toml_binstall::TargetTriple as TargetTripleInner;
 
-use crate::{errors::BinstallError, helpers::is_universal_macos};
+use crate::errors::BinstallError;
 
 #[derive(Clone, Debug)]
-pub struct TargetTriple {
-    pub target_family: Cow<'static, str>,
-    pub target_arch: Cow<'static, str>,
-    pub target_libc: Cow<'static, str>,
-    pub target_vendor: CompactString,
+pub struct TargetTriple(TargetTripleInner);
+
+impl Deref for TargetTriple {
+    type Target = TargetTripleInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl FromStr for TargetTriple {
     type Err = BinstallError;
 
-    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
-        let is_universal_macos = is_universal_macos(s);
-
-        if is_universal_macos {
-            s = "x86_64-apple-darwin";
-        }
-
-        let triple = Triple::from_str(s)?;
-
-        Ok(Self {
-            target_family: triple.operating_system.into_str(),
-            target_arch: if is_universal_macos {
-                Cow::Borrowed("universal")
-            } else {
-                triple.architecture.into_str()
-            },
-            target_libc: triple.environment.into_str(),
-            target_vendor: triple.vendor.to_compact_string(),
-        })
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
     }
 }
 
 impl leon::Values for TargetTriple {
     fn get_value<'s>(&'s self, key: &str) -> Option<Cow<'s, str>> {
         match key {
-            "target-family" => Some(Cow::Borrowed(&self.target_family)),
-            "target-arch" => Some(Cow::Borrowed(&self.target_arch)),
-            "target-libc" => Some(Cow::Borrowed(&self.target_libc)),
-            "target-vendor" => Some(Cow::Borrowed(&self.target_vendor)),
+            // Intentional: `target-family` in the template refers to the OS,
+            // not to the `rustc` target family.
+            "target-family" => Some(self.os.into_str()),
+            "target-arch" => Some(self.arch.into_str()),
+            "target-libc" => Some(self.env.into_str()),
+            "target-vendor" => Some(Cow::Borrowed(self.vendor.as_str())),
 
             _ => None,
         }


### PR DESCRIPTION
This commit adds support for specifying overrides as Cargo-style `cfg` expressions, in addition to exact target names. Under the hood:

* `TargetTriple` moves from `binstalk` to `binstalk_types`. `binstalk::TargetTriple` still exists as a newtype around `binstalk_types::TargetTriple`, for templating.
* The new `TargetTriple` translates between LLVM target triple fields and `rustc` attributes for `cfg` expressions.

Closes #2432.