### PR TITLE
binstalk: Remove GITHUB_TOKEN and GH_TOKEN when installing from source

### DIFF
--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -179,6 +179,9 @@ impl ResolutionSource {
             .arg(version)
             .kill_on_drop(true);
 
+        // Do not leak tokens to build scripts via environment variables.
+        cmd.env_remove("GITHUB_TOKEN").env_remove("GH_TOKEN");
+
         apply_registry_selection(
             &mut cmd,
             opts.cargo_install_registry.as_deref(),


### PR DESCRIPTION
This reduces the risk of leaks of tokens for users who pass the `GITHUN_TOKEN` or `GH_TOKEN` environment variables to cargo-binstall to avoid GitHub API rate limits.
