### PR TITLE
fix install-from-binstall-release.sh for riscv64gc riscv64

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -37,6 +37,9 @@ elif [ "$os" = "Linux" ]; then
     if [ "$machine" = "armv7l" ]; then
         machine="armv7"
     fi
+    if [ "$machine" = "riscv64" ]; then
+        machine="riscv64gc"
+    fi
     target="${machine}-unknown-linux-musl"
     if [ "$machine" = "armv7" ]; then
         target="${target}eabihf"


### PR DESCRIPTION
Fixed #2522

* riscv64 architecture maps to riscv64gc in the rust triplet arch