### PR TITLE
fix: fallback to hickory_resolver's default config if reading /etc/resolv.conf fails

### DIFF
--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -5,16 +5,21 @@ use std::io;
 
 use hickory_resolver::{
     config::{
-        LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts, CLOUDFLARE, GOOGLE, QUAD9,
+        LookupIpStrategy,
+        NameServerConfig,
+        ResolverConfig,
+        ResolverOpts,
+        ServerGroup,
+        CLOUDFLARE,
+        GOOGLE,
+        QUAD9,
     },
-    systemconf, TokioResolver as TokioAsyncResolver,
+    system_conf, TokioResolver as TokioAsyncResolver,
 };
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tracing::{debug, instrument, warn};
 
-#[cfg(windows)]
-use hickory_resolver::net::xfer::Protocol;
 #[cfg(windows)]
 use netdev::Interface;
 
@@ -46,19 +51,23 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
     system_conf::read_system_conf().unwrap_or_else(|err| {
         debug!(
             "hickory-dns: failed to load system DNS configuration; \
-            falling back to google: {:?}",
+            falling back to quad9, cloudflare and then googld: {:?}",
             err
         );
 
         let mut config = ResolverConfig::default();
-        for dns in [QUAD9, CLOUDFLARE, GOOGLE] {
-            dns.udp_and_tcp()
-                .chain(dns.tls())
-                .chain(dns.https())
-                .chain(dns.quic())
-                .chain(dns.h3())
-                .for_each(|name_server| config.add_name_server(name_server));
-        }
+
+        let dns_providers = [QUAD9, CLOUDFLARE, GOOGLE];
+        // quic first as it is secure while being the fastest
+        dns_providers.iter().flat_map(ServerGroup::quic)
+            // h3 is secure but slower than quic
+            .chain(dns_providers.iter().flat_map(ServerGroup::h3)
+            // likewise tls is faster tha https
+            .chain(dns_providers.iter().flat_map(ServerGroup::tls)
+            .chain(dns_providers.iter().flat_map(ServerGroup::https)
+            // fallback to udp and tcp
+            .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp)
+            .for_each(|name_server| config.add_name_server(name_server));
 
         (config, Default::default())
     })

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -44,11 +44,14 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
     system_conf::read_system_conf().unwrap_or_else(|err| {
         debug!(
             "hickory-dns: failed to load system DNS configuration; \
-            falling back to hickory_resolver defaults: {:?}",
+            falling back to google: {:?}",
             err
         );
 
-        Default::default()
+        (
+            ResolverConfig::udp_and_tcp(hickory_resolver::config::GOOGLE),
+            Default::default(),
+        )
     })
 }
 

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -5,15 +5,8 @@ use std::io;
 
 use hickory_resolver::{
     config::{
-        ConnectionConfig,
-        LookupIpStrategy,
-        NameServerConfig,
-        ResolverConfig,
-        ResolverOpts,
-        ServerGroup,
-        CLOUDFLARE,
-        GOOGLE,
-        QUAD9,
+        ConnectionConfig, LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts,
+        ServerGroup, CLOUDFLARE, GOOGLE, QUAD9,
     },
     system_conf, TokioResolver as TokioAsyncResolver,
 };
@@ -59,8 +52,10 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
         let mut config = ResolverConfig::default();
 
         let dns_providers = [QUAD9, CLOUDFLARE, GOOGLE];
-        // quic first as it is secure while being the fastest
-        dns_providers.iter().flat_map(ServerGroup::quic)
+        // quic first as it is secure while being the fastes
+        dns_providers
+            .iter()
+            .flat_map(ServerGroup::quic)
             // h3 is secure but slower than quic
             .chain(dns_providers.iter().flat_map(ServerGroup::h3))
             // likewise tls is faster tha https

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -77,7 +77,7 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
 
     interface.dns_servers.iter().for_each(|addr| {
         tracing::trace!("Adding DNS server: {}", addr);
-        config.add_name_server(NameServerConfig::udp_and_tcp(*addr));
+        config.add_name_server(NameServerConfig::opportunistic_encryption(*addr));
     });
 
     Ok((config, opts))

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -56,7 +56,7 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
 #[cfg(unix)]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     debug!("Using system DNS resolver configuration");
-    Ok(get_system_config())
+    Ok(get_system_configs())
 }
 
 #[cfg(windows)]
@@ -70,7 +70,7 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     if interface.dns_servers.is_empty() {
         warn!("No DNS servers found on default interface; falling back to system DNS config");
 
-        return Ok(get_system_config());
+        return Ok(get_system_configs());
     }
 
     interface.dns_servers.iter().for_each(|addr| {

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -103,7 +103,10 @@ fn new_resolver() -> Result<TokioAsyncResolver, BoxError> {
     let (config, mut opts) = get_configs()?;
 
     debug!("Resolver configuration complete");
+
+    opts.validate = true;
     opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+
     let mut builder = TokioAsyncResolver::builder_with_config(config, Default::default());
     *builder.options_mut() = opts;
     Ok(builder.build()?)

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -41,16 +41,15 @@ impl Resolve for TrustDnsResolver {
 }
 
 fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
-    system_conf::read_system_conf()
-        .unwrap_or_else(|err| {
-            debug!(
-                "hickory-dns: failed to load system DNS configuration; \
-                falling back to hickory_resolver defaults: {:?}",
-                err
-            );
+    system_conf::read_system_conf().unwrap_or_else(|err| {
+        debug!(
+            "hickory-dns: failed to load system DNS configuration; \
+            falling back to hickory_resolver defaults: {:?}",
+            err
+        );
 
-            Default::default()
-        })
+        Default::default()
+    })
 }
 
 #[cfg(unix)]

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -49,7 +49,7 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
         );
 
         (
-            ResolverConfig::udp_and_tcp(hickory_resolver::config::GOOGLE),
+            ResolverConfig::udp_and_tcp(&hickory_resolver::config::GOOGLE),
             Default::default(),
         )
     })

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -4,7 +4,15 @@ use std::{net::SocketAddr, sync::Arc};
 use std::io;
 
 use hickory_resolver::{
-    config::{LookupIpStrategy, ResolverConfig, ResolverOpts},
+    config::{
+        CLOUDFLARE,
+        GOOGLE,
+        LookupIpStrategy,
+        NameServerConfig,
+        QUAD9,
+        ResolverConfig,
+        ResolverOpts,
+    },
     system_conf, TokioResolver as TokioAsyncResolver,
 };
 use once_cell::sync::OnceCell;
@@ -12,7 +20,7 @@ use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tracing::{debug, instrument, warn};
 
 #[cfg(windows)]
-use hickory_resolver::{config::NameServerConfig, net::xfer::Protocol};
+use hickory_resolver::net::xfer::Protocol;
 #[cfg(windows)]
 use netdev::Interface;
 
@@ -48,10 +56,17 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
             err
         );
 
-        (
-            ResolverConfig::udp_and_tcp(&hickory_resolver::config::GOOGLE),
-            Default::default(),
-        )
+        let mut config = ResolverConfig::default();
+        for dns in [QUAD9, CLOUDFLARE, GOOGLE] {
+            dns.udp_and_tcp()
+                .chain(dns.tls())
+                .chain(dns.https())
+                .chain(dns.quic())
+                .chain(dns.h3())
+                .for_each(|name_server| config.add_name_server(name_server));
+        }
+
+        (config, Default::default())
     })
 }
 

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -5,15 +5,9 @@ use std::io;
 
 use hickory_resolver::{
     config::{
-        CLOUDFLARE,
-        GOOGLE,
-        LookupIpStrategy,
-        NameServerConfig,
-        QUAD9,
-        ResolverConfig,
-        ResolverOpts,
+        LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts, CLOUDFLARE, GOOGLE, QUAD9,
     },
-    system_conf, TokioResolver as TokioAsyncResolver,
+    systemconf, TokioResolver as TokioAsyncResolver,
 };
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -43,7 +43,7 @@ impl Resolve for TrustDnsResolver {
 fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
     system_conf::read_system_conf()
         .unwrap_or_else(|err| {
-            log::debug!(
+            debug!(
                 "hickory-dns: failed to load system DNS configuration; \
                 falling back to hickory_resolver defaults: {:?}",
                 err

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -62,12 +62,12 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
         // quic first as it is secure while being the fastest
         dns_providers.iter().flat_map(ServerGroup::quic)
             // h3 is secure but slower than quic
-            .chain(dns_providers.iter().flat_map(ServerGroup::h3)
+            .chain(dns_providers.iter().flat_map(ServerGroup::h3))
             // likewise tls is faster tha https
-            .chain(dns_providers.iter().flat_map(ServerGroup::tls)
-            .chain(dns_providers.iter().flat_map(ServerGroup::https)
+            .chain(dns_providers.iter().flat_map(ServerGroup::tls))
+            .chain(dns_providers.iter().flat_map(ServerGroup::https))
             // fallback to udp and tcp
-            .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp)
+            .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp))
             .for_each(|name_server| config.add_name_server(name_server));
 
         (config, Default::default())

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -5,6 +5,7 @@ use std::io;
 
 use hickory_resolver::{
     config::{
+        ConnectionConfig,
         LookupIpStrategy,
         NameServerConfig,
         ResolverConfig,
@@ -93,9 +94,18 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
         return Ok(get_system_configs());
     }
 
-    interface.dns_servers.iter().for_each(|addr| {
+    interface.dns_servers.into_iter().for_each(|addr| {
         tracing::trace!("Adding DNS server: {}", addr);
-        config.add_name_server(NameServerConfig::opportunistic_encryption(*addr));
+        config.add_name_server(NameServerConfig::new(
+            addr,
+            true,
+            vec![
+                ConnectionConfig::quic(Arc::from(ip.to_string())),
+                ConnectionConfig::tls(Arc::from(ip.to_string())),
+                ConnectionConfig::udp(),
+                ConnectionConfig::tcp(),
+            ],
+        ));
     });
 
     Ok((config, opts))

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -40,10 +40,23 @@ impl Resolve for TrustDnsResolver {
     }
 }
 
+fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
+    system_conf::read_system_conf()
+        .unwrap_or_else(|err| {
+            log::debug!(
+                "hickory-dns: failed to load system DNS configuration; \
+                falling back to hickory_resolver defaults: {:?}",
+                err
+            );
+
+            Default::default()
+        })
+}
+
 #[cfg(unix)]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     debug!("Using system DNS resolver configuration");
-    system_conf::read_system_conf().map_err(Into::into)
+    Ok(get_system_config())
 }
 
 #[cfg(windows)]
@@ -57,9 +70,7 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     if interface.dns_servers.is_empty() {
         warn!("No DNS servers found on default interface; falling back to system DNS config");
 
-        return system_conf::read_system_conf().map_err(|err| {
-            io::Error::other(format!("Failed to read system DNS config: {err}")).into()
-        });
+        return Ok(get_system_config());
     }
 
     interface.dns_servers.iter().for_each(|addr| {

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -100,8 +100,8 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
             addr,
             true,
             vec![
-                ConnectionConfig::quic(Arc::from(ip.to_string())),
-                ConnectionConfig::tls(Arc::from(ip.to_string())),
+                ConnectionConfig::quic(Arc::from(addr.to_string())),
+                ConnectionConfig::tls(Arc::from(addr.to_string())),
                 ConnectionConfig::udp(),
                 ConnectionConfig::tcp(),
             ],


### PR DESCRIPTION
Should fix #2181

On some platforms, for example Android, `/etc/resolv.conf` does not exist, so it'd cause `cargo-binstall` to fail.

Ported from reqwest PR: seanmonstar/reqwest#2797
Related hickory-dns issue: hickory-dns/hickory-dns#652.