### PR TITLE
feat: add os-name template variable for pkg-url and bin-dir

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -42,6 +42,7 @@ with the following variables available:
 - `binary-ext` is the string `.exe` if the `target` is for Windows, or the empty string otherwise
 - `format` is a soft-deprecated alias for `archive-format` in `pkg-url`, and alias for `binary-ext` in `bin-dir`; in the future, this may warn at install time.
 - `target-family`: Operating system of the target from [`target_lexicon::OperatingSystem`]
+- `os-name`: `rustc`-style operating system name of the target, e.g. `windows`, `macos` or `linux`
 - `target-arch`: Architecture of the target, `universal` on `{universal, universal2}-apple-darwin`,
   otherwise from [`target_lexicon::Architecture`]
 - `target-libc`: ABI environment of the target from [`target_lexicon::Environment`]

--- a/crates/binstalk/src/helpers/target_triple.rs
+++ b/crates/binstalk/src/helpers/target_triple.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::Deref, str::FromStr};
 
-use binstalk_types::cargo_toml_binstall::TargetTriple as TargetTripleInner;
+use binstalk_types::cargo_toml_binstall::{CfgOption, TargetTriple as TargetTripleInner};
 
 use crate::errors::BinstallError;
 
@@ -29,11 +29,45 @@ impl leon::Values for TargetTriple {
             // Intentional: `target-family` in the template refers to the OS,
             // not to the `rustc` target family.
             "target-family" => Some(self.os.into_str()),
+            // `rustc`-style OS name, e.g. `macos` rather than `darwin`.
+            "os-name" => Some(CfgOption::Os(self.os).value()),
             "target-arch" => Some(self.arch.into_str()),
             "target-libc" => Some(self.env.into_str()),
             "target-vendor" => Some(Cow::Borrowed(self.vendor.as_str())),
 
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leon::Values;
+
+    #[test]
+    fn test_os_name_macos() {
+        let triple: TargetTriple = "aarch64-apple-darwin".parse().unwrap();
+        assert_eq!(triple.get_value("os-name").as_deref(), Some("macos"));
+    }
+
+    #[test]
+    fn test_os_name_linux() {
+        let triple: TargetTriple = "x86_64-unknown-linux-gnu".parse().unwrap();
+        assert_eq!(triple.get_value("os-name").as_deref(), Some("linux"));
+    }
+
+    #[test]
+    fn test_os_name_windows() {
+        let triple: TargetTriple = "x86_64-pc-windows-msvc".parse().unwrap();
+        assert_eq!(triple.get_value("os-name").as_deref(), Some("windows"));
+    }
+
+    #[test]
+    fn test_existing_keys_unchanged() {
+        let triple: TargetTriple = "x86_64-unknown-linux-gnu".parse().unwrap();
+        assert_eq!(triple.get_value("target-arch").as_deref(), Some("x86_64"));
+        assert_eq!(triple.get_value("target-libc").as_deref(), Some("gnu"));
+        assert_eq!(triple.get_value("unknown-key"), None);
     }
 }


### PR DESCRIPTION
Closes #2328. Adds an `os-name` template variable exposing the rustc-style OS name (`windows`, `macos`, `linux`), since the existing `target-family` returns the raw target_lexicon OS (e.g. `darwin`). The maintainer said "Not opposed, would accept a PR with the `os-name` variant" and the kebab-cased `os-name` spelling was requested in the thread.

Existing template variables are unchanged. SUPPORT.md documents the new variable.