### PR TITLE
feat: support `cargo:token-from-stdout` in private registries

### DIFF
--- a/crates/bin/src/registry_auth.rs
+++ b/crates/bin/src/registry_auth.rs
@@ -11,7 +11,6 @@ use binstalk_manifests::{
 };
 use binstalk_types::SecretString;
 use compact_str::CompactString;
-use zeroize::Zeroizing;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum SupportedRegistryCredentialProvider {
@@ -118,6 +117,7 @@ fn resolve_global_supported_provider(
     providers: &[CompactString],
 ) -> Option<SupportedRegistryCredentialProvider> {
     let mut seen_aliases = Vec::new();
+    debug_assert!(seen_aliases.is_empty());
     providers.iter().rev().find_map(|provider| {
         resolve_supported_provider_name(cargo_config, provider, &mut seen_aliases)
     })
@@ -165,10 +165,10 @@ fn resolve_cargo_token(
     None
 }
 
-fn resolve_provider_command_arg(arg: &str, registry: &Registry) -> String {
+fn resolve_provider_command_arg(arg: &str, index_url: &str) -> String {
     // Cargo's `BasicProcessCredential` replaces `{index_url}` before spawning `cargo:token-from-stdout` commands.
     // https://github.com/rust-lang/cargo/blob/master/src/cargo/util/credential/adaptor.rs#L27-L34
-    arg.replace("{index_url}", &registry.cargo_install_index_arg())
+    arg.replace("{index_url}", index_url)
 }
 
 fn resolve_cargo_token_from_stdout(
@@ -182,22 +182,20 @@ fn resolve_cargo_token_from_stdout(
             "The first argument to `cargo:token-from-stdout` must be a command that prints a token on stdout",
         ));
     };
+    let index_url = registry.cargo_install_index_arg();
 
     let mut command = Command::new(executable.as_str());
     command
         .args(
             provider_args[1..]
                 .iter()
-                .map(|arg| resolve_provider_command_arg(arg, registry)),
+                .map(|arg| resolve_provider_command_arg(arg, &index_url)),
         )
         .env(
             "CARGO",
             env::var_os("CARGO").unwrap_or_else(|| "cargo".into()),
         )
-        .env(
-            "CARGO_REGISTRY_INDEX_URL",
-            registry.cargo_install_index_arg(),
-        )
+        .env("CARGO_REGISTRY_INDEX_URL", &index_url)
         .stdout(Stdio::piped());
 
     if let Some(name) = registry_name {
@@ -207,17 +205,25 @@ fn resolve_cargo_token_from_stdout(
     let mut child = command.spawn()?;
     let mut stdout = child.stdout.take().unwrap();
 
-    let mut buffer = Zeroizing::new(String::new());
+    let mut buffer = SecretString::from_string(String::new());
     use std::io::Read as _;
     stdout.read_to_string(&mut buffer)?;
 
-    if let Some(end) = buffer.find('\n') {
-        if buffer.len() > end + 1 {
+    if let Some(line) = buffer.lines().next() {
+        let end = line.len();
+        let line_ending_len = if buffer[end..].starts_with("\r\n") {
+            2
+        } else if buffer[end..].starts_with('\n') {
+            1
+        } else {
+            0
+        };
+
+        if buffer.len() > end + line_ending_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "process `{}` returned more than one line of output; expected a single token",
-                    executable
+                    "process `{executable}` returned more than one line of output; expected a single token",
                 ),
             ));
         }
@@ -227,14 +233,11 @@ fn resolve_cargo_token_from_stdout(
     let status = child.wait()?;
     if !status.success() {
         return Err(io::Error::other(format!(
-            "process `{}` failed with status `{status}`",
-            executable
+            "process `{executable}` failed with status `{status}`",
         )));
     }
 
-    Ok(SecretString::from_boxed_str(
-        std::mem::take(&mut *buffer).into_boxed_str(),
-    ))
+    Ok(buffer)
 }
 
 pub(crate) fn resolve_registry_auth(

--- a/crates/bin/src/registry_auth.rs
+++ b/crates/bin/src/registry_auth.rs
@@ -11,7 +11,7 @@ use binstalk_manifests::{
 };
 use binstalk_types::SecretString;
 use compact_str::CompactString;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum SupportedRegistryCredentialProvider {
@@ -165,6 +165,7 @@ fn resolve_cargo_token(
 }
 
 fn resolve_provider_command_arg(arg: &str, registry: &Registry) -> String {
+    // Cargo's BasicProcessCredential replaces `{index_url}` before spawning `cargo:token-from-stdout` commands.
     arg.replace("{index_url}", &registry.cargo_install_index_arg())
 }
 
@@ -188,6 +189,10 @@ fn resolve_cargo_token_from_stdout(
                 .map(|arg| resolve_provider_command_arg(arg, registry)),
         )
         .env(
+            "CARGO",
+            env::var_os("CARGO").unwrap_or_else(|| "cargo".into()),
+        )
+        .env(
             "CARGO_REGISTRY_INDEX_URL",
             registry.cargo_install_index_arg(),
         )
@@ -198,17 +203,14 @@ fn resolve_cargo_token_from_stdout(
     }
 
     let mut child = command.spawn()?;
-    let Some(mut stdout) = child.stdout.take() else {
-        return Err(io::Error::other("credential process stdout was not piped"));
-    };
+    let mut stdout = child.stdout.take().unwrap();
 
-    let mut buffer = String::new();
+    let mut buffer = Zeroizing::new(String::new());
     use std::io::Read as _;
     stdout.read_to_string(&mut buffer)?;
 
     if let Some(end) = buffer.find('\n') {
         if buffer.len() > end + 1 {
-            buffer.zeroize();
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
@@ -222,14 +224,15 @@ fn resolve_cargo_token_from_stdout(
 
     let status = child.wait()?;
     if !status.success() {
-        buffer.zeroize();
         return Err(io::Error::other(format!(
             "process `{}` failed with status `{status}`",
             executable
         )));
     }
 
-    Ok(SecretString::from_boxed_str(buffer.into_boxed_str()))
+    Ok(SecretString::from_boxed_str(
+        std::mem::take(&mut *buffer).into_boxed_str(),
+    ))
 }
 
 pub(crate) fn resolve_registry_auth(

--- a/crates/bin/src/registry_auth.rs
+++ b/crates/bin/src/registry_auth.rs
@@ -74,13 +74,10 @@ fn resolve_supported_provider(
         return None;
     }
 
-    let Some(provider) = cargo_config
+    let provider = cargo_config
         .credential_alias
         .as_ref()
-        .and_then(|aliases| aliases.get(provider_name.as_str()))
-    else {
-        return None;
-    };
+        .and_then(|aliases| aliases.get(provider_name.as_str()))?;
 
     seen_aliases.push(provider_name.clone());
     let supports = resolve_supported_provider_from_config(cargo_config, provider, seen_aliases);

--- a/crates/bin/src/registry_auth.rs
+++ b/crates/bin/src/registry_auth.rs
@@ -1,4 +1,8 @@
-use std::{env, path::Path};
+use std::{
+    env, io,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use binstalk::registry::{Registry, RegistryAuth};
 use binstalk_manifests::{
@@ -7,6 +11,13 @@ use binstalk_manifests::{
 };
 use binstalk_types::SecretString;
 use compact_str::CompactString;
+use zeroize::Zeroize;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SupportedRegistryCredentialProvider {
+    CargoToken,
+    CargoTokenFromStdout(Vec<CompactString>),
+}
 
 fn normalize_registry_name(value: &str) -> String {
     value
@@ -18,33 +29,61 @@ fn normalize_registry_name(value: &str) -> String {
         .collect()
 }
 
-fn provider_name_supports_cargo_token(
+fn split_provider_string(provider: &str) -> Vec<CompactString> {
+    provider
+        .split_whitespace()
+        .map(CompactString::from)
+        .collect()
+}
+
+fn resolve_supported_provider_name(
     cargo_config: &CargoConfig,
     provider_name: &str,
     seen_aliases: &mut Vec<CompactString>,
-) -> bool {
+) -> Option<SupportedRegistryCredentialProvider> {
+    let provider = split_provider_string(provider_name);
+    resolve_supported_provider(cargo_config, &provider, seen_aliases)
+}
+
+fn resolve_supported_provider(
+    cargo_config: &CargoConfig,
+    provider: &[CompactString],
+    seen_aliases: &mut Vec<CompactString>,
+) -> Option<SupportedRegistryCredentialProvider> {
+    let provider_name = provider.first()?;
+
     if provider_name == "cargo:token" {
-        return true;
+        return (provider.len() == 1).then_some(SupportedRegistryCredentialProvider::CargoToken);
+    }
+
+    if provider_name == "cargo:token-from-stdout" {
+        return (provider.len() > 1).then_some(
+            SupportedRegistryCredentialProvider::CargoTokenFromStdout(provider[1..].to_vec()),
+        );
     }
 
     if provider_name.starts_with("cargo:") {
-        return false;
+        return None;
     }
 
     if seen_aliases.iter().any(|alias| alias == provider_name) {
-        return false;
+        return None;
+    }
+
+    if provider.len() != 1 {
+        return None;
     }
 
     let Some(provider) = cargo_config
         .credential_alias
         .as_ref()
-        .and_then(|aliases| aliases.get(provider_name))
+        .and_then(|aliases| aliases.get(provider_name.as_str()))
     else {
-        return false;
+        return None;
     };
 
-    seen_aliases.push(provider_name.into());
-    let supports = provider_supports_cargo_token(cargo_config, provider, seen_aliases);
+    seen_aliases.push(provider_name.clone());
+    let supports = resolve_supported_provider_from_config(cargo_config, provider, seen_aliases);
     seen_aliases.pop();
     supports
 }
@@ -62,43 +101,44 @@ pub(crate) fn get_registry_env_var(name: &str, suffix: &str) -> Option<String> {
     })
 }
 
-fn provider_supports_cargo_token(
+fn resolve_supported_provider_from_config(
     cargo_config: &CargoConfig,
     provider: &CredentialProvider,
     seen_aliases: &mut Vec<CompactString>,
-) -> bool {
+) -> Option<SupportedRegistryCredentialProvider> {
     match provider {
         CredentialProvider::String(provider) => {
-            provider_name_supports_cargo_token(cargo_config, provider, seen_aliases)
+            resolve_supported_provider_name(cargo_config, provider, seen_aliases)
         }
         CredentialProvider::Array(provider) => {
-            provider.len() == 1
-                && provider_name_supports_cargo_token(cargo_config, &provider[0], seen_aliases)
+            resolve_supported_provider(cargo_config, provider, seen_aliases)
         }
     }
 }
 
-fn global_provider_supports_cargo_token(
+fn resolve_global_supported_provider(
     cargo_config: &CargoConfig,
     providers: &[CompactString],
-) -> bool {
-    let mut seen_aliases = Vec::new();
-    providers.iter().any(|provider| {
-        provider_name_supports_cargo_token(cargo_config, provider, &mut seen_aliases)
+) -> Option<SupportedRegistryCredentialProvider> {
+    providers.iter().rev().find_map(|provider| {
+        resolve_supported_provider_name(cargo_config, provider, &mut Vec::new())
     })
 }
 
-fn cargo_token_provider_enabled(cargo_config: &CargoConfig, registry_name: Option<&str>) -> bool {
+fn resolve_registry_credential_provider(
+    cargo_config: &CargoConfig,
+    registry_name: Option<&str>,
+) -> Option<SupportedRegistryCredentialProvider> {
     if let Some(registry_name) = registry_name {
         if let Some(provider) = get_registry_env_var(registry_name, "CREDENTIAL_PROVIDER") {
-            return provider_name_supports_cargo_token(cargo_config, &provider, &mut Vec::new());
+            return resolve_supported_provider_name(cargo_config, &provider, &mut Vec::new());
         }
 
         if let Some(provider) = cargo_config
             .get_registry(registry_name)
             .and_then(|registry| registry.credential_provider.as_ref())
         {
-            return provider_supports_cargo_token(cargo_config, provider, &mut Vec::new());
+            return resolve_supported_provider_from_config(cargo_config, provider, &mut Vec::new());
         }
     }
 
@@ -106,8 +146,8 @@ fn cargo_token_provider_enabled(cargo_config: &CargoConfig, registry_name: Optio
         .registry
         .as_ref()
         .and_then(|registry| registry.global_credential_providers.as_deref())
-        .map(|providers| global_provider_supports_cargo_token(cargo_config, providers))
-        .unwrap_or(true)
+        .and_then(|providers| resolve_global_supported_provider(cargo_config, providers))
+        .or(Some(SupportedRegistryCredentialProvider::CargoToken))
 }
 
 fn resolve_cargo_token(
@@ -127,18 +167,90 @@ fn resolve_cargo_token(
     None
 }
 
+fn resolve_provider_command_arg(arg: &str, registry: &Registry) -> String {
+    arg.replace("{index_url}", &registry.cargo_install_index_arg())
+}
+
+fn resolve_cargo_token_from_stdout(
+    provider_args: &[CompactString],
+    registry_name: Option<&str>,
+    registry: &Registry,
+) -> io::Result<SecretString> {
+    let Some(executable) = provider_args.first() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "The first argument to `cargo:token-from-stdout` must be a command that prints a token on stdout",
+        ));
+    };
+
+    let mut command = Command::new(executable.as_str());
+    command
+        .args(
+            provider_args[1..]
+                .iter()
+                .map(|arg| resolve_provider_command_arg(arg, registry)),
+        )
+        .env(
+            "CARGO_REGISTRY_INDEX_URL",
+            registry.cargo_install_index_arg(),
+        )
+        .stdout(Stdio::piped());
+
+    if let Some(name) = registry_name {
+        command.env("CARGO_REGISTRY_NAME_OPT", name);
+    }
+
+    let mut child = command.spawn()?;
+    let Some(mut stdout) = child.stdout.take() else {
+        return Err(io::Error::other("credential process stdout was not piped"));
+    };
+
+    let mut buffer = String::new();
+    use std::io::Read as _;
+    stdout.read_to_string(&mut buffer)?;
+
+    if let Some(end) = buffer.find('\n') {
+        if buffer.len() > end + 1 {
+            buffer.zeroize();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "process `{}` returned more than one line of output; expected a single token",
+                    executable
+                ),
+            ));
+        }
+        buffer.truncate(end);
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        buffer.zeroize();
+        return Err(io::Error::other(format!(
+            "process `{}` failed with status `{status}`",
+            executable
+        )));
+    }
+
+    Ok(SecretString::from_boxed_str(buffer.into_boxed_str()))
+}
+
 pub(crate) fn resolve_registry_auth(
     cargo_config: &CargoConfig,
     cargo_home: &Path,
     registry_name: Option<&str>,
-    _registry: &Registry,
+    registry: &Registry,
 ) -> Option<RegistryAuth> {
-    if !cargo_token_provider_enabled(cargo_config, registry_name) {
-        return None;
-    }
-
-    let cargo_credentials = Credentials::load_from_home(cargo_home).ok()?;
-    let token = resolve_cargo_token(&cargo_credentials, registry_name)?;
+    let provider = resolve_registry_credential_provider(cargo_config, registry_name)?;
+    let token = match provider {
+        SupportedRegistryCredentialProvider::CargoToken => {
+            let cargo_credentials = Credentials::load_from_home(cargo_home).ok()?;
+            resolve_cargo_token(&cargo_credentials, registry_name)?
+        }
+        SupportedRegistryCredentialProvider::CargoTokenFromStdout(provider_args) => {
+            resolve_cargo_token_from_stdout(&provider_args, registry_name, registry).ok()?
+        }
+    };
 
     RegistryAuth::new(registry_name.map(CompactString::from), token)
 }
@@ -168,12 +280,13 @@ mod tests {
 
     #[test]
     fn test_global_provider_defaults_to_cargo_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::default();
 
-        assert!(cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoToken)
+        );
     }
 
     #[test]
@@ -196,16 +309,14 @@ credential-provider = "cargo:token"
         )
         .unwrap();
 
-        assert!(!cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert!(resolve_registry_credential_provider(&config, Some("private-registry")).is_none());
 
         env::remove_var("CARGO_REGISTRIES_PRIVATE_REGISTRY_CREDENTIAL_PROVIDER");
     }
 
     #[test]
     fn test_registry_provider_alias_enables_cargo_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::load_from_reader(
             Cursor::new(
                 r#"
@@ -221,10 +332,10 @@ custom = "cargo:token"
         )
         .unwrap();
 
-        assert!(cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoToken)
+        );
     }
 
     #[test]
@@ -250,16 +361,17 @@ custom = "cargo:token"
         )
         .unwrap();
 
-        assert!(cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoToken)
+        );
 
         env::remove_var("CARGO_REGISTRIES_PRIVATE_REGISTRY_CREDENTIAL_PROVIDER");
     }
 
     #[test]
     fn test_registry_provider_alias_non_token_disables_cargo_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::load_from_reader(
             Cursor::new(
                 r#"
@@ -275,14 +387,12 @@ custom = ["cargo-credential-example", "--account", "test"]
         )
         .unwrap();
 
-        assert!(!cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert!(resolve_registry_credential_provider(&config, Some("private-registry")).is_none());
     }
 
     #[test]
     fn test_registry_provider_array_alias_enables_cargo_token() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::load_from_reader(
             Cursor::new(
                 r#"
@@ -298,14 +408,15 @@ custom = "cargo:token"
         )
         .unwrap();
 
-        assert!(cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoToken)
+        );
     }
 
     #[test]
     fn test_registry_provider_builtin_cargo_names_do_not_use_aliases() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::load_from_reader(
             Cursor::new(
                 r#"
@@ -321,14 +432,113 @@ credential-provider = "cargo:token-from-stdout"
         )
         .unwrap();
 
-        assert!(!cargo_token_provider_enabled(
-            &config,
-            Some("private-registry")
-        ));
+        assert!(resolve_registry_credential_provider(&config, Some("private-registry")).is_none());
+    }
+
+    #[test]
+    fn test_registry_provider_string_enables_cargo_token_from_stdout() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let config = CargoConfig::load_from_reader(
+            Cursor::new(
+                r#"
+[registries.private-registry]
+index = "sparse+https://registry.example.com/index/"
+credential-provider = "cargo:token-from-stdout rustc --print sysroot"
+                "#,
+            ),
+            std::path::Path::new("."),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoTokenFromStdout(
+                vec!["rustc".into(), "--print".into(), "sysroot".into()]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_registry_provider_alias_enables_cargo_token_from_stdout() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let config = CargoConfig::load_from_reader(
+            Cursor::new(
+                r#"
+[registries.private-registry]
+index = "sparse+https://registry.example.com/index/"
+credential-provider = "custom"
+
+[credential-alias]
+custom = ["cargo:token-from-stdout", "rustc", "--print", "sysroot"]
+                "#,
+            ),
+            std::path::Path::new("."),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoTokenFromStdout(
+                vec!["rustc".into(), "--print".into(), "sysroot".into()]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_global_provider_prefers_last_supported_provider() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let config = CargoConfig::load_from_reader(
+            Cursor::new(
+                r#"
+[registry]
+global-credential-providers = [
+    "cargo:token",
+    "cargo:token-from-stdout rustc --print sysroot",
+]
+                "#,
+            ),
+            std::path::Path::new("."),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_registry_credential_provider(&config, Some("private-registry")),
+            Some(SupportedRegistryCredentialProvider::CargoTokenFromStdout(
+                vec!["rustc".into(), "--print".into(), "sysroot".into()]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_resolve_registry_auth_uses_token_from_stdout_provider() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let config = CargoConfig::load_from_reader(
+            Cursor::new(
+                r#"
+[registries.private-registry]
+index = "sparse+https://registry.example.com/index/"
+credential-provider = "cargo:token-from-stdout rustc --print sysroot"
+                "#,
+            ),
+            std::path::Path::new("."),
+        )
+        .unwrap();
+        let tempdir = tempdir().unwrap();
+        let registry: Registry = "sparse+https://registry.example.com/index/"
+            .parse()
+            .unwrap();
+
+        let auth =
+            resolve_registry_auth(&config, tempdir.path(), Some("private-registry"), &registry)
+                .unwrap();
+
+        assert!(!auth.token().is_empty());
+        assert_eq!(auth.registry_name(), Some("private-registry"));
     }
 
     #[test]
     fn test_resolve_registry_auth_uses_credentials_when_cargo_token_is_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = CargoConfig::load_from_reader(
             Cursor::new(
                 r#"

--- a/crates/bin/src/registry_auth.rs
+++ b/crates/bin/src/registry_auth.rs
@@ -117,8 +117,9 @@ fn resolve_global_supported_provider(
     cargo_config: &CargoConfig,
     providers: &[CompactString],
 ) -> Option<SupportedRegistryCredentialProvider> {
+    let mut seen_aliases = Vec::new();
     providers.iter().rev().find_map(|provider| {
-        resolve_supported_provider_name(cargo_config, provider, &mut Vec::new())
+        resolve_supported_provider_name(cargo_config, provider, &mut seen_aliases)
     })
 }
 
@@ -165,7 +166,8 @@ fn resolve_cargo_token(
 }
 
 fn resolve_provider_command_arg(arg: &str, registry: &Registry) -> String {
-    // Cargo's BasicProcessCredential replaces `{index_url}` before spawning `cargo:token-from-stdout` commands.
+    // Cargo's `BasicProcessCredential` replaces `{index_url}` before spawning `cargo:token-from-stdout` commands.
+    // https://github.com/rust-lang/cargo/blob/master/src/cargo/util/credential/adaptor.rs#L27-L34
     arg.replace("{index_url}", &registry.cargo_install_index_arg())
 }
 

--- a/crates/binstalk-types/src/secrets.rs
+++ b/crates/binstalk-types/src/secrets.rs
@@ -1,4 +1,7 @@
-use std::{fmt, ops::Deref};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 use zeroize::Zeroizing;
 
@@ -12,9 +15,13 @@ impl<T> Redacted<T> {
     }
 }
 
-impl Redacted<Zeroizing<Box<str>>> {
-    pub fn from_boxed_str(value: Box<str>) -> Self {
+impl Redacted<Zeroizing<String>> {
+    pub fn from_string(value: String) -> Self {
         Self::new(Zeroizing::new(value))
+    }
+
+    pub fn from_boxed_str(value: Box<str>) -> Self {
+        Self::from_string(value.into())
     }
 }
 
@@ -26,10 +33,16 @@ impl<T> Deref for Redacted<T> {
     }
 }
 
+impl<T> DerefMut for Redacted<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl<T> fmt::Debug for Redacted<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("<redacted>")
     }
 }
 
-pub type SecretString = Redacted<Zeroizing<Box<str>>>;
+pub type SecretString = Redacted<Zeroizing<String>>;


### PR DESCRIPTION
Addresses #2312

## Summary

This PR adds phase-2 private registry authentication support to `cargo-binstall`.

In this PR, "phase 2" means extending the existing private-registry auth support from `cargo:token` to Cargo's built-in `cargo:token-from-stdout` provider, without yet taking on the full external credential-process surface area.

Concretely, phase 2 includes:

- `cargo:token-from-stdout`
- `credential-alias` resolution for `cargo:token-from-stdout`
- Cargo-compatible provider selection and precedence
- preserving `--registry` / `--index` during `cargo install` fallback

Phase 2 still does not include:

- generic external credential-process providers using Cargo's JSON protocol
- OS-native Cargo credential providers

The main goal is to make private registry flows work in the same cases where `cargo install` already works with `cargo:token-from-stdout`, especially for registries like AWS CodeArtifact that mint short-lived tokens on demand through an external command.

## What Changed

### `cargo:token-from-stdout` support

- Refactor private-registry credential selection from a `cargo:token` boolean check into explicit provider resolution
- Add support for Cargo's built-in `cargo:token-from-stdout` provider
- Support both provider forms Cargo accepts:
  - space-separated string values
  - array values
- Resolve `credential-alias` before deciding whether the effective provider enables the token path
- Respect Cargo's precedence rules:
  - registry-specific env override
  - registry-specific config
  - `registry.global-credential-providers`, with later entries winning
- Treat built-in `cargo:*` provider names as built-ins, not alias targets

### Provider execution behavior

- Execute the configured command and read the token from stdout
- Match Cargo's single-line token behavior
- Replace `{index_url}` in subprocess arguments
- Set:
  - `CARGO_REGISTRY_INDEX_URL`
  - `CARGO_REGISTRY_NAME_OPT`

### Fallback behavior

- Keep the existing fallback fix from phase 1: when `cargo-binstall` falls back to `cargo install`, it preserves the selected registry or index instead of silently defaulting back to crates.io

## Real Validation

Validated manually against AWS CodeArtifact using a sparse private registry configured with `credential-provider = "cargo:token-from-stdout ..."` and no pre-stored login requirement.

Validation flow:

1. Configure a CodeArtifact registry with `cargo:token-from-stdout`
2. Verify plain `cargo install --registry private-test ...`
3. Verify `cargo-binstall --registry private-test ...`
4. Verify `cargo-binstall --force` falls back using the same private registry

Observed result:

- plain Cargo succeeded with `cargo:token-from-stdout`
- `cargo-binstall` resolved the crate from CodeArtifact without `401 Unauthorized`
- fallback to `cargo install` preserved `--registry private-test`
- the fallback install completed successfully

## Test Commands

```bash
cargo test -p cargo-binstall --lib registry_auth
cargo fmt --check
```

Manual CodeArtifact smoke test:

```bash
cargo uninstall codeartifact-smoke || true
cargo install --registry private-test codeartifact-smoke --version 0.1.0
cargo run -p cargo-binstall -- --registry private-test codeartifact-smoke@0.1.0 -y --force
```

Example registry configuration used for validation:

```toml
[registries.private-test]
index = "sparse+https://<domain>-<account>.d.codeartifact.<region>.amazonaws.com/cargo/<repo>/"
credential-provider = [
  "cargo:token-from-stdout",
  "aws", "codeartifact", "get-authorization-token",
  "--domain", "<domain>",
  "--domain-owner", "<account>",
  "--region", "<region>",
  "--query", "authorizationToken",
  "--output", "text",
]
```
