### PR TITLE
Replace github-tag-action with action-gh-release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -24,11 +24,11 @@ jobs:
     - uses: actions/checkout@v6
     - if: fromJSON(inputs.info).is-release == 'true'
       name: Push cli release tag
-      uses: mathieudutour/github-tag-action@v6.2
+      uses: softprops/action-gh-release@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ fromJSON(inputs.info).version }}
-        tag_prefix: v
+        draft: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: v${{ fromJSON(inputs.info).version }}
 
   keygen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To create a draft release so that we can keep uploading artefacts with immutable release on