### PR TITLE
feat: add --features / --no-default-features / --all-features flags

### DIFF
--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -108,6 +108,39 @@ pub struct Args {
     )]
     pub(crate) bin: Option<Vec<CompactString>>,
 
+    /// Space- or comma-separated list of features to activate.
+    ///
+    /// This flag only affects the `compile` strategy (cargo install fallback).
+    /// If a prebuilt binary is selected, binstall will warn that the feature
+    /// list cannot be enforced and proceed with the prebuilt.
+    #[clap(
+        help_heading = "Overrides",
+        short = 'F',
+        long,
+        value_delimiter(','),
+        action = clap::ArgAction::Append,
+        value_name = "FEATURES"
+    )]
+    pub(crate) features: Vec<CompactString>,
+
+    /// Do not activate the `default` feature when compiling from source.
+    ///
+    /// Implies that the compile strategy is required: prebuilt strategies
+    /// (crate-meta-data, quick-install) are disabled for this invocation.
+    #[clap(help_heading = "Overrides", long)]
+    pub(crate) no_default_features: bool,
+
+    /// Activate every feature declared by the package when compiling from source.
+    ///
+    /// Implies that the compile strategy is required: prebuilt strategies
+    /// (crate-meta-data, quick-install) are disabled for this invocation.
+    #[clap(
+        help_heading = "Overrides",
+        long,
+        conflicts_with = "no_default_features"
+    )]
+    pub(crate) all_features: bool,
+
     /// Override Cargo.toml package manifest path.
     ///
     /// This skips searching crates.io for a manifest and uses the specified path directly, useful
@@ -552,6 +585,20 @@ impl ValueEnum for StrategyWrapped {
     }
 }
 
+/// `--features` accepts a "space or comma separated list" per cargo's contract.
+///
+/// clap's `value_delimiter(',')` on the `features` field already handles
+/// commas. `split_ascii_whitespace` then expands whitespace inside each parsed
+/// value and, because it never yields empty slices, also drops the empty
+/// entries produced by stray commas (e.g. `--features a,,b`).
+fn sanitize_features(parsed: &[CompactString]) -> Vec<CompactString> {
+    parsed
+        .iter()
+        .flat_map(|value| value.split_ascii_whitespace())
+        .map(CompactString::from)
+        .collect()
+}
+
 pub fn parse() -> (Args, PkgOverride) {
     // Filter extraneous arg when invoked by cargo
     // `cargo run -- --help` gives ["target/debug/cargo-binstall", "--help"]
@@ -574,6 +621,8 @@ pub fn parse() -> (Args, PkgOverride) {
 
     // Load options
     let mut opts = Args::parse_from(args);
+
+    opts.features = sanitize_features(&opts.features);
 
     #[cfg(feature = "clap-markdown")]
     if opts.markdown_help {
@@ -606,6 +655,12 @@ pub fn parse() -> (Args, PkgOverride) {
             "version"
         } else if opts.manifest_path.is_some() {
             "manifest-path"
+        } else if !opts.features.is_empty() {
+            "features"
+        } else if opts.no_default_features {
+            "no-default-features"
+        } else if opts.all_features {
+            "all-features"
         } else {
             #[cfg(not(feature = "git"))]
             {
@@ -701,6 +756,19 @@ You cannot use --{option} and specify multiple packages at the same time. Do one
             .exit()
     }
 
+    // --no-default-features / --all-features require the `compile` strategy.
+    // Reject up-front instead of failing later with NoFallbackToCargoInstall (exit 94).
+    let must_compile = opts.no_default_features || opts.all_features;
+    if must_compile && !opts.strategies.iter().any(|s| s.0 == Strategy::Compile) {
+        command
+            .error(
+                ErrorKind::ArgumentConflict,
+                "--no-default-features and --all-features require the `compile` strategy, \
+                 but it has been disabled via --strategies or --disable-strategies",
+            )
+            .exit()
+    }
+
     if opts.github_token.is_none() {
         if let Ok(github_token) = env::var("GH_TOKEN") {
             opts.github_token = Some(GithubToken(Zeroizing::new(github_token.into())));
@@ -738,6 +806,106 @@ mod test {
     #[test]
     fn verify_cli() {
         Args::command().debug_assert()
+    }
+
+    fn cs(s: &str) -> CompactString {
+        CompactString::from(s)
+    }
+
+    #[test]
+    fn sanitize_features_splits_on_whitespace() {
+        // M1: cargo accepts `--features "foo bar"` (a single arg with whitespace).
+        // clap's value_delimiter splits commas; sanitize_features must split spaces.
+        assert_eq!(sanitize_features(&[cs("foo bar")]), [cs("foo"), cs("bar")]);
+    }
+
+    #[test]
+    fn sanitize_features_drops_empty_from_stray_commas() {
+        // M2: clap value_delimiter(',') on input "a,,b" produces ["a", "", "b"].
+        // The empty entry must not reach `cargo install` as `--features ''`.
+        assert_eq!(
+            sanitize_features(&[cs("a"), cs(""), cs("b")]),
+            [cs("a"), cs("b")]
+        );
+    }
+
+    #[test]
+    fn sanitize_features_drops_whitespace_only_entries() {
+        assert_eq!(
+            sanitize_features(&[cs("   "), cs("tls"), cs("\t\n")]),
+            [cs("tls")]
+        );
+    }
+
+    #[test]
+    fn sanitize_features_preserves_pkg_slash_feat_syntax() {
+        assert_eq!(sanitize_features(&[cs("dep/feat-x")]), [cs("dep/feat-x")]);
+    }
+
+    #[test]
+    fn sanitize_features_handles_mixed_whitespace_and_commas() {
+        // Repeated --features arg with internal mixed delimiters.
+        assert_eq!(
+            sanitize_features(&[cs("tls async"), cs("extra")]),
+            [cs("tls"), cs("async"), cs("extra")]
+        );
+    }
+
+    #[test]
+    fn sanitize_features_empty_input_yields_empty() {
+        assert!(sanitize_features(&[]).is_empty());
+    }
+
+    #[test]
+    fn no_default_features_conflicts_with_all_features() {
+        // binstall deliberately rejects both flags together via clap's
+        // `conflicts_with`. Note this is stricter than cargo, which accepts
+        // `--all-features --no-default-features` (the latter is redundant but
+        // not an error); we reject it up-front to avoid a confusing no-op flag.
+        let err = Args::try_parse_from([
+            "cargo-binstall",
+            "--no-default-features",
+            "--all-features",
+            "ripgrep",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn features_accept_comma_separated() {
+        let args =
+            Args::try_parse_from(["cargo-binstall", "--features", "tls,async", "ripgrep"]).unwrap();
+        assert_eq!(
+            args.features.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            ["tls", "async"]
+        );
+    }
+
+    #[test]
+    fn features_short_flag_is_capital_f() {
+        let args = Args::try_parse_from(["cargo-binstall", "-F", "tls", "ripgrep"]).unwrap();
+        assert_eq!(
+            args.features.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            ["tls"]
+        );
+    }
+
+    #[test]
+    fn features_can_be_repeated() {
+        let args = Args::try_parse_from([
+            "cargo-binstall",
+            "--features",
+            "a",
+            "--features",
+            "b,c",
+            "ripgrep",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.features.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
     }
 
     #[test]

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -54,11 +54,16 @@ pub fn install_crates(
         temp_dir,
     } = crate::initialise::initialise(&args)?;
 
+    let must_compile = args.no_default_features || args.all_features;
+
     let mut cargo_install_fallback = false;
     let resolvers: Vec<_> = settings
         .strategies
         .into_iter()
         .filter_map(|strategy| match strategy.0 {
+            // --no-default-features / --all-features demand a custom build that no
+            // prebuilt artifact can satisfy, so drop prebuilt fetchers entirely.
+            Strategy::CrateMetaData | Strategy::QuickInstall if must_compile => None,
             Strategy::CrateMetaData => Some(GhCrateMeta::new as Resolver),
             Strategy::QuickInstall => Some(QuickInstall::new as Resolver),
             Strategy::Compile => {
@@ -67,6 +72,20 @@ pub fn install_crates(
             }
         })
         .collect();
+
+    if must_compile {
+        // args.rs rejects must_compile without Strategy::Compile at parse time, so the
+        // Compile arm above has already set this. assert! (not debug_assert!) so an
+        // arg-validation regression surfaces in release builds too.
+        assert!(
+            cargo_install_fallback,
+            "must_compile invariant: args.rs must guarantee Compile is enabled"
+        );
+        info!(
+            "--no-default-features/--all-features requested; \
+             prebuilt strategies disabled, will use `cargo install` directly"
+        );
+    }
 
     // Remove installed crates
     let mut crate_names = filter_out_installed_crates(
@@ -207,6 +226,10 @@ pub fn install_crates(
             bins.sort_unstable();
             bins
         }),
+
+        features: args.features,
+        no_default_features: args.no_default_features,
+        all_features: args.all_features,
 
         temp_dir: temp_dir.path().to_owned(),
         install_path,

--- a/crates/binstalk/CHANGELOG.md
+++ b/crates/binstalk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `Options` fields `features: Vec<CompactString>`, `no_default_features: bool`, and `all_features: bool`. Forwarded to `cargo install` when the `Compile` resolution path is used. The `features` list also drives a warn-and-proceed advisory when a prebuilt fetcher is selected.
+
 ## [0.28.75](https://github.com/cargo-bins/cargo-binstall/compare/binstalk-v0.28.74...binstalk-v0.28.75) - 2026-05-06
 
 ### Other

--- a/crates/binstalk/src/ops.rs
+++ b/crates/binstalk/src/ops.rs
@@ -47,6 +47,26 @@ pub struct Options {
     /// If provided, the names are sorted.
     pub bins: Option<Vec<CompactString>>,
 
+    /// Features to activate when the `compile` (cargo install) strategy is used.
+    ///
+    /// These are passed through verbatim to `cargo install --features <value>` (one
+    /// argument per element). When a prebuilt fetcher is selected instead, binstall
+    /// will log a warning that the feature list cannot be enforced.
+    pub features: Vec<CompactString>,
+
+    /// When true, the `compile` strategy will be invoked with
+    /// `--no-default-features`. Callers are responsible for ensuring the compile
+    /// strategy is actually reachable (e.g. by removing prebuilt resolvers from
+    /// `resolvers`). Ignored when `all_features == true`, matching cargo's
+    /// mutual exclusion of the two flags.
+    pub no_default_features: bool,
+
+    /// When true, the `compile` strategy will be invoked with `--all-features`.
+    /// Callers are responsible for ensuring the compile strategy is actually
+    /// reachable (e.g. by removing prebuilt resolvers from `resolvers`).
+    /// Takes precedence over `no_default_features`.
+    pub all_features: bool,
+
     pub temp_dir: PathBuf,
     pub install_path: PathBuf,
     pub has_overriden_install_path: bool,

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -196,6 +196,17 @@ async fn resolve_inner(
                     {
                         Ok(bin_files) => {
                             if !bin_files.is_empty() {
+                                if !opts.features.is_empty() {
+                                    warn!(
+                                        "--features {} was supplied, but binstall \
+                                         selected a prebuilt binary from fetcher `{}`. \
+                                         Feature flags cannot be enforced on prebuilt \
+                                         artifacts and will be ignored. Re-run with \
+                                         --strategies compile to force a build from source.",
+                                        opts.features.iter().format(","),
+                                        fetcher.source_name(),
+                                    );
+                                }
                                 if !opts.disable_telemetry {
                                     fetcher.clone().report_to_upstream();
                                 }

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -218,6 +218,13 @@ impl ResolutionSource {
             }
         }
 
+        apply_feature_selection(
+            &mut cmd,
+            opts.all_features,
+            opts.no_default_features,
+            &opts.features,
+        );
+
         debug!("Running `{}`", format_cmd(&cmd));
 
         if !opts.dry_run {
@@ -259,6 +266,27 @@ fn apply_registry_selection(cmd: &mut Command, registry: Option<&str>, index: Op
         cmd.arg("--registry").arg(registry);
     } else if let Some(index) = index {
         cmd.arg("--index").arg(index);
+    }
+}
+
+// binstall rejects `--all-features` together with `--no-default-features` at
+// parse time in `crates/bin/src/args.rs` via `clap`'s `conflicts_with` (cargo
+// itself accepts both, treating `--no-default-features` as a redundant no-op).
+// The `else if` mirrors that precedence at the call site so a future code path
+// that bypasses arg-parsing prefers `--all-features` rather than emitting both.
+fn apply_feature_selection(
+    cmd: &mut Command,
+    all_features: bool,
+    no_default_features: bool,
+    features: &[CompactString],
+) {
+    if all_features {
+        cmd.arg("--all-features");
+    } else if no_default_features {
+        cmd.arg("--no-default-features");
+    }
+    for feature in features {
+        cmd.arg("--features").arg(feature.as_str());
     }
 }
 
@@ -312,5 +340,77 @@ mod tests {
             args,
             ["--index", "sparse+https://registry.example.com/index/"]
         );
+    }
+
+    fn collect_args(cmd: &Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn test_feature_selection_all_features_only_when_both_set() {
+        // `--all-features` takes precedence over `--no-default-features`.
+        // CLI-level `conflicts_with` makes this combination unreachable from
+        // the binary (binstall is stricter than cargo here), but library
+        // callers may set both fields on `Options`.
+        let mut cmd = Command::new("cargo");
+        let features = vec![CompactString::from("a"), CompactString::from("b")];
+
+        apply_feature_selection(&mut cmd, true, true, &features);
+
+        assert_eq!(
+            collect_args(&cmd),
+            ["--all-features", "--features", "a", "--features", "b",]
+        );
+    }
+
+    #[test]
+    fn test_feature_selection_no_default_features_with_features() {
+        let mut cmd = Command::new("cargo");
+        let features = vec![CompactString::from("tls")];
+
+        apply_feature_selection(&mut cmd, false, true, &features);
+
+        assert_eq!(
+            collect_args(&cmd),
+            ["--no-default-features", "--features", "tls"]
+        );
+    }
+
+    #[test]
+    fn test_feature_selection_emits_nothing_when_all_disabled() {
+        let mut cmd = Command::new("cargo");
+        let features: Vec<CompactString> = Vec::new();
+
+        apply_feature_selection(&mut cmd, false, false, &features);
+
+        assert_eq!(cmd.as_std().get_args().count(), 0);
+    }
+
+    #[test]
+    fn test_feature_selection_preserves_pkg_slash_feat_syntax() {
+        let mut cmd = Command::new("cargo");
+        let features = vec![CompactString::from("dep/feat-x")];
+
+        apply_feature_selection(&mut cmd, false, true, &features);
+
+        assert_eq!(
+            collect_args(&cmd),
+            ["--no-default-features", "--features", "dep/feat-x"]
+        );
+    }
+
+    #[test]
+    fn test_feature_selection_features_only() {
+        // Plain `--features X` without --all-features or --no-default-features
+        // is the warn-and-proceed code path's "compile from source" arm.
+        let mut cmd = Command::new("cargo");
+        let features = vec![CompactString::from("a"), CompactString::from("b")];
+
+        apply_feature_selection(&mut cmd, false, false, &features);
+
+        assert_eq!(collect_args(&cmd), ["--features", "a", "--features", "b"]);
     }
 }


### PR DESCRIPTION
Fixed #2458

## Summary

For #2458, add cargo-style feature selection flags to `cargo binstall`. These flags
let users control which Cargo features are activated when a crate is built
from source via the `compile` strategy (the `cargo install` fallback):

- `-F`, `--features <FEATURES>` — space- or comma-separated list of features
  to activate. Can be repeated.
- `--no-default-features` — do not activate the `default` feature.
- `--all-features` — activate every feature declared by the package.

## Behavior

- **Compile strategy only.** Prebuilt artifacts cannot honor arbitrary
  feature sets, so these flags only affect the `compile` path.
- **`--no-default-features` / `--all-features` force a source build.** When
  either is set, the prebuilt fetchers (`crate-meta-data`, `quick-install`)
  are dropped from the resolver list, so the install goes straight to
  `cargo install`. If the `compile` strategy has been disabled (via
  `--strategies` / `--disable-strategies`), this is rejected at parse time
  with a clear `ArgumentConflict` error rather than failing later with a cryptic exit code.
- **`--features` alone is advisory.** If a prebuilt binary is selected,
  binstall logs a warning that the feature list cannot be enforced and
  proceeds with the prebuilt. Re-run with `--strategies compile` to force a
  build from source.
- **`--all-features` and `--no-default-features` are mutually exclusive.**
  binstall rejects the combination via clap's `conflicts_with` (slightly
  stricter than cargo, which treats the pair as a redundant no-op).

## Argument parsing

The `--features` value follows cargo's contract: clap splits on commas, and
a post-parse `sanitize_features` step splits on whitespace and drops empty
entries (e.g. from stray commas like `--features a,,b`). `pkg/feat` syntax is
preserved verbatim.

## Library API

`binstalk::ops::Options` gains three new public fields — `features`,
`no_default_features`, and `all_features` — forwarded to `cargo install` when
the `Compile` resolution path runs. Documented in the binstalk CHANGELOG.

## Tests

Unit tests cover feature-string sanitization, flag conflict rejection, short/repeated
flag forms, and the exact `cargo install` argument vector produced for each combination of flags.

The PR is exactly the two feature commits (8937e12f + 66f8be26); the dep-upgrade and os-name commits shown in git log are already on main, so I excluded them.

---

Close: #2458 