### PR TITLE
Enable features system-proxy and charset of reqwest by default

### DIFF
--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -101,7 +101,6 @@ rustls = [
     "__tls",
 
     "reqwest/rustls",
-    "reqwest/rustls-native-certs",
 
     # Enable the following features only if hickory-resolver is enabled.
     "hickory-resolver?/tls-ring",


### PR DESCRIPTION
Should be enabled so that the proxy settings on windows and macos are honored