### PR TITLE
feat: support typed extra-file installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "leon",
  "miette",
  "normalize-path",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,6 +12,10 @@ As an example, the configuration would be like this:
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
 bin-dir = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"
+man = "man/man1/{ bin }.1"
+bash-completion = "completions/bash/{ bin }"
+fish-completion = "completions/fish/{ bin }.fish"
+zsh-completion = "completions/zsh/_{ bin }"
 pkg-fmt = "tgz"
 disabled-strategies = ["quick-install", "compile"]
 ```
@@ -20,6 +24,10 @@ With the following configuration keys:
 
 - `pkg-url` specifies the package download URL for a given target/version, templated
 - `bin-dir` specifies the binary path within the package, templated (with an `.exe` suffix on windows)
+- `man` specifies the man page source path within the package archive, templated
+- `bash-completion` specifies the bash completion source path within the package archive, templated
+- `fish-completion` specifies the fish completion source path within the package archive, templated
+- `zsh-completion` specifies the zsh completion source path within the package archive, templated
 - `pkg-fmt` overrides the package format for download/extraction (defaults to: `tgz`), check [the documentation](https://docs.rs/binstalk-types/latest/binstalk_types/cargo_toml_binstall/enum.PkgFmt.html) for all supported formats.
 - `disabled-strategies` to disable specific strategies (e.g. `crate-meta-data` for trying to find pre-built on your repository,
   `quick-install` for pre-built from third-party cargo-bins/cargo-quickinstall, `compile` for falling back to `cargo-install`)
@@ -27,8 +35,8 @@ With the following configuration keys:
   If `--strategies` is passed on the command line, then the `disabled-strategies` in `package.metadata` will be ignored.
   Otherwise, the `disabled-strategies` in `package.metadata` and `--disable-strategies` will be merged.
 
-
-`pkg-url` and `bin-dir` are templated to support different names for different versions / architectures / etc.
+`pkg-url`, `bin-dir`, and the extra-file source paths are templated to support different names for
+different versions / architectures / etc.
 Template variables use the format `{ VAR }` where `VAR` is the name of the variable,
 `\{` for literal `{`, `\}` for literal `}` and `\\` for literal `\`,
 with the following variables available:
@@ -52,7 +60,9 @@ with the following variables available:
 [`target_lexicon::Environment`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Environment.html
 [`target_lexicon::Vendor`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Vendor.html
 
-`pkg-url`, `pkg-fmt` and `bin-dir` can be overridden on a per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip` archives this could be set via:
+`pkg-url`, `pkg-fmt`, `bin-dir`, and the extra-file source paths can be overridden on a
+per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip`
+archives this could be set via:
 
 ```toml
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
@@ -121,6 +131,42 @@ that exists:
  - `{ name }`
 
 Then it will concat the dir with `"{ bin }{ binary-ext }"` and use that as the final `bin-dir`.
+
+When the package archive contains extra files, `binstall` also checks these default source paths
+for each installed binary:
+
+- `man/man1/{ bin }.1`
+- `completions/bash/{ bin }`
+- `completions/fish/{ bin }.fish`
+- `completions/zsh/_{ bin }`
+
+If present, they are installed automatically to:
+
+- `$CARGO_HOME/share/man/man1/{bin}.1`
+- `$CARGO_HOME/share/bash-completion/completions/{bin}`
+- `$CARGO_HOME/share/fish/vendor_completions.d/{bin}.fish`
+- `$CARGO_HOME/share/zsh/site-functions/_{bin}`
+
+Missing default extra files are ignored. If you set `man`, `bash-completion`, `fish-completion`,
+or `zsh-completion` explicitly, the referenced file must exist in the archive.
+
+The destination side of this feature is intentionally opinionated: metadata
+describes where extra files live in the published archive, while `binstall`
+chooses where to install them locally. In v1, that means extra files always
+target Cargo's `share/` tree rather than following a custom binary
+`--install-path`. This keeps packaged layout separate from host install policy
+and gives upgrades a stable root for cleanup.
+
+Extra-file templates are evaluated per installed binary using that binary's
+`{ bin }` value. For multi-bin crates, use templates that vary with `{ bin }`
+when each binary has its own man page or completion file. If several selected
+binaries resolve to the same installed extra-file destination, `binstall`
+reports that as an error rather than letting one overwrite another.
+
+Extra-file installation currently applies only when `binstall` installs from a
+fetched binary artifact. If resolution falls back to `cargo install`, binstall
+does not try to discover or install man pages or shell completions from the
+source build.
 
 `name` here is name of the crate, `bin` is the cargo binary name and `binary-ext` is `.exe`
 on windows and empty on other platforms).
@@ -229,3 +275,32 @@ bin-dir = "{ bin }-{ target }{ binary-ext }"
 ```
 
 Which provides a binary path of: `sx128x-util-x86_64-unknown-linux-gnu[.exe]`. It is worth noting that binary names are inferred from the crate, so as long as cargo builds them this _should_ just work.
+
+#### If the package includes man pages or shell completions
+
+The default extra-file conventions already match a layout like this:
+
+```text
+my-tool-v1.2.3-x86_64-unknown-linux-gnu/
+  my-tool
+  man/
+    man1/
+      my-tool.1
+  completions/
+    bash/
+      my-tool
+    fish/
+      my-tool.fish
+    zsh/
+      _my-tool
+```
+
+If your archive uses different paths, override them explicitly:
+
+```toml
+[package.metadata.binstall]
+man = "docs/man/{ bin }.1"
+bash-completion = "assets/completions/bash/{ bin }"
+fish-completion = "assets/completions/fish/{ bin }.fish"
+zsh-completion = "assets/completions/zsh/_{ bin }"
+```

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -715,6 +715,7 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
         pkg_url: opts.pkg_url.take(),
         pkg_fmt: opts.pkg_fmt.take(),
         bin_dir: opts.bin_dir.take(),
+        extra_files: Default::default(),
         disabled_strategies: Some(
             mem::take(&mut opts.disable_strategies)
                 .into_iter()

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -592,6 +592,7 @@ pub fn self_install(args: Args) -> Result<()> {
             source: CrateSource::cratesio_registry(),
             target: CompactString::const_new(TARGET),
             bins: vec![CompactString::const_new("cargo-binstall")],
+            extra_files: Vec::new(),
         }])?;
     }
 

--- a/crates/binstalk-bins/Cargo.toml
+++ b/crates/binstalk-bins/Cargo.toml
@@ -19,3 +19,6 @@ miette = "7.0.0"
 normalize-path = { version = "0.2.1", path = "../normalize-path" }
 thiserror = "2.0.11"
 tracing = "0.1.43"
+
+[dev-dependencies]
+tempfile = "3.5.0"

--- a/crates/binstalk-bins/src/lib.rs
+++ b/crates/binstalk-bins/src/lib.rs
@@ -32,6 +32,10 @@ pub enum Error {
     #[error("bin file {} not found", .0.display())]
     BinFileNotFound(Box<Path>),
 
+    /// Source file is not found.
+    #[error("source file {} not found", .0.display())]
+    SourceFileNotFound(Box<Path>),
+
     #[error(transparent)]
     Io(#[from] io::Error),
 
@@ -134,19 +138,9 @@ impl BinFile {
         } else {
             // Generate install paths
             // Source path is the download dir + the generated binary path
-            let path = tt.render(&ctx)?;
+            let path = render_relative_path(tt, &ctx)?;
 
-            let path_normalized = Path::new(&path).normalize();
-
-            if path_normalized.components().next().is_none() {
-                return Err(Error::EmptySourceFilePath);
-            }
-
-            if !is_valid_path(&path_normalized) {
-                return Err(Error::InvalidSourceFilePath(path_normalized.into()));
-            }
-
-            (data.bin_path.join(&path_normalized), path_normalized)
+            (data.bin_path.join(&path), path)
         };
 
         // Destination at install dir + base-name{.extension}
@@ -296,6 +290,168 @@ impl BinFile {
     }
 }
 
+/// The fixed set of extra file kinds supported by binstall v1.
+///
+/// This enum may look heavier than a few ad-hoc string constants, but it keeps
+/// the feature's policy decisions in one place:
+///
+/// - the default archive lookup convention for each kind
+/// - the install destination under Cargo root
+/// - the human-readable label used during preview / dry-run output
+///
+/// Centralizing that mapping makes it harder for preview, install, and docs to
+/// drift from each other as the feature evolves.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ExtraFileKind {
+    Man,
+    BashCompletion,
+    FishCompletion,
+    ZshCompletion,
+}
+
+impl ExtraFileKind {
+    /// Human-readable label used in dry-run / preview output.
+    pub fn label(self) -> &'static str {
+        match self {
+            ExtraFileKind::Man => "man page",
+            ExtraFileKind::BashCompletion => "bash completion",
+            ExtraFileKind::FishCompletion => "fish completion",
+            ExtraFileKind::ZshCompletion => "zsh completion",
+        }
+    }
+
+    /// Conventional archive location to probe when metadata does not specify
+    /// an explicit path for this file kind.
+    ///
+    /// These defaults are intentionally best-effort. Resolver code treats
+    /// missing convention-based files as "not packaged" and only raises an
+    /// error for explicit metadata entries.
+    pub fn default_source_template(self) -> &'static str {
+        match self {
+            ExtraFileKind::Man => "man/man1/{ bin }.1",
+            ExtraFileKind::BashCompletion => "completions/bash/{ bin }",
+            ExtraFileKind::FishCompletion => "completions/fish/{ bin }.fish",
+            ExtraFileKind::ZshCompletion => "completions/zsh/_{ bin }",
+        }
+    }
+
+    /// Relative install location under Cargo root.
+    ///
+    /// Extras are installed under Cargo root rather than `--install-path`
+    /// because they are not peer executables. They belong to Cargo-managed
+    /// shared data directories (`share/man`, completion roots, etc.), and
+    /// keeping them there matches the behavior documented for this feature and
+    /// gives manifest tracking a single stable root to manage.
+    ///
+    /// A different design could have made these destinations relative to the
+    /// binary install path, but that would make custom `--install-path`
+    /// invocations produce less conventional layouts and would complicate
+    /// stale-file cleanup.
+    pub fn dest_relative_path(self, bin: &str) -> PathBuf {
+        match self {
+            ExtraFileKind::Man => PathBuf::from(format!("share/man/man1/{bin}.1")),
+            ExtraFileKind::BashCompletion => {
+                PathBuf::from(format!("share/bash-completion/completions/{bin}"))
+            }
+            ExtraFileKind::FishCompletion => {
+                PathBuf::from(format!("share/fish/vendor_completions.d/{bin}.fish"))
+            }
+            ExtraFileKind::ZshCompletion => {
+                PathBuf::from(format!("share/zsh/site-functions/_{bin}"))
+            }
+        }
+    }
+}
+
+/// A resolved extra file ready for previewing, installation, and manifest
+/// tracking.
+///
+/// This is intentionally parallel to `BinFile`: resolution computes the
+/// archive-relative source path and final destination once, and later phases
+/// reuse that exact result. That avoids re-rendering templates during install
+/// and ensures dry-run output matches what will actually be written to disk.
+pub struct ExtraFile {
+    pub kind: ExtraFileKind,
+    pub source: PathBuf,
+    pub archive_source_path: PathBuf,
+    pub dest: PathBuf,
+    pub relative_dest: PathBuf,
+}
+
+impl ExtraFile {
+    /// Build an installable extra file from archive metadata.
+    ///
+    /// `cargo_root` is passed explicitly rather than inferred from
+    /// `Data::install_path` because callers may override the binary install
+    /// directory while extra files still need to land in Cargo's shared-data
+    /// hierarchy.
+    pub fn new(
+        data: &Data<'_>,
+        base_name: &str,
+        tt: &Template<'_>,
+        cargo_root: &Path,
+        kind: ExtraFileKind,
+    ) -> Result<Self, Error> {
+        let binary_ext = if data.target.contains("windows") {
+            ".exe"
+        } else {
+            ""
+        };
+
+        let ctx = Context {
+            name: data.name,
+            repo: data.repo,
+            target: data.target,
+            version: data.version,
+            bin: base_name,
+            binary_ext,
+            target_related_info: data.target_related_info,
+        };
+
+        let archive_source_path = render_relative_path(tt, &ctx)?;
+        let relative_dest = kind.dest_relative_path(base_name);
+        let dest = cargo_root.join(&relative_dest);
+
+        Ok(Self {
+            kind,
+            source: data.bin_path.join(&archive_source_path),
+            archive_source_path,
+            dest,
+            relative_dest,
+        })
+    }
+
+    pub fn preview(&self) -> impl fmt::Display + '_ {
+        struct PreviewExtraFile<'a> {
+            label: &'a str,
+            dest: path::Display<'a>,
+        }
+
+        impl fmt::Display for PreviewExtraFile<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{} => {}", self.label, self.dest)
+            }
+        }
+
+        PreviewExtraFile {
+            label: self.kind.label(),
+            dest: self.dest.display(),
+        }
+    }
+
+    pub fn check_source_exists(
+        &self,
+        has_file: &mut dyn FnMut(&Path) -> bool,
+    ) -> Result<(), Error> {
+        if has_file(&self.archive_source_path) {
+            Ok(())
+        } else {
+            Err(Error::SourceFileNotFound((&*self.source).into()))
+        }
+    }
+
+}
+
 /// Data required to get bin paths
 pub struct Data<'a> {
     pub name: &'a str,
@@ -304,6 +460,12 @@ pub struct Data<'a> {
     pub repo: Option<&'a str>,
     pub meta: PkgMeta,
     pub bin_path: &'a Path,
+    /// Destination root for the main artifact flow.
+    ///
+    /// For binaries this is the executable install path. Extra-file resolution
+    /// currently reuses the same render context type for access to shared
+    /// template variables, even though `ExtraFile::new` takes the final Cargo
+    /// root destination explicitly.
     pub install_path: &'a Path,
     /// More target related info, it's recommend to provide the following keys:
     ///  - target_family,
@@ -342,6 +504,28 @@ impl leon::Values for Context<'_> {
             key => self.target_related_info.get_value(key),
         }
     }
+}
+
+/// Render a template into a normalized archive-relative path.
+///
+/// Both binaries and extra files use the same path safety rules:
+/// templates may describe files within the extracted package tree, but they
+/// must never escape that tree. Centralizing the validation keeps the binary
+/// and extra-file code paths consistent and makes missing-file behavior easier
+/// to reason about in the resolver.
+fn render_relative_path(tt: &Template<'_>, ctx: &Context<'_>) -> Result<PathBuf, Error> {
+    let path = tt.render(ctx)?;
+    let path_normalized = Path::new(&path).normalize();
+
+    if path_normalized.components().next().is_none() {
+        return Err(Error::EmptySourceFilePath);
+    }
+
+    if !is_valid_path(&path_normalized) {
+        return Err(Error::InvalidSourceFilePath(path_normalized.into()));
+    }
+
+    Ok(path_normalized)
 }
 
 struct LazyFormat<'a> {

--- a/crates/binstalk-bins/src/lib.rs
+++ b/crates/binstalk-bins/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    fmt, io,
+    fmt, fs, io,
     path::{self, Component, Path, PathBuf},
 };
 
@@ -450,6 +450,27 @@ impl ExtraFile {
         }
     }
 
+    pub fn install(&self) -> Result<(), Error> {
+        if !self.source.try_exists()? {
+            return Err(Error::SourceFileNotFound((&*self.source).into()));
+        }
+
+        // Extra files may live in nested `share/...` directories that do not
+        // exist yet even when the Cargo root itself does.
+        if let Some(parent) = self.dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        debug!(
+            "Atomically install file from '{}' to '{}'",
+            self.source.display(),
+            self.dest.display()
+        );
+
+        atomic_install(&self.source, &self.dest)?;
+
+        Ok(())
+    }
 }
 
 /// Data required to get bin paths
@@ -549,5 +570,90 @@ impl fmt::Display for OptionalLazyFormat<'_> {
         } else {
             Ok(())
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, fs, path::Path};
+
+    use leon::Template;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    struct EmptyValues;
+
+    impl leon::Values for EmptyValues {
+        fn get_value<'s>(&'s self, _: &str) -> Option<Cow<'s, str>> {
+            None
+        }
+    }
+
+    fn test_data<'a>(bin_path: &'a Path, install_path: &'a Path) -> Data<'a> {
+        Data {
+            name: "cargo-watch",
+            target: "x86_64-unknown-linux-gnu",
+            version: "8.4.0",
+            repo: Some("https://github.com/watchexec/cargo-watch"),
+            meta: PkgMeta::default(),
+            bin_path,
+            install_path,
+            target_related_info: &EmptyValues,
+        }
+    }
+
+    #[test]
+    fn extra_file_uses_expected_destinations() {
+        let archive_dir = tempdir().unwrap();
+        let cargo_root = tempdir().unwrap();
+        let data = test_data(archive_dir.path(), cargo_root.path());
+        let template = Template::parse("completions/zsh/_{ bin }").unwrap();
+
+        let extra_file = ExtraFile::new(
+            &data,
+            "cargo-watch",
+            &template,
+            cargo_root.path(),
+            ExtraFileKind::ZshCompletion,
+        )
+        .unwrap();
+
+        assert_eq!(
+            extra_file.relative_dest,
+            PathBuf::from("share/zsh/site-functions/_cargo-watch")
+        );
+        assert_eq!(
+            extra_file.dest,
+            cargo_root
+                .path()
+                .join("share/zsh/site-functions/_cargo-watch")
+        );
+    }
+
+    #[test]
+    fn extra_file_install_copies_to_share_path() {
+        let archive_dir = tempdir().unwrap();
+        let cargo_root = tempdir().unwrap();
+        let source_dir = archive_dir.path().join("man").join("man1");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(source_dir.join("cargo-watch.1"), "cargo-watch manual").unwrap();
+
+        let data = test_data(archive_dir.path(), cargo_root.path());
+        let template = Template::parse("man/man1/{ bin }.1").unwrap();
+        let extra_file = ExtraFile::new(
+            &data,
+            "cargo-watch",
+            &template,
+            cargo_root.path(),
+            ExtraFileKind::Man,
+        )
+        .unwrap();
+
+        extra_file.install().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(cargo_root.path().join("share/man/man1/cargo-watch.1")).unwrap(),
+            "cargo-watch manual"
+        );
     }
 }

--- a/crates/binstalk-manifests/src/binstall_crates_v1.rs
+++ b/crates/binstalk-manifests/src/binstall_crates_v1.rs
@@ -276,6 +276,7 @@ mod test {
                 source: CrateSource::cratesio_registry(),
                 target: target.clone(),
                 bins: vec!["1".into(), "2".into()],
+                extra_files: vec![],
             },
             CrateInfo {
                 name: "b".into(),
@@ -284,6 +285,7 @@ mod test {
                 source: CrateSource::cratesio_registry(),
                 target: target.clone(),
                 bins: vec!["1".into(), "2".into()],
+                extra_files: vec![],
             },
             CrateInfo {
                 name: "a".into(),
@@ -292,6 +294,7 @@ mod test {
                 source: CrateSource::cratesio_registry(),
                 target: target.clone(),
                 bins: vec!["1".into()],
+                extra_files: vec![],
             },
         ];
 
@@ -322,6 +325,7 @@ mod test {
             source: CrateSource::cratesio_registry(),
             target,
             bins: vec!["1".into(), "2".into()],
+            extra_files: vec![],
         };
         append_to_path(path, [new_metadata.clone()]).unwrap();
         metadata_set.insert(new_metadata);

--- a/crates/binstalk-manifests/src/cargo_crates_v1.rs
+++ b/crates/binstalk-manifests/src/cargo_crates_v1.rs
@@ -237,6 +237,7 @@ mod tests {
                 source: CrateSource::cratesio_registry(),
                 target: TARGET.into(),
                 bins: vec!["cargo-binstall".into()],
+                extra_files: vec![],
             }],
         )
         .unwrap();
@@ -263,6 +264,7 @@ mod tests {
                 source: CrateSource::cratesio_registry(),
                 target: TARGET.into(),
                 bins: vec!["cargo-binstall".into()],
+                extra_files: vec![],
             }],
         )
         .unwrap();

--- a/crates/binstalk-manifests/src/crates_manifests.rs
+++ b/crates/binstalk-manifests/src/crates_manifests.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     fs,
     io::{self, Seek},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use fs_lock::FileLock;
@@ -34,6 +34,12 @@ pub enum ManifestsError {
 
 pub struct Manifests {
     binstall: BinstallCratesV1Records,
+    /// Current Cargo root used to resolve tracked extra-file paths.
+    ///
+    /// The persisted manifest stores extra files relative to Cargo root so
+    /// updates can clean up stale files without baking absolute machine-local
+    /// paths into the record.
+    cargo_root: PathBuf,
     cargo_crates_v1: FileLock,
     installed_crates: BTreeMap<CompactString, Version>,
 }
@@ -60,6 +66,7 @@ impl Manifests {
 
         Ok(Self {
             binstall,
+            cargo_root: cargo_roots.to_path_buf(),
             cargo_crates_v1,
             installed_crates,
         })
@@ -82,11 +89,107 @@ impl Manifests {
 
         CratesToml::append_to_file(&mut self.cargo_crates_v1, &metadata_vec)?;
 
+        // Tracking extra files is the most stateful part of this feature, but
+        // it is what makes upgrades behave like users expect: if a release
+        // stops shipping a completion or moves a man page, the old file should
+        // not be left behind indefinitely. We therefore update `.crates.toml`,
+        // remove stale tracked extras for the crate, then replace the binstall
+        // record with the new relative paths.
         for metadata in metadata_vec {
+            // Remove files that this crate used to own before replacing the
+            // record. This keeps upgrades idempotent when a maintainer changes
+            // completion/manpage paths or stops shipping one of them.
+            self.remove_stale_extra_files(&metadata)?;
             self.binstall.replace(metadata);
         }
         self.binstall.overwrite()?;
 
         Ok(())
+    }
+
+    fn remove_stale_extra_files(&self, metadata: &CrateInfo) -> Result<(), ManifestsError> {
+        let Some(previous) = self.binstall.get(&metadata.name) else {
+            return Ok(());
+        };
+
+        // Cleanup is intentionally conservative: only paths previously tracked
+        // for the same crate and no longer present in the new record are
+        // removed. Missing files are ignored so manual deletion does not block
+        // upgrades.
+        for extra_file in previous
+            .extra_files
+            .iter()
+            .filter(|path| !metadata.extra_files.contains(path))
+        {
+            let path = self.cargo_root.join(extra_file);
+            match fs::remove_file(&path) {
+                Ok(()) => (),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+                Err(err) => return Err(ManifestsError::Io(err)),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        binstall_crates_v1::append_to_path as append_binstall_records, cargo_crates_v1::CratesToml,
+        crate_info::CrateSource,
+    };
+    use detect_targets::TARGET;
+    use semver::Version;
+    use tempfile::tempdir;
+
+    #[test]
+    fn update_removes_stale_extra_files() {
+        let cargo_root = tempdir().unwrap();
+        let old_extra = PathBuf::from("share/man/man1/cargo-watch.1");
+        let new_extra = PathBuf::from("share/man/man1/cargo-watch-new.1");
+
+        fs::create_dir_all(cargo_root.path().join("share/man/man1")).unwrap();
+        fs::write(cargo_root.path().join(&old_extra), "old").unwrap();
+        fs::write(cargo_root.path().join(&new_extra), "new").unwrap();
+
+        let old_record = CrateInfo {
+            name: "cargo-watch".into(),
+            version_req: "*".into(),
+            current_version: Version::new(8, 4, 0),
+            source: CrateSource::cratesio_registry(),
+            target: TARGET.into(),
+            bins: vec!["cargo-watch".into()],
+            extra_files: vec![old_extra.clone()],
+        };
+
+        CratesToml::append_to_path(
+            cargo_root.path().join(".crates.toml"),
+            &[old_record.clone()],
+        )
+        .unwrap();
+        fs::create_dir_all(cargo_root.path().join("binstall")).unwrap();
+        append_binstall_records(
+            cargo_root.path().join("binstall/crates-v1.json"),
+            [old_record],
+        )
+        .unwrap();
+
+        let manifests = Manifests::open_exclusive(cargo_root.path()).unwrap();
+        manifests
+            .update(vec![CrateInfo {
+                name: "cargo-watch".into(),
+                version_req: "*".into(),
+                current_version: Version::new(8, 5, 0),
+                source: CrateSource::cratesio_registry(),
+                target: TARGET.into(),
+                bins: vec!["cargo-watch".into()],
+                extra_files: vec![new_extra.clone()],
+            }])
+            .unwrap();
+
+        assert!(!cargo_root.path().join(old_extra).exists());
+        assert!(cargo_root.path().join(new_extra).exists());
     }
 }

--- a/crates/binstalk-types/src/cargo_toml_binstall.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall.rs
@@ -1,6 +1,17 @@
 //! The format of the `[package.metadata.binstall]` manifest.
 //!
-//! This manifest defines how a particular binary crate may be installed by Binstall.
+//! This manifest defines how a particular binary crate may be installed by
+//! Binstall.
+//!
+//! A useful way to read this schema is:
+//!
+//! - metadata describes where files live in the published artifact
+//! - binstall decides where those files should be installed locally
+//!
+//! That split is especially important for extra files such as man pages and
+//! shell completions. The manifest can say "the zsh completion is at
+//! `completions/zsh/_{ bin }` in the archive", but it does not attempt to
+//! encode arbitrary host destination policy.
 
 use std::borrow::Cow;
 
@@ -76,6 +87,15 @@ pub struct PkgMeta {
     /// Path template for binary files in packages
     pub bin_dir: Option<String>,
 
+    /// Source paths for extra installed files.
+    ///
+    /// These are archive-relative templates, not destination paths.
+    /// Binstall intentionally fixes the install destinations under Cargo's
+    /// `share/` tree so crates can describe where files live in the archive
+    /// without also needing to encode host-specific filesystem policy.
+    #[serde(flatten)]
+    pub extra_files: PkgExtraFiles,
+
     /// Package signing configuration
     pub signing: Option<PkgSigning>,
 
@@ -98,15 +118,26 @@ impl PkgMeta {
         if let Some(o) = &pkg_override.bin_dir {
             self.bin_dir = Some(o.clone());
         }
+        self.extra_files.merge(&pkg_override.extra_files);
     }
 
-    /// Merge configuration overrides into object
+    /// Merge configuration overrides into object.
+    ///
+    /// The iterator order matters: the first matching non-`None` value wins.
+    /// Callers are expected to pass exact-target matches before `cfg(...)`
+    /// matches so this preserves the precedence documented in `SUPPORT.md`.
     ///
     ///  * `pkg_overrides` - ordered in preference
     pub fn merge_overrides<'a, It>(&self, pkg_overrides: It) -> Self
     where
         It: IntoIterator<Item = &'a PkgOverride> + Clone,
     {
+        let extra_file_overrides = pkg_overrides
+            .clone()
+            .into_iter()
+            .map(|pkg_override| &pkg_override.extra_files)
+            .collect::<Vec<_>>();
+
         let ignore_disabled_strategies = pkg_overrides
             .clone()
             .into_iter()
@@ -130,6 +161,8 @@ impl PkgMeta {
                 .into_iter()
                 .find_map(|pkg_override| pkg_override.bin_dir.clone())
                 .or_else(|| self.bin_dir.clone()),
+
+            extra_files: self.extra_files.merge_overrides(extra_file_overrides),
 
             signing: pkg_overrides
                 .clone()
@@ -174,6 +207,14 @@ pub struct PkgOverride {
     /// Path template override for binary files in packages
     pub bin_dir: Option<String>,
 
+    /// Source path overrides for extra installed files.
+    ///
+    /// These follow the same precedence rules as `pkg-url` / `bin-dir` and
+    /// are kept grouped so target overrides can replace one extra-file type
+    /// without restating the others.
+    #[serde(flatten)]
+    pub extra_files: PkgExtraFiles,
+
     /// Strategies to disable
     pub disabled_strategies: Option<Box<[Strategy]>>,
 
@@ -182,6 +223,94 @@ pub struct PkgOverride {
 
     #[serde(skip)]
     pub ignore_disabled_strategies: bool,
+}
+
+/// Source path templates for extra installed files.
+///
+/// Each field points at the file location inside the fetched archive.
+/// Destination paths are derived from the file kind and binary name so that:
+///
+/// - crates describe packaging layout, not host install policy
+/// - installs remain consistent across repositories
+/// - tracked cleanup can key off a stable relative destination
+///
+/// These fields are intentionally about source discovery only. Reviewers may
+/// reasonably ask why there is no companion "destination override" here; the
+/// answer is that binstall currently treats install locations as part of its
+/// own policy so packages cannot redirect files outside the conventional Cargo
+/// layout.
+///
+/// For crates with multiple binaries, these templates are rendered once per
+/// selected binary using that binary's `{ bin }` value. That means a constant
+/// template such as `man = "docs/tool.1"` is treated as "every installed
+/// binary uses the same source file" and may therefore collide at destination
+/// time if more than one binary resolves to the same installed path.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct PkgExtraFiles {
+    /// Man page source path template within package archive
+    pub man: Option<String>,
+
+    /// Bash completion source path template within package archive
+    pub bash_completion: Option<String>,
+
+    /// Fish completion source path template within package archive
+    pub fish_completion: Option<String>,
+
+    /// Zsh completion source path template within package archive
+    pub zsh_completion: Option<String>,
+}
+
+impl PkgExtraFiles {
+    /// Merge a single override into this set.
+    ///
+    /// We merge field-by-field so a target override can replace only the zsh
+    /// completion path, for example, while inheriting the default man page
+    /// and other completion locations from the base metadata.
+    pub fn merge(&mut self, other: &Self) {
+        if let Some(man) = &other.man {
+            self.man = Some(man.clone());
+        }
+        if let Some(bash_completion) = &other.bash_completion {
+            self.bash_completion = Some(bash_completion.clone());
+        }
+        if let Some(fish_completion) = &other.fish_completion {
+            self.fish_completion = Some(fish_completion.clone());
+        }
+        if let Some(zsh_completion) = &other.zsh_completion {
+            self.zsh_completion = Some(zsh_completion.clone());
+        }
+    }
+
+    pub fn merge_overrides<'a, It>(&self, overrides: It) -> Self
+    where
+        It: IntoIterator<Item = &'a PkgExtraFiles> + Clone,
+    {
+        // Clone is required because precedence is independent per field:
+        // the first override that sets `man` may differ from the first that
+        // sets `bash-completion`.
+        Self {
+            man: overrides
+                .clone()
+                .into_iter()
+                .find_map(|extra_files| extra_files.man.clone())
+                .or_else(|| self.man.clone()),
+            bash_completion: overrides
+                .clone()
+                .into_iter()
+                .find_map(|extra_files| extra_files.bash_completion.clone())
+                .or_else(|| self.bash_completion.clone()),
+            fish_completion: overrides
+                .clone()
+                .into_iter()
+                .find_map(|extra_files| extra_files.fish_completion.clone())
+                .or_else(|| self.fish_completion.clone()),
+            zsh_completion: overrides
+                .into_iter()
+                .find_map(|extra_files| extra_files.zsh_completion.clone())
+                .or_else(|| self.zsh_completion.clone()),
+        }
+    }
 }
 
 /// An ordered map of target-specific overrides.
@@ -377,5 +506,45 @@ mod tests {
             .collect();
 
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_extra_files_parse_and_merge() {
+        let meta: PkgMeta = serde_json::from_value(json!({
+            "man": "docs/man/{ bin }.1",
+            "bash-completion": "completions/bash/{ bin }",
+            "overrides": {
+                "x86_64-unknown-linux-gnu": {
+                    "fish-completion": "completions/fish/{ bin }.fish"
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(meta.extra_files.man.as_deref(), Some("docs/man/{ bin }.1"));
+        assert_eq!(
+            meta.extra_files.bash_completion.as_deref(),
+            Some("completions/bash/{ bin }")
+        );
+
+        let cfgs = vec![
+            Cfg::from_str(r#"target_os="linux""#).unwrap(),
+            Cfg::from_str(r#"target_arch="x86_64""#).unwrap(),
+            Cfg::from_str("unix").unwrap(),
+        ];
+
+        let merged = meta.merge_overrides(
+            meta.overrides
+                .get_matching("x86_64-unknown-linux-gnu", &cfgs),
+        );
+
+        assert_eq!(
+            merged.extra_files.fish_completion.as_deref(),
+            Some("completions/fish/{ bin }.fish")
+        );
+        assert_eq!(
+            merged.extra_files.man.as_deref(),
+            Some("docs/man/{ bin }.1")
+        );
     }
 }

--- a/crates/binstalk-types/src/crate_info.rs
+++ b/crates/binstalk-types/src/crate_info.rs
@@ -1,6 +1,6 @@
 //! Common structure for crate information for post-install manifests.
 
-use std::{borrow, cmp, hash};
+use std::{borrow, cmp, hash, path::PathBuf};
 
 use compact_str::CompactString;
 use maybe_owned::MaybeOwned;
@@ -24,6 +24,13 @@ pub struct CrateInfo {
     pub source: CrateSource,
     pub target: CompactString,
     pub bins: Vec<CompactString>,
+    /// Relative paths rooted at Cargo root for extra installed files.
+    ///
+    /// These are persisted as relative paths rather than absolute paths so
+    /// records remain portable if the Cargo root moves and so stale cleanup
+    /// can reconstruct the current on-disk location at update time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_files: Vec<PathBuf>,
 }
 
 impl borrow::Borrow<str> for CrateInfo {

--- a/crates/binstalk/src/errors.rs
+++ b/crates/binstalk/src/errors.rs
@@ -375,6 +375,18 @@ pub enum BinstallError {
     #[diagnostic(severity(error), code(binstall::SourceFilePath))]
     DuplicateSourceFilePath { path: PathBuf },
 
+    /// Extra-file configuration resolves to duplicate install destinations.
+    ///
+    /// This commonly indicates a multi-bin crate whose extra-file templates do
+    /// not vary by `{ bin }`, causing several selected binaries to install to
+    /// the same manpage or completion path.
+    ///
+    /// - Code: `binstall::extra_files::duplicate_destination`
+    /// - Exit: 91
+    #[error("extra-file configuration resolves to duplicate install destination: {path}")]
+    #[diagnostic(severity(error), code(binstall::extra_files::duplicate_destination))]
+    DuplicateExtraFileDestination { path: PathBuf },
+
     /// Fallback to `cargo-install` is disabled.
     ///
     /// - Code: `binstall::no_fallback_to_cargo_install`
@@ -472,6 +484,7 @@ impl BinstallError {
             BinFile(_) => 88,
             CargoTomlMissingPackage(_) => 89,
             DuplicateSourceFilePath { .. } => 90,
+            DuplicateExtraFileDestination { .. } => 91,
             NoFallbackToCargoInstall => 94,
             InvalidPkgFmt(..) => 95,
             GhApiErr(..) => 96,

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -1,4 +1,26 @@
 //! Concrete Binstall operations.
+//!
+//! The install flow distinguishes between two destination roots:
+//!
+//! - `install_path` for executable artifacts that should appear on `PATH`
+//! - `cargo_root` for Cargo-managed shared data such as man pages and shell
+//!   completions
+//!
+//! This split is intentional. Callers may override where binaries are placed,
+//! but extra files still need a stable, conventional home under Cargo's
+//! `share/` tree so previewing, installation, and tracked cleanup all reason
+//! about the same location.
+//!
+//! In particular, package metadata is allowed to describe where extra files
+//! live inside an archive, but it does not choose arbitrary on-disk install
+//! destinations. That keeps crate metadata focused on packaging layout while
+//! binstall owns host policy such as "which root should man pages be installed
+//! under?".
+//!
+//! This is an opinionated v1 design. The alternative would be to make extras
+//! follow `install_path` or to allow package metadata to control destinations.
+//! That would make the resulting layout less conventional and harder to track,
+//! especially when binaries are installed into custom locations.
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
@@ -48,8 +70,21 @@ pub struct Options {
     pub bins: Option<Vec<CompactString>>,
 
     pub temp_dir: PathBuf,
+    /// Directory where executables are installed.
+    ///
+    /// This may differ from `cargo_root.join("bin")` when the user supplies a
+    /// custom install path.
+    ///
+    /// Only executable artifacts use this root. Extra files continue to target
+    /// `cargo_root` so they land in Cargo's shared-data layout rather than next
+    /// to the binary.
     pub install_path: PathBuf,
     pub has_overriden_install_path: bool,
+    /// Cargo-managed root used for manifests and shared install data.
+    ///
+    /// Extra files are rooted here even when binaries are installed elsewhere.
+    /// This gives a single stable base for man pages, shell completions, and
+    /// manifest-based stale-file cleanup.
     pub cargo_root: Option<PathBuf>,
     pub cargo_install_registry: Option<CompactString>,
     pub cargo_install_index: Option<CompactString>,

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -1,4 +1,31 @@
-use std::{borrow::Cow, collections::BTreeSet, iter, mem, path::Path, str::FromStr, sync::Arc};
+//! Resolution for binary and extra-file installs from fetched artifacts.
+//!
+//! This module turns manifest metadata plus archive contents into a concrete
+//! install plan. The key policy choice is that binaries and extra files use the
+//! same archive-resolution pass but different destination roots:
+//!
+//! - binaries target `Options::install_path`
+//! - extra files target `Options::cargo_root` and therefore Cargo's `share/`
+//!   tree
+//!
+//! Keeping that decision at resolution time means preview output, validation,
+//! installation, and manifest tracking all operate on the same resolved file
+//! set instead of recomputing paths later.
+//!
+//! This module only resolves extra files for fetched artifacts. Source builds
+//! performed through `cargo install` are intentionally out of scope here
+//! because they do not have a stable, already-packaged archive layout to
+//! inspect. That boundary keeps this logic focused on "consume packaged
+//! artifacts as published" rather than trying to infer post-build outputs.
+
+use std::{
+    borrow::Cow,
+    collections::BTreeSet,
+    iter, mem,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
 
 use binstalk_fetchers::FETCHER_GH_CRATE_META;
 use binstalk_types::{
@@ -189,12 +216,13 @@ async fn resolve_inner(
                         &bin_path,
                         &package_info,
                         &opts.install_path,
+                        opts.cargo_root.as_deref(),
                         opts.no_symlinks,
                         &opts.bins,
                     )
                     .await
                     {
-                        Ok(bin_files) => {
+                        Ok((bin_files, extra_files)) => {
                             if !bin_files.is_empty() {
                                 if !opts.disable_telemetry {
                                     fetcher.clone().report_to_upstream();
@@ -206,6 +234,7 @@ async fn resolve_inner(
                                     version_req: version_req_str,
                                     source: package_info.source,
                                     bin_files,
+                                    extra_files,
                                 })));
                             } else {
                                 warn!(
@@ -283,14 +312,20 @@ async fn resolve_inner(
 ///
 /// Can return empty Vec if all `BinFile` is optional and does not exist
 /// in the archive downloaded.
+///
+/// Extra files are resolved here as well because they depend on the same
+/// extracted archive inventory as binaries. Doing this before installation
+/// keeps preview output, required-file validation, and later manifest tracking
+/// all driven from the same resolved set.
 async fn download_extract_and_verify(
     fetcher: &dyn Fetcher,
     bin_path: &Path,
     package_info: &PackageInfo,
     install_path: &Path,
+    cargo_root: Option<&Path>,
     no_symlinks: bool,
     bins: &Option<Vec<CompactString>>,
-) -> Result<Vec<bins::BinFile>, BinstallError> {
+) -> Result<(Vec<bins::BinFile>, Vec<bins::ExtraFile>), BinstallError> {
     // Download and extract it.
     // If that fails, then ignore this fetcher.
     let extracted_files = fetcher.fetch_and_extract(bin_path).await?;
@@ -303,7 +338,7 @@ async fn download_extract_and_verify(
     let bin_files = collect_bin_files(
         fetcher,
         package_info,
-        meta,
+        meta.clone(),
         bin_path,
         install_path,
         no_symlinks,
@@ -311,50 +346,58 @@ async fn download_extract_and_verify(
     )?;
 
     let name = &package_info.name;
+    let mut selected_bin_files = Vec::new();
+    let mut extra_files = Vec::new();
+    // Extra files install into Cargo's shared data tree, not the executable
+    // directory. In practice `cargo_root` should be present for normal CLI
+    // flows; the fallback keeps library callers from panicking if they omit it.
+    let cargo_root = cargo_root.unwrap_or(install_path);
 
-    package_info
-        .binaries
-        .iter()
-        .zip(bin_files)
-        .filter_map(|(bin, bin_file)| {
-            // skip binaries that were not requested by user
-            if bins
-                .as_ref()
-                .is_some_and(|bins| !bins.iter().any(|b| b == bin.name))
-            {
-                return None;
+    for (bin, bin_file) in package_info.binaries.iter().zip(bin_files) {
+        if bins
+            .as_ref()
+            .is_some_and(|bins| !bins.iter().any(|b| b == bin.name))
+        {
+            continue;
+        }
+
+        match bin_file.check_source_exists(&mut |p| extracted_files.has_file(p)) {
+            Ok(()) => {
+                extra_files.extend(collect_extra_files(
+                    fetcher,
+                    package_info,
+                    &meta,
+                    bin.name.as_str(),
+                    bin_path,
+                    cargo_root,
+                    &extracted_files,
+                )?);
+                selected_bin_files.push(bin_file);
             }
 
-            match bin_file.check_source_exists(&mut |p| extracted_files.has_file(p)) {
-                Ok(()) => Some(Ok(bin_file)),
+            Err(err) => {
+                let required_features = &bin.required_features;
+                let bin_name = bin.name.as_str();
 
-                // This binary is optional
-                Err(err) => {
-                    let required_features = &bin.required_features;
-                    let bin_name = bin.name.as_str();
-
-                    if required_features.is_empty() {
-                        error!(
-                            "When resolving {name} bin {bin_name} is not found. \
+                if required_features.is_empty() {
+                    error!(
+                        "When resolving {name} bin {bin_name} is not found. \
 This binary is not optional so it must be included in the archive, please contact with \
 upstream to fix this issue."
-                        );
-                        // This bin is not optional, error
-                        Some(Err(err))
-                    } else {
-                        // Optional, print a warning and continue.
-                        let features = required_features.iter().format(",");
-                        warn!(
-                            "When resolving {name} bin {bin_name} is not found. \
+                    );
+                    return Err(BinstallError::from(err));
+                } else {
+                    let features = required_features.iter().format(",");
+                    warn!(
+                        "When resolving {name} bin {bin_name} is not found. \
 But since it requires features {features}, this bin is ignored."
-                        );
-                        None
-                    }
+                    );
                 }
             }
-        })
-        .collect::<Result<Vec<bins::BinFile>, bins::Error>>()
-        .map_err(BinstallError::from)
+        }
+    }
+
+    Ok((selected_bin_files, extra_files))
 }
 
 fn collect_bin_files(
@@ -408,6 +451,98 @@ fn collect_bin_files(
     }
 
     Ok(bin_files)
+}
+
+/// Resolve extra files for one selected binary from the extracted archive.
+///
+/// This returns fully resolved [`bins::ExtraFile`] values rather than raw
+/// paths so preview output, installation, and later manifest tracking all use
+/// the exact same resolved file set. Centralizing that resolution here avoids
+/// each later phase re-rendering templates and drifting on path policy.
+///
+/// Extra-file templates are evaluated per binary. That allows one crate-level
+/// template to expand differently via `{ bin }`, but it also means constant
+/// templates in multi-bin crates can collide on the same installed destination.
+/// Those collisions are rejected here during resolution.
+///
+/// The render context intentionally reuses the binary path template data so
+/// extra-file metadata can refer to the same `{ bin }`, `{ version }`,
+/// `{ target }`, and related variables as `bin-dir`.
+fn collect_extra_files(
+    fetcher: &dyn Fetcher,
+    package_info: &PackageInfo,
+    meta: &PkgMeta,
+    bin_name: &str,
+    bin_path: &Path,
+    cargo_root: &Path,
+    extracted_files: &ExtractedFiles,
+) -> Result<Vec<bins::ExtraFile>, BinstallError> {
+    // Reuse the same render context as binaries so archive templates can refer
+    // to `{ bin }`, `{ version }`, `{ target }`, etc. The `install_path` field
+    // on `Data` is unused for path rendering here, but passing Cargo root keeps
+    // the struct semantically aligned with the resulting `ExtraFile`.
+    let bin_data = bins::Data {
+        name: &package_info.name,
+        target: fetcher.target(),
+        version: &package_info.version_str,
+        repo: package_info.repo.as_deref(),
+        meta: meta.clone(),
+        bin_path,
+        install_path: cargo_root,
+        target_related_info: &fetcher.target_data().target_related_info,
+    };
+
+    let mut extra_files = Vec::new();
+    let mut destinations = BTreeSet::<PathBuf>::new();
+
+    for (kind, template, is_explicit) in [
+        (
+            bins::ExtraFileKind::Man,
+            meta.extra_files.man.as_deref(),
+            meta.extra_files.man.is_some(),
+        ),
+        (
+            bins::ExtraFileKind::BashCompletion,
+            meta.extra_files.bash_completion.as_deref(),
+            meta.extra_files.bash_completion.is_some(),
+        ),
+        (
+            bins::ExtraFileKind::FishCompletion,
+            meta.extra_files.fish_completion.as_deref(),
+            meta.extra_files.fish_completion.is_some(),
+        ),
+        (
+            bins::ExtraFileKind::ZshCompletion,
+            meta.extra_files.zsh_completion.as_deref(),
+            meta.extra_files.zsh_completion.is_some(),
+        ),
+    ] {
+        // Convention-based lookup is best-effort; explicit metadata is a hard
+        // contract with the packager and therefore becomes a resolution error
+        // when the file is absent.
+        let template = template.unwrap_or_else(|| kind.default_source_template());
+        let template = Template::parse(template)?;
+        let extra_file = bins::ExtraFile::new(&bin_data, bin_name, &template, cargo_root, kind)?;
+
+        match extra_file.check_source_exists(&mut |p| extracted_files.has_file(p)) {
+            Ok(()) => {
+                // Different kinds may legally point at different archive paths,
+                // but they must not overwrite the same installed destination.
+                // This also catches multi-bin crates that try to reuse one
+                // fixed destination for more than one selected binary.
+                if !destinations.insert(extra_file.dest.clone()) {
+                    return Err(BinstallError::DuplicateExtraFileDestination {
+                        path: extra_file.dest.clone(),
+                    });
+                }
+                extra_files.push(extra_file);
+            }
+            Err(_err) if !is_explicit => (),
+            Err(err) => return Err(BinstallError::from(err)),
+        }
+    }
+
+    Ok(extra_files)
 }
 
 struct PackageInfo {

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -105,6 +105,13 @@ impl ResolutionFetch {
             source: self.source,
             target: self.fetcher.target().to_compact_string(),
             bins: Self::resolve_bins(&opts.bins, self.bin_files),
+            // Persist relative Cargo-root paths so future upgrades can remove
+            // stale files even if the absolute Cargo root changed.
+            extra_files: self
+                .extra_files
+                .into_iter()
+                .map(|file| file.relative_dest)
+                .collect(),
         })
     }
 

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -81,6 +81,16 @@ impl ResolutionFetch {
             install_bin(file)?;
         }
 
+        if !self.extra_files.is_empty() {
+            // Install extras after the binaries themselves so a partially
+            // packaged archive does not leave man/completion files behind when
+            // the primary executable failed to install.
+            info!("Installing extra files...");
+            for file in &self.extra_files {
+                file.install()?;
+            }
+        }
+
         // Generate symlinks
         if !opts.no_symlinks {
             for file in &self.bin_files {

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -23,6 +23,12 @@ pub struct ResolutionFetch {
     pub name: CompactString,
     pub version_req: CompactString,
     pub bin_files: Vec<bins::BinFile>,
+    /// Extra files that were resolved against the fetched archive.
+    ///
+    /// Keeping these on the resolved unit, rather than recomputing them during
+    /// install, ensures dry-run output, installation, and manifest tracking all
+    /// refer to the exact same file set.
+    pub extra_files: Vec<bins::ExtraFile>,
     pub source: CrateSource,
 }
 
@@ -142,6 +148,13 @@ impl ResolutionFetch {
                 info!("  - {}", file.preview_link());
             }
         }
+
+        if !self.extra_files.is_empty() {
+            info!("This will also install the following extra files:");
+            for file in &self.extra_files {
+                info!("  - {}", file.preview());
+            }
+        }
     }
 }
 
@@ -166,6 +179,11 @@ impl ResolutionSource {
 
         let name = &self.name;
         let version = &self.version;
+
+        // Source installs intentionally do not participate in extra-file
+        // installation. That keeps the current feature scoped to published
+        // binary artifacts, where archive layout and bundled extras are known
+        // ahead of time.
 
         let cargo = env::var_os("CARGO")
             .map(Cow::Owned)


### PR DESCRIPTION
## Summary

This PR adds typed extra-file installation for fetched binary artifacts.

Fixes #1978.

Prepared with Codex.

It supports package metadata and default archive conventions for:
- man pages
- bash completions
- fish completions
- zsh completions

The implementation is split into five commits that line up with the feature flow:
1. add extra-file metadata
2. resolve extra files from archives
3. install extra files under Cargo root
4. persist tracked extra files
5. remove stale tracked extra files on upgrade

## Why

The issue asks for first-class support for installing extra files from fetched artifacts.
The main policy choices in this implementation are:
- metadata describes archive source paths, not arbitrary install destinations
- extra files install under Cargo root `share/...` rather than following a custom binary install path
- extra-file installation applies to fetched artifacts, not `cargo install` fallback
- convention-based lookup is best-effort, while explicit metadata is required

## Impact

Crates can now ship typed extra files in their binary archives and have `cargo-binstall`
install and track them consistently.

Upgrades also remove stale tracked extra files that are no longer part of the installed crate.

## Validation

- `cargo test -p binstalk-types --lib`
- `cargo test -p binstalk --lib`
- `cargo test -p binstalk-bins -p binstalk --lib`
- `cargo test -p binstalk-manifests --lib`
- `cargo check -p cargo-binstall`
