### PR TITLE
fix(action): use GITHUB_ACTION_PATH env var instead of context var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ runs:
         BINSTALL_VERSION: ${{ inputs.version }}
       run: |
         set -eu
-        bash "${{ github.action_path }}/install-from-binstall-release.sh"
+        bash "$GITHUB_ACTION_PATH/install-from-binstall-release.sh"
     - name: Install cargo-binstall
       if: runner.os == 'Windows'
       shell: powershell
       env:
         BINSTALL_VERSION: ${{ inputs.version }}
-      run: Set-ExecutionPolicy Unrestricted -Scope Process; iex "${{ github.action_path }}/install-from-binstall-release.ps1"
+      run: Set-ExecutionPolicy Unrestricted -Scope Process; iex "$Env:GITHUB_ACTION_PATH/install-from-binstall-release.ps1"


### PR DESCRIPTION
Fix "No such file or directory" when running in container

Known issue: actions/runner#2185
Fixes #2547