### PR TITLE
allow pinning binstall version in the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ cargo install cargo-binstall
 
 ### In GitHub Actions
 
-We provide a first-party, minimal action that installs the latest version of Binstall:
+We provide a first-party, minimal action that installs Binstall:
 
 ```yml
   - uses: cargo-bins/cargo-binstall@main
+    with:
+      version: "1.2.3" # optional; defaults to latest
 ```
 
 For more features, we recommend the excellent [taiki-e/install-action](https://github.com/marketplace/actions/install-development-tools), which has dedicated support for selected tools and uses Binstall for everything else.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,11 @@
 name: 'Install cargo-binstall'
-description: 'Install the latest version of cargo-binstall tool'
+description: 'Install cargo-binstall tool'
+
+inputs:
+  version:
+    description: 'Version of cargo-binstall to install (e.g. 1.2.3 or v1.2.3). Defaults to latest.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -7,10 +13,14 @@ runs:
     - name: Install cargo-binstall
       if: runner.os != 'Windows'
       shell: sh
+      env:
+        BINSTALL_VERSION: ${{ inputs.version }}
       run: |
         set -eu
         bash "${{ github.action_path }}/install-from-binstall-release.sh"
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       shell: powershell
+      env:
+        BINSTALL_VERSION: ${{ inputs.version }}
       run: Set-ExecutionPolicy Unrestricted -Scope Process; iex "${{ github.action_path }}/install-from-binstall-release.ps1"


### PR DESCRIPTION
Pinning the cargo-binstall version adds more stability to the pipelines.

Tested in https://github.com/release-plz/release-plz/pull/2611

EDIT: Actually, this is not needed, as you can already specify the environment variable `BINSTALL_VERSION`. But I think `with` is better as it is "more typed". 