### PR TITLE
Run ci.yml on ready-to-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
   push:
     branches:
       - main


### PR DESCRIPTION
So that for CI-opened PR, simply hitting ready for review would trigger PRs