### PR TITLE
bugfix: IPv6 DNS issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "once_cell",
  "rc-zip-sync",
  "reqwest",
+ "resolv-conf",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/binstalk-downloader/Cargo.toml
+++ b/crates/binstalk-downloader/Cargo.toml
@@ -112,7 +112,7 @@ rustls = [
 native-tls = ["__tls", "native-tls-crate", "reqwest/native-tls"]
 
 # Enable hickory-resolver so that features on it will also be enabled.
-hickory-dns = ["hickory-resolver", "netdev", "once_cell"]
+hickory-dns = ["hickory-resolver", "netdev", "once_cell", "resolv-conf"]
 
 # Deprecated alias for hickory-dns, since trust-dns is renamed to hickory-dns
 trust-dns = ["hickory-dns"]
@@ -128,6 +128,9 @@ zstd-thin = ["zstd/thin"]
 cross-lang-fat-lto = ["zstd/fat-lto"]
 
 json = ["serde", "serde_json"]
+
+[target."cfg(unix)".dependencies]
+resolv-conf = { version = "0.7.6", optional = true }
 
 [target."cfg(windows)".dependencies]
 netdev = { version = "0.43.0", optional = true }

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -3,10 +3,12 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 #[cfg(windows)]
 use std::io;
 
+#[cfg(windows)]
+use hickory_resolver::config::ConnectionConfig;
 use hickory_resolver::{
     config::{
-        ConnectionConfig, LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts,
-        ServerGroup, CLOUDFLARE, GOOGLE, QUAD9,
+        LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts, ServerGroup, CLOUDFLARE,
+        GOOGLE,
     },
     system_conf, TokioResolver as TokioAsyncResolver,
 };
@@ -41,41 +43,107 @@ impl Resolve for TrustDnsResolver {
     }
 }
 
+/// Encrypted public DNS (Cloudflare then Google), used as a last resort when no usable
+/// system nameserver can be obtained.
+fn public_dns_configs() -> (ResolverConfig, ResolverOpts) {
+    let mut config = ResolverConfig::default();
+    let mut opts = ResolverOpts::default();
+
+    let dns_providers = [CLOUDFLARE, GOOGLE];
+    // quic first as it is secure while being the fastes
+    dns_providers
+        .iter()
+        .flat_map(ServerGroup::quic)
+        // h3 is secure but slower than quic
+        .chain(dns_providers.iter().flat_map(ServerGroup::h3))
+        // likewise tls is faster tha https
+        .chain(dns_providers.iter().flat_map(ServerGroup::tls))
+        .chain(dns_providers.iter().flat_map(ServerGroup::https))
+        // fallback to udp and tcp
+        .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp))
+        .for_each(|name_server| config.add_name_server(name_server));
+
+    opts.timeout = Duration::from_millis(750);
+
+    (config, opts)
+}
+
+#[cfg(windows)]
 fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
     system_conf::read_system_conf().unwrap_or_else(|err| {
         debug!(
             "hickory-dns: failed to load system DNS configuration; \
-            falling back to cloudflare and then googld: {:?}",
+            falling back to cloudflare and then google: {:?}",
             err
         );
-
-        let mut config = ResolverConfig::default();
-        let mut opts = ResolverOpts::default();
-
-        let dns_providers = [CLOUDFLARE, GOOGLE];
-        // quic first as it is secure while being the fastes
-        dns_providers
-            .iter()
-            .flat_map(ServerGroup::quic)
-            // h3 is secure but slower than quic
-            .chain(dns_providers.iter().flat_map(ServerGroup::h3))
-            // likewise tls is faster tha https
-            .chain(dns_providers.iter().flat_map(ServerGroup::tls))
-            .chain(dns_providers.iter().flat_map(ServerGroup::https))
-            // fallback to udp and tcp
-            .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp))
-            .for_each(|name_server| config.add_name_server(name_server));
-
-        opts.timeout = Duration::from_millis(750);
-
-        (config, opts)
+        public_dns_configs()
     })
+}
+
+/// Extract the usable nameserver IPs from `/etc/resolv.conf`-style contents.
+///
+/// `hickory_resolver::system_conf::read_system_conf` is all-or-nothing: a single
+/// unparseable `nameserver` entry fails the whole load. macOS routinely lists a
+/// router-advertised link-local IPv6 server with a zone id (e.g.
+/// `fe80::1%en0`) that it cannot parse, which throws away the valid
+/// IPv4 nameserver alongside it. We salvage the entries we can actually use: scoped
+/// (zone-suffixed) addresses are skipped because a link-local server is unusable without
+/// its scope id, and anything that is not a bare `IpAddr` is ignored.
+#[cfg(unix)]
+fn parse_nameservers(contents: &str) -> Vec<std::net::IpAddr> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let mut tokens = line.split_whitespace();
+            (tokens.next() == Some("nameserver"))
+                .then(|| tokens.next())
+                .flatten()
+        })
+        // Skip scoped/link-local entries (`addr%zone`); unusable without scope handling.
+        .filter(|tok| !tok.contains('%'))
+        .filter_map(|tok| tok.parse().ok())
+        .collect()
+}
+
+/// Build a resolver config from the parseable system nameservers, or `None` if none are
+/// usable.
+#[cfg(unix)]
+fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
+    let contents = std::fs::read_to_string("/etc/resolv.conf").ok()?;
+    let nameservers = parse_nameservers(&contents);
+    if nameservers.is_empty() {
+        return None;
+    }
+
+    debug!(
+        "Salvaged {} usable system nameserver(s) from /etc/resolv.conf",
+        nameservers.len()
+    );
+
+    let mut config = ResolverConfig::default();
+    for ip in nameservers {
+        config.add_name_server(NameServerConfig::udp_and_tcp(ip));
+    }
+    Some((config, ResolverOpts::default()))
 }
 
 #[cfg(unix)]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     debug!("Using system DNS resolver configuration");
-    Ok(get_system_configs())
+    match system_conf::read_system_conf() {
+        Ok(configs) => Ok(configs),
+        Err(err) => {
+            debug!(
+                "hickory-dns: failed to load system DNS configuration ({:?}); \
+                attempting to salvage parseable nameservers from /etc/resolv.conf",
+                err
+            );
+            Ok(salvage_system_configs().unwrap_or_else(|| {
+                debug!("No usable system nameservers; falling back to public encrypted DNS");
+                public_dns_configs()
+            }))
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -148,4 +216,67 @@ fn get_default_interface() -> Result<Interface, BoxError> {
     );
 
     Ok(interface)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::parse_nameservers;
+    use std::net::IpAddr;
+
+    fn ips(contents: &str) -> Vec<IpAddr> {
+        parse_nameservers(contents)
+    }
+
+    #[test]
+    fn skips_scoped_link_local_keeps_ipv4() {
+        // The exact failure case on the affected macOS machine: a router-advertised
+        // link-local IPv6 nameserver with a zone id that hickory cannot parse,
+        // followed by a usable IPv4 nameserver.
+        let resolv = "search home\n\
+                      nameserver fe80::1%en0\n\
+                      nameserver 192.168.1.254\n";
+        let got = ips(resolv);
+        assert_eq!(got, vec!["192.168.1.254".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn keeps_plain_ipv6_nameserver() {
+        let got = ips("nameserver 2606:4700:4700::1111\n");
+        assert_eq!(got, vec!["2606:4700:4700::1111".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn all_unparseable_yields_empty() {
+        let got = ips("nameserver fe80::1%en0\nnameserver not-an-ip\n");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn ignores_comments_and_other_directives() {
+        let resolv = "# a comment\n\
+                      ; another comment\n\
+                      domain example.com\n\
+                      options edns0\n\
+                      search a.example b.example\n\
+                      nameserver 8.8.8.8\n\
+                      garbage line without keyword\n\
+                      nameserver\n";
+        let got = ips(resolv);
+        assert_eq!(got, vec!["8.8.8.8".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn preserves_order_and_mix() {
+        let resolv = "nameserver 1.1.1.1\n\
+                      nameserver fe80::1%en0\n\
+                      nameserver 2606:4700:4700::1111\n";
+        let got = ips(resolv);
+        assert_eq!(
+            got,
+            vec![
+                "1.1.1.1".parse::<IpAddr>().unwrap(),
+                "2606:4700:4700::1111".parse::<IpAddr>().unwrap(),
+            ]
+        );
+    }
 }

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -13,7 +13,7 @@ use hickory_resolver::{
     TokioResolver as TokioAsyncResolver,
 };
 
-#[cfg(windows)]
+#[cfg(any(windows, target_vendor = "apple"))]
 use hickory_resolver::system_conf;
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
@@ -156,7 +156,38 @@ fn read_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
     result
 }
 
-#[cfg(unix)]
+/// macOS reads its authoritative DNS configuration from the System Configuration dynamic
+/// store, not `/etc/resolv.conf`: hickory's `read_system_conf` compiles `apple.rs` on
+/// `target_vendor = "apple"` and queries `State:/Network/Global/DNS`, while
+/// `/etc/resolv.conf` is only a best-effort mirror. So prefer `read_system_conf` here and
+/// keep its result whenever it parses. It is all-or-nothing, though — a single scoped
+/// link-local IPv6 nameserver (e.g. `fe80::1%en0`) hard-fails the whole read with
+/// "invalid IP address syntax" — and only then do we salvage parseable entries from the
+/// `/etc/resolv.conf` mirror before falling back to public encrypted DNS.
+/// See https://github.com/hickory-dns/hickory-dns/issues/3713.
+#[cfg(target_vendor = "apple")]
+fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
+    debug!("Using system DNS resolver configuration");
+    if let Ok(configs) = system_conf::read_system_conf() {
+        return Ok(configs);
+    }
+
+    debug!(
+        "hickory-dns: failed to load system DNS configuration; \
+        attempting to salvage parseable nameservers from /etc/resolv.conf"
+    );
+    Ok(read_system_configs().unwrap_or_else(|| {
+        debug!("No usable system nameservers; falling back to public encrypted DNS");
+        public_dns_configs()
+    }))
+}
+
+/// On non-apple unix, hickory's `read_system_conf` (`unix.rs`) reads the same
+/// `/etc/resolv.conf` our parser does, but via `resolv_conf`'s fail-fast `parse` and an
+/// `ip.into()` that silently drops IPv6 zone ids. Our parser reads that file directly,
+/// tolerates malformed lines, and keeps usable nameservers a scoped entry would otherwise
+/// discard, so it is the sole primary path here with no hickory call to fall back from.
+#[cfg(all(unix, not(target_vendor = "apple")))]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     debug!("Using system DNS resolver configuration");
     Ok(read_system_configs().unwrap_or_else(|| {

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -94,6 +94,9 @@ fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConf
     let nameservers: Vec<NameServerConfig> = parsed
         .nameservers
         .iter()
+        // Drop scoped IPv6 nameservers for now: hickory only accepts socket addresses here,
+        // so link-local entries with a zone id from resolv.conf cannot be represented.
+        // Revisit this once hickory supports scoped nameserver addresses directly.
         .filter(|ip| !matches!(ip, resolv_conf::ScopedIp::V6(_, Some(_))))
         .map(|ip| NameServerConfig::udp_and_tcp(ip.into()))
         .collect();

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -83,51 +83,63 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
     })
 }
 
-/// Extract the usable nameserver IPs from `/etc/resolv.conf`-style contents.
-///
-/// `hickory_resolver::system_conf::read_system_conf` is all-or-nothing: a single
-/// unparseable `nameserver` entry fails the whole load. macOS routinely lists a
-/// router-advertised link-local IPv6 server with a zone id (e.g.
-/// `fe80::1%en0`) that it cannot parse, which throws away the valid
-/// IPv4 nameserver alongside it. We salvage the entries we can actually use: scoped
-/// (zone-suffixed) addresses are skipped because a link-local server is unusable without
-/// its scope id, and anything that is not a bare `IpAddr` is ignored.
+/// Build a resolver config from a parsed `resolv_conf::Config`, skipping scoped IPv6
+/// nameservers (link-local with zone id, e.g. `fe80::1%en0`) that are unusable without
+/// the scope id. Returns `None` when no usable nameservers remain.
 #[cfg(unix)]
-fn parse_nameservers(contents: &str) -> Vec<std::net::IpAddr> {
-    contents
-        .lines()
-        .filter_map(|line| {
-            let mut tokens = line.split_whitespace();
-            (tokens.next() == Some("nameserver"))
-                .then(|| tokens.next())
-                .flatten()
-        })
-        // Skip scoped/link-local entries (`addr%zone`); unusable without scope handling.
-        .filter(|tok| !tok.contains('%'))
-        .filter_map(|tok| tok.parse().ok())
-        .collect()
-}
+fn configs_from_resolv_conf(
+    parsed: resolv_conf::Config,
+) -> Option<(ResolverConfig, ResolverOpts)> {
+    use hickory_resolver::proto::rr::Name as DnsName;
+    use std::str::FromStr as _;
 
-/// Build a resolver config from the parseable system nameservers, or `None` if none are
-/// usable.
-#[cfg(unix)]
-fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
-    let contents = std::fs::read_to_string("/etc/resolv.conf").ok()?;
-    let nameservers = parse_nameservers(&contents);
+    let nameservers: Vec<NameServerConfig> = parsed
+        .nameservers
+        .iter()
+        .filter(|ip| !matches!(ip, resolv_conf::ScopedIp::V6(_, Some(_))))
+        .map(|ip| NameServerConfig::udp_and_tcp(ip.into()))
+        .collect();
+
     if nameservers.is_empty() {
         return None;
     }
 
-    debug!(
-        "Salvaged {} usable system nameserver(s) from /etc/resolv.conf",
-        nameservers.len()
-    );
+    let domain = parsed
+        .get_system_domain()
+        .and_then(|d| DnsName::from_str(d.as_str()).ok());
 
-    let mut config = ResolverConfig::default();
-    for ip in nameservers {
-        config.add_name_server(NameServerConfig::udp_and_tcp(ip));
+    let search = parsed
+        .get_last_search_or_domain()
+        .filter(|s| *s != "--")
+        .filter_map(|s| DnsName::from_str_relaxed(s).ok())
+        .collect();
+
+    let config = ResolverConfig::from_parts(domain, search, nameservers);
+
+    let mut opts = ResolverOpts::default();
+    opts.ndots = parsed.ndots as usize;
+    opts.timeout = Duration::from_secs(u64::from(parsed.timeout));
+    opts.attempts = parsed.attempts as usize;
+    opts.edns0 = parsed.edns0;
+
+    Some((config, opts))
+}
+
+/// Read `/etc/resolv.conf` and build a resolver config, salvaging nameservers that
+/// hickory's all-or-nothing parser would reject (e.g. scoped link-local IPv6 entries).
+/// Returns `None` when no usable nameservers remain or the file cannot be read.
+#[cfg(unix)]
+fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
+    let data = std::fs::read("/etc/resolv.conf").ok()?;
+    let parsed = resolv_conf::Config::parse(&data).ok()?;
+    let result = configs_from_resolv_conf(parsed);
+    if let Some((ref config, _)) = result {
+        debug!(
+            "Salvaged {} usable system nameserver(s) from /etc/resolv.conf",
+            config.name_servers().len()
+        );
     }
-    Some((config, ResolverOpts::default()))
+    result
 }
 
 #[cfg(unix)]
@@ -223,11 +235,19 @@ fn get_default_interface() -> Result<Interface, BoxError> {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::parse_nameservers;
+    use super::configs_from_resolv_conf;
     use std::{net::IpAddr, time::Duration};
 
-    fn ips(contents: &str) -> Vec<IpAddr> {
-        parse_nameservers(contents)
+    fn nameserver_ips(resolv: &str) -> Vec<IpAddr> {
+        let parsed = resolv_conf::Config::parse(resolv.as_bytes()).expect("parse failed");
+        configs_from_resolv_conf(parsed)
+            .map(|(cfg, _)| cfg.name_servers().iter().map(|ns| ns.ip).collect())
+            .unwrap_or_default()
+    }
+
+    fn configs(resolv: &str) -> Option<(hickory_resolver::config::ResolverConfig, hickory_resolver::config::ResolverOpts)> {
+        let parsed = resolv_conf::Config::parse(resolv.as_bytes()).expect("parse failed");
+        configs_from_resolv_conf(parsed)
     }
 
     #[test]
@@ -238,34 +258,40 @@ mod tests {
         let resolv = "search home\n\
                       nameserver fe80::1%en0\n\
                       nameserver 192.168.1.254\n";
-        let got = ips(resolv);
-        assert_eq!(got, vec!["192.168.1.254".parse::<IpAddr>().unwrap()]);
+        assert_eq!(
+            nameserver_ips(resolv),
+            vec!["192.168.1.254".parse::<IpAddr>().unwrap()]
+        );
     }
 
     #[test]
     fn keeps_plain_ipv6_nameserver() {
-        let got = ips("nameserver 2606:4700:4700::1111\n");
-        assert_eq!(got, vec!["2606:4700:4700::1111".parse::<IpAddr>().unwrap()]);
+        assert_eq!(
+            nameserver_ips("nameserver 2606:4700:4700::1111\n"),
+            vec!["2606:4700:4700::1111".parse::<IpAddr>().unwrap()]
+        );
     }
 
     #[test]
-    fn all_unparseable_yields_empty() {
-        let got = ips("nameserver fe80::1%en0\nnameserver not-an-ip\n");
-        assert!(got.is_empty());
+    fn all_scoped_yields_none() {
+        // resolv_conf parses scoped addresses fine; configs_from_resolv_conf should
+        // filter them all out and return None.
+        let parsed =
+            resolv_conf::Config::parse("nameserver fe80::1%en0\n".as_bytes()).expect("parse");
+        assert!(configs_from_resolv_conf(parsed).is_none());
     }
 
     #[test]
     fn ignores_comments_and_other_directives() {
         let resolv = "# a comment\n\
-                      ; another comment\n\
                       domain example.com\n\
                       options edns0\n\
                       search a.example b.example\n\
-                      nameserver 8.8.8.8\n\
-                      garbage line without keyword\n\
-                      nameserver\n";
-        let got = ips(resolv);
-        assert_eq!(got, vec!["8.8.8.8".parse::<IpAddr>().unwrap()]);
+                      nameserver 8.8.8.8\n";
+        assert_eq!(
+            nameserver_ips(resolv),
+            vec!["8.8.8.8".parse::<IpAddr>().unwrap()]
+        );
     }
 
     #[test]
@@ -273,14 +299,24 @@ mod tests {
         let resolv = "nameserver 1.1.1.1\n\
                       nameserver fe80::1%en0\n\
                       nameserver 2606:4700:4700::1111\n";
-        let got = ips(resolv);
         assert_eq!(
-            got,
+            nameserver_ips(resolv),
             vec![
                 "1.1.1.1".parse::<IpAddr>().unwrap(),
                 "2606:4700:4700::1111".parse::<IpAddr>().unwrap(),
             ]
         );
+    }
+
+    #[test]
+    fn extracts_resolver_opts() {
+        let resolv = "nameserver 8.8.8.8\n\
+                      options ndots:3 timeout:2 attempts:4 edns0\n";
+        let (_, opts) = configs(resolv).expect("should produce config");
+        assert_eq!(opts.ndots, 3);
+        assert_eq!(opts.timeout, Duration::from_secs(2));
+        assert_eq!(opts.attempts, 4);
+        assert!(opts.edns0);
     }
 
     /// The cold-resolver query order is the config order (hickory defaults to

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -131,7 +131,14 @@ fn configs_from_resolv_conf(
 #[cfg(unix)]
 fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
     let data = std::fs::read("/etc/resolv.conf").ok()?;
-    let parsed = resolv_conf::Config::parse(&data).ok()?;
+    let (parsed, errors) = resolv_conf::Config::parse_with_errors(&data);
+    if let Some(err) = errors.first() {
+        debug!(
+            "Ignoring {} resolv.conf parse error(s) while salvaging usable nameservers; first error: {:?}",
+            errors.len(),
+            err
+        );
+    }
     let result = configs_from_resolv_conf(parsed);
     if let Some((ref config, _)) = result {
         debug!(
@@ -239,14 +246,14 @@ mod tests {
     use std::{net::IpAddr, time::Duration};
 
     fn nameserver_ips(resolv: &str) -> Vec<IpAddr> {
-        let parsed = resolv_conf::Config::parse(resolv.as_bytes()).expect("parse failed");
+        let (parsed, _) = resolv_conf::Config::parse_with_errors(resolv.as_bytes());
         configs_from_resolv_conf(parsed)
             .map(|(cfg, _)| cfg.name_servers().iter().map(|ns| ns.ip).collect())
             .unwrap_or_default()
     }
 
     fn configs(resolv: &str) -> Option<(hickory_resolver::config::ResolverConfig, hickory_resolver::config::ResolverOpts)> {
-        let parsed = resolv_conf::Config::parse(resolv.as_bytes()).expect("parse failed");
+        let (parsed, _) = resolv_conf::Config::parse_with_errors(resolv.as_bytes());
         configs_from_resolv_conf(parsed)
     }
 
@@ -288,6 +295,19 @@ mod tests {
                       options edns0\n\
                       search a.example b.example\n\
                       nameserver 8.8.8.8\n";
+        assert_eq!(
+            nameserver_ips(resolv),
+            vec!["8.8.8.8".parse::<IpAddr>().unwrap()]
+        );
+    }
+
+    #[test]
+    fn salvages_nameservers_despite_malformed_lines() {
+        let resolv = "nameserver fe80::1%en0\n\
+                      search a.example b.example\n\
+                      garbage line without keyword\n\
+                      nameserver 8.8.8.8\n\
+                      nameserver\n";
         assert_eq!(
             nameserver_ips(resolv),
             vec!["8.8.8.8".parse::<IpAddr>().unwrap()]

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -50,16 +50,19 @@ fn public_dns_configs() -> (ResolverConfig, ResolverOpts) {
     let mut opts = ResolverOpts::default();
 
     let dns_providers = [CLOUDFLARE, GOOGLE];
-    // quic first as it is secure while being the fastes
+    // Order for reachability, not raw speed: hickory queries servers in config order
+    // (two at a time) until it has RTT statistics, so the cold-start order decides what
+    // is attempted first. Lead with the TCP-based encrypted transports (DoT then DoH),
+    // which traverse UDP-blocking / restrictive networks where DoQ and DoH3 (UDP-based)
+    // silently stall. Keep plain unencrypted DNS as the universal last resort.
     dns_providers
         .iter()
-        .flat_map(ServerGroup::quic)
-        // h3 is secure but slower than quic
-        .chain(dns_providers.iter().flat_map(ServerGroup::h3))
-        // likewise tls is faster tha https
-        .chain(dns_providers.iter().flat_map(ServerGroup::tls))
+        .flat_map(ServerGroup::tls)
         .chain(dns_providers.iter().flat_map(ServerGroup::https))
-        // fallback to udp and tcp
+        // UDP-based encrypted transports: faster when reachable, often firewalled.
+        .chain(dns_providers.iter().flat_map(ServerGroup::quic))
+        .chain(dns_providers.iter().flat_map(ServerGroup::h3))
+        // Last resort: plain, unencrypted DNS.
         .chain(dns_providers.iter().flat_map(ServerGroup::udp_and_tcp))
         .for_each(|name_server| config.add_name_server(name_server));
 
@@ -221,7 +224,7 @@ fn get_default_interface() -> Result<Interface, BoxError> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::parse_nameservers;
-    use std::net::IpAddr;
+    use std::{net::IpAddr, time::Duration};
 
     fn ips(contents: &str) -> Vec<IpAddr> {
         parse_nameservers(contents)
@@ -277,6 +280,54 @@ mod tests {
                 "1.1.1.1".parse::<IpAddr>().unwrap(),
                 "2606:4700:4700::1111".parse::<IpAddr>().unwrap(),
             ]
+        );
+    }
+
+    /// The cold-resolver query order is the config order (hickory defaults to
+    /// `QueryStatistics` ordering, which with no statistics yet preserves insertion
+    /// order, and queries `num_concurrent_reqs == 2` servers at a time). The public-DNS
+    /// fallback must therefore lead with the encrypted transports most likely to
+    /// traverse restrictive/UDP-blocking networks (TCP-based DoT/DoH) before the
+    /// UDP-based ones (DoQ/DoH3), and keep plain unencrypted DNS as the last resort.
+    #[test]
+    fn public_dns_fallback_orders_transports_for_reachability() {
+        use hickory_resolver::config::ProtocolConfig;
+
+        fn tier(p: &ProtocolConfig) -> u8 {
+            match p {
+                ProtocolConfig::Tls { .. } => 0,                // DoT  — TCP/853
+                ProtocolConfig::Https { .. } => 1,              // DoH  — TCP/443
+                ProtocolConfig::Quic { .. } => 2,               // DoQ  — UDP/853
+                ProtocolConfig::H3 { .. } => 3,                 // DoH3 — UDP/443
+                ProtocolConfig::Udp | ProtocolConfig::Tcp => 4, // plain, unencrypted
+            }
+        }
+
+        let (config, opts) = super::public_dns_configs();
+        let tiers: Vec<u8> = config
+            .name_servers()
+            .iter()
+            .map(|ns| tier(&ns.connections[0].protocol))
+            .collect();
+
+        assert!(!tiers.is_empty());
+        assert!(
+            tiers.windows(2).all(|w| w[0] <= w[1]),
+            "transport tiers not non-decreasing: {tiers:?}"
+        );
+        assert_eq!(
+            tiers.first(),
+            Some(&0),
+            "DoT (TCP/853) should be tried first"
+        );
+        assert_eq!(
+            tiers.last(),
+            Some(&4),
+            "plain unencrypted DNS should be last"
+        );
+        assert!(
+            opts.timeout <= Duration::from_millis(750),
+            "fallback per-query timeout should stay aggressive so blocked transports fail fast"
         );
     }
 }

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -98,7 +98,7 @@ fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConf
         // so link-local entries with a zone id from resolv.conf cannot be represented.
         // Revisit this once hickory supports scoped nameserver addresses directly.
         .filter(|ip| !matches!(ip, resolv_conf::ScopedIp::V6(_, Some(_))))
-        .map(|ip| NameServerConfig::udp_and_tcp(ip.into()))
+        .map(|ip| NameServerConfig::opportunistic_encryption(ip.into()))
         .collect();
 
     if nameservers.is_empty() {
@@ -343,6 +343,33 @@ mod tests {
         assert_eq!(opts.timeout, Duration::from_secs(2));
         assert_eq!(opts.attempts, 4);
         assert!(opts.edns0);
+    }
+
+    #[test]
+    fn salvaged_nameservers_use_opportunistic_encryption() {
+        use hickory_resolver::config::NameServerConfig;
+        use std::net::IpAddr;
+
+        let (config, _) = configs("nameserver 8.8.8.8\n").expect("should produce config");
+        let nameserver = config
+            .name_servers()
+            .first()
+            .expect("should contain a nameserver");
+        let expected =
+            NameServerConfig::opportunistic_encryption("8.8.8.8".parse::<IpAddr>().unwrap());
+
+        let protocols: Vec<String> = nameserver
+            .connections
+            .iter()
+            .map(|connection| format!("{:?}", connection.protocol))
+            .collect();
+        let expected_protocols: Vec<String> = expected
+            .connections
+            .iter()
+            .map(|connection| format!("{:?}", connection.protocol))
+            .collect();
+
+        assert_eq!(protocols, expected_protocols);
     }
 
     /// The cold-resolver query order is the config order (hickory defaults to

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -133,12 +133,12 @@ fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConf
 fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
     let data = std::fs::read("/etc/resolv.conf").ok()?;
     let (parsed, errors) = resolv_conf::Config::parse_with_errors(&data);
-    if let Some(err) = errors.first() {
+    if !errors.is_empty() {
         debug!(
-            "Ignoring {} resolv.conf parse error(s) while salvaging usable nameservers; first error: {:?}",
-            errors.len(),
-            err
+            "Ignoring {} resolv.conf parse error(s) while salvaging usable nameservers:",
+            errors.len()
         );
+        errors.iter().for_each(|err| debug!("    {err:?}"));
     }
     let result = configs_from_resolv_conf(parsed);
     if let Some((ref config, _)) = result {

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -96,7 +96,8 @@ fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConf
         .iter()
         // Drop scoped IPv6 nameservers for now: hickory only accepts socket addresses here,
         // so link-local entries with a zone id from resolv.conf cannot be represented.
-        // Revisit this once hickory supports scoped nameserver addresses directly.
+        // Revisit this once hickory supports scoped nameserver addresses directly:
+        // https://github.com/hickory-dns/hickory-dns/issues/3713
         .filter(|ip| !matches!(ip, resolv_conf::ScopedIp::V6(_, Some(_))))
         .map(|ip| NameServerConfig::opportunistic_encryption(ip.into()))
         .collect();

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -87,9 +87,7 @@ fn get_system_configs() -> (ResolverConfig, ResolverOpts) {
 /// nameservers (link-local with zone id, e.g. `fe80::1%en0`) that are unusable without
 /// the scope id. Returns `None` when no usable nameservers remain.
 #[cfg(unix)]
-fn configs_from_resolv_conf(
-    parsed: resolv_conf::Config,
-) -> Option<(ResolverConfig, ResolverOpts)> {
+fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConfig, ResolverOpts)> {
     use hickory_resolver::proto::rr::Name as DnsName;
     use std::str::FromStr as _;
 
@@ -252,7 +250,12 @@ mod tests {
             .unwrap_or_default()
     }
 
-    fn configs(resolv: &str) -> Option<(hickory_resolver::config::ResolverConfig, hickory_resolver::config::ResolverOpts)> {
+    fn configs(
+        resolv: &str,
+    ) -> Option<(
+        hickory_resolver::config::ResolverConfig,
+        hickory_resolver::config::ResolverOpts,
+    )> {
         let (parsed, _) = resolv_conf::Config::parse_with_errors(resolv.as_bytes());
         configs_from_resolv_conf(parsed)
     }

--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -10,8 +10,11 @@ use hickory_resolver::{
         LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts, ServerGroup, CLOUDFLARE,
         GOOGLE,
     },
-    system_conf, TokioResolver as TokioAsyncResolver,
+    TokioResolver as TokioAsyncResolver,
 };
+
+#[cfg(windows)]
+use hickory_resolver::system_conf;
 use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tracing::{debug, instrument, warn};
@@ -127,16 +130,18 @@ fn configs_from_resolv_conf(parsed: resolv_conf::Config) -> Option<(ResolverConf
     Some((config, opts))
 }
 
-/// Read `/etc/resolv.conf` and build a resolver config, salvaging nameservers that
-/// hickory's all-or-nothing parser would reject (e.g. scoped link-local IPv6 entries).
-/// Returns `None` when no usable nameservers remain or the file cannot be read.
+/// Read `/etc/resolv.conf` and build a resolver config, keeping usable nameservers that
+/// hickory's all-or-nothing `read_system_conf` would reject (e.g. scoped link-local IPv6
+/// entries). This is our own parser, used in place of hickory's so a single unparseable
+/// entry does not discard the whole configuration. Returns `None` when no usable
+/// nameservers remain or the file cannot be read.
 #[cfg(unix)]
-fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
+fn read_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
     let data = std::fs::read("/etc/resolv.conf").ok()?;
     let (parsed, errors) = resolv_conf::Config::parse_with_errors(&data);
     if !errors.is_empty() {
         debug!(
-            "Ignoring {} resolv.conf parse error(s) while salvaging usable nameservers:",
+            "Ignoring {} resolv.conf parse error(s) while keeping usable nameservers:",
             errors.len()
         );
         errors.iter().for_each(|err| debug!("    {err:?}"));
@@ -144,7 +149,7 @@ fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
     let result = configs_from_resolv_conf(parsed);
     if let Some((ref config, _)) = result {
         debug!(
-            "Salvaged {} usable system nameserver(s) from /etc/resolv.conf",
+            "Loaded {} usable system nameserver(s) from /etc/resolv.conf",
             config.name_servers().len()
         );
     }
@@ -154,20 +159,10 @@ fn salvage_system_configs() -> Option<(ResolverConfig, ResolverOpts)> {
 #[cfg(unix)]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     debug!("Using system DNS resolver configuration");
-    match system_conf::read_system_conf() {
-        Ok(configs) => Ok(configs),
-        Err(err) => {
-            debug!(
-                "hickory-dns: failed to load system DNS configuration ({:?}); \
-                attempting to salvage parseable nameservers from /etc/resolv.conf",
-                err
-            );
-            Ok(salvage_system_configs().unwrap_or_else(|| {
-                debug!("No usable system nameservers; falling back to public encrypted DNS");
-                public_dns_configs()
-            }))
-        }
-    }
+    Ok(read_system_configs().unwrap_or_else(|| {
+        debug!("No usable system nameservers; falling back to public encrypted DNS");
+        public_dns_configs()
+    }))
 }
 
 #[cfg(windows)]

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -65,8 +65,16 @@ nameserver[0] : fe80::1%en0      <-- link-local IPv6 + zone id
 nameserver[1] : <LAN IPv4>       <-- plain IPv4, fine
 ```
 
-`/etc/resolv.conf` mirrors this; `nameserver[0]` is the router advertising itself as the
-IPv6 DNS server via RA. The `%en0` zone id is what hickory's `IpAddr` parse chokes on.
+`nameserver[0]` is the router advertising itself as the IPv6 DNS server via RA. The
+`%en0` zone id is what hickory's `IpAddr` parse chokes on.
+
+On macOS this list does **not** come from `/etc/resolv.conf`: hickory's `read_system_conf`
+uses `system_conf/apple.rs`, which reads `ServerAddresses` from the System Configuration
+dynamic store (`State:/Network/Global/DNS`) and parses each entry with
+`IpAddr::from_str`. `/etc/resolv.conf` only *mirrors* the same servers — it matters
+because binstall's **salvage** path re-reads that file with the tolerant `resolv_conf`
+parser (see §3 and §5.1). The original failure, though, originates in the SC store, not
+in `/etc/resolv.conf`.
 
 ### 2.4 Both nameservers actually work
 
@@ -94,14 +102,38 @@ LAN resolver that was wrongly discarded.
 system_conf::read_system_conf().unwrap_or_else(|err| { /* public-DNS fallback */ })
 ```
 
-`read_system_conf()` is **all-or-nothing**: a single unparseable nameserver entry
+`read_system_conf()` is **all-or-nothing on macOS**: a single unparseable nameserver entry
 (here, the scoped link-local IPv6 address) makes the whole call return `Err`, taking the
 valid IPv4 nameserver down with it. The code then jumps straight to encrypted public DNS
-instead of using the still-valid system nameservers.
+(or, with the §5.1 fix, into the salvage path) instead of using the still-valid system
+nameservers.
 
-This is a known class of issue with `resolv-conf` / `hickory-resolver` and macOS RA-advertised
-link-local IPv6 DNS servers (zone-scoped addresses). Versions in tree:
-`hickory-resolver 0.26.1`, `reqwest 0.13.4`, `hyper-util 0.1.20`.
+The exact mechanism is **platform-specific**, because hickory's `read_system_conf` is a
+different implementation per OS:
+
+- **macOS (`system_conf/apple.rs`):** reads `ServerAddresses` from the System
+  Configuration dynamic store and parses each with `IpAddr::from_str`, mapping a failure
+  to `"failed to parse nameserver address: {e}"` and propagating it with `?`. So one
+  scoped entry hard-fails the **entire** read with exactly the §2.2 error
+  (`invalid IP address syntax`). This is the affected path for the reported hosts, and the
+  hard `Err` is what routes binstall into the salvage path. Verified on macOS:
+  `IpAddr::from_str("fe80::1%en0")` → `invalid IP address syntax`. Note this path never
+  touches `resolv-conf`, so scoped-address support in `resolv-conf` alone would not help
+  it — `apple.rs` would need its own `%zone` handling.
+- **Linux (`system_conf/unix.rs`):** parses via `resolv_conf::Config::parse` (fail-fast)
+  and maps nameservers with `ip.into()`. With `resolv-conf 0.7.6`, `parse` **succeeds** on
+  a scoped address (it becomes a `ScopedIp::V6(_, Some(_))`) and `ip.into(): IpAddr`
+  **silently drops the zone**, yielding a scope-0 `fe80::1`. So `read_system_conf` returns
+  `Ok` with an unusable nameserver, and binstall's `Ok` arm uses it directly — the salvage
+  path is **not** triggered. Non-fatal when a usable nameserver coexists (the dead entry
+  is merely queried and times out); for an IPv6-only LAN whose only server is link-local
+  this leaks a dead config with no public-DNS fallback. This is a latent, Linux-only edge
+  case; the reported failure is macOS-only.
+
+Both symptoms share one root: there is nowhere in hickory's `NameServerConfig` to carry a
+scope id (tracked upstream as [hickory-dns/hickory-dns#3713](https://github.com/hickory-dns/hickory-dns/issues/3713)).
+Versions in tree: `hickory-resolver 0.26.1`, `resolv-conf 0.7.6`, `reqwest 0.13.4`,
+`hyper-util 0.1.20`.
 
 ---
 

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -1,6 +1,6 @@
 # IPv6 / DNS Remediation Plan
 
-**Status:** implemented (§5.1 option 1) and verified on an affected host
+**Status:** implemented (§5.1 option 1) and verified on an affected host; salvage parser refactored to use `resolv_conf` crate (PR #2579)
 **Scope:** restore `cargo-binstall` DNS resolution on macOS hosts where the failure
 manifests as an IPv6-related error. Other (non-IPv6) failures are out of scope.
 
@@ -172,7 +172,13 @@ Two sub-options for the scoped link-local entry:
    hickory gains scope support. This gap does **not** affect hosts that have a usable
    IPv4 nameserver.
 
-Sketch (option 1):
+Implemented as `configs_from_resolv_conf` (testable, takes a parsed `resolv_conf::Config`)
+plus `salvage_system_configs` (reads the file and calls the former). Uses the `resolv_conf`
+crate for parsing — already a transitive dep via `hickory-resolver` — instead of a
+hand-rolled line scanner. Filters `ScopedIp::V6(_, Some(_))` entries (scoped link-local)
+and propagates all other resolver options (`domain`, `search`, `ndots`, `timeout`,
+`attempts`, `edns0`) so a salvaged config is fully equivalent to what hickory would have
+built from a clean parse.
 
 ```rust
 #[cfg(unix)]
@@ -182,19 +188,14 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
         Err(err) => {
             debug!("read_system_conf failed ({err}); attempting to salvage \
                     parseable nameservers from /etc/resolv.conf");
-            match build_config_from_resolv_conf() {        // strips scoped/link-local
-                Some(cfg) => Ok(cfg),
-                None => Ok(get_system_configs()),           // existing public-DNS fallback
-            }
+            Ok(salvage_system_configs().unwrap_or_else(|| {
+                debug!("No usable system nameservers; falling back to public encrypted DNS");
+                public_dns_configs()
+            }))
         }
     }
 }
 ```
-
-`build_config_from_resolv_conf()` parses nameserver lines, strips any `%zone` suffix,
-attempts `IpAddr::from_str`, and adds each successful one with
-`config.add_name_server(NameServerConfig::udp_and_tcp(SocketAddr::new(ip, 53)))`.
-Returns `None` if no nameserver parses.
 
 ### 5.2 Secondary hardening — order the public-DNS fallback for reachability — DONE
 
@@ -219,20 +220,19 @@ connector — not by suppressing AAAA in DNS.
 
 ---
 
-## 6. Tests (TDD — write first)
+## 6. Tests
 
-Pure-function target: a `parse_nameservers(resolv_conf_contents: &str) -> Vec<IpAddr>`
-(or `Vec<NameServerConfig>`) extracted so it is unit-testable without touching the OS.
+Pure-function target: `configs_from_resolv_conf(resolv_conf::Config) -> Option<(ResolverConfig, ResolverOpts)>`.
 
 1. **Scoped link-local v6 is skipped, IPv4 retained** (the core failure case):
    input two nameservers `fe80::1%en0` and a plain IPv4 address →
    output contains the IPv4 address, is non-empty.
 2. **Plain IPv6 nameserver retained:** `2606:4700:4700::1111` → kept.
-3. **All-unparseable input → `None`/empty**, so caller uses public-DNS fallback.
+3. **All-scoped input → `None`**, so caller uses public-DNS fallback.
 4. **Mixed garbage tolerated:** comments, `search` lines, malformed entries ignored
-   without failing the whole parse.
-5. (If implementing 5.1-option-2) **zone id parsed into scope_id** for a link-local
-   entry.
+   without failing the whole parse (handled by `resolv_conf::Config::parse`).
+5. **Resolver options extracted:** `ndots`, `timeout`, `attempts`, `edns0` match
+   the values in the `options` line.
 
 Integration-level (best-effort, network-gated, not in CI default): with hickory enabled,
 a resolver built from a config containing only the salvaged IPv4 nameserver resolves
@@ -244,7 +244,7 @@ a resolver built from a config containing only the salvaged IPv4 nameserver reso
 
 - [x] Reproduce pre-fix: `cargo-binstall binstall ripgrep --dry-run --no-confirm
       --log-level debug` → `dns error` (baseline confirmed).
-- [x] Unit tests in §6 pass (5 tests, `--features hickory-dns`).
+- [x] Unit tests in §6 pass (6 tests, `--features hickory-dns`).
 - [x] Post-fix, same command resolves and completes the dry-run with the scoped
       link-local nameserver still present in `scutil --dns` (i.e. without workaround §4a).
       Log shows `Salvaged 1 usable system nameserver(s)` then successful fetches.
@@ -262,11 +262,11 @@ possible with hickory-resolver 0.26.1, see §5.1 for the dependency limitation a
 ## 8. Files
 
 - `crates/binstalk-downloader/src/remote/resolver.rs` — `get_configs` (unix),
-  `get_system_configs`, new `parse_nameservers` / `build_config_from_resolv_conf`.
-- Tests: same crate, `#[cfg(test)]` module.
-- Note: an unrelated pre-existing `unused_imports` warning (`QUAD9`, `ConnectionConfig`,
-  `NameServerConfig`) exists after the quad9 fallback removal; tidy while in the file but
-  it is not part of this fix.
+  `configs_from_resolv_conf`, `salvage_system_configs`.
+- `crates/binstalk-downloader/Cargo.toml` — `resolv-conf = "0.7.6"` added as a
+  unix-only optional dep, enabled by the `hickory-dns` feature (already a transitive dep,
+  so no new binary weight).
+- Tests: same crate, `#[cfg(all(test, unix))]` module.
 
 ---
 
@@ -325,9 +325,9 @@ In increasing order of cost / decreasing preference:
 `hickory_resolver::system_conf::read_system_conf()` is all-or-nothing: one unparseable
 `nameserver` entry fails the entire load. That strictness is what forced our §5.1 salvage
 workaround. An upstream fix to skip/tolerate unparseable entries (or to parse scoped
-addresses) would make `parse_nameservers` / `salvage_system_configs` redundant — they
-could be removed once a fixed hickory is in `Cargo.lock`. → optional **bug report to
-hickory**; our workaround is harmless until then.
+addresses) would make `salvage_system_configs` redundant — it could be removed once a
+fixed hickory is in `Cargo.lock`. → optional **bug report to hickory**; our workaround
+is harmless until then.
 
 ### 9.5 Action items outside this repo
 

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -356,7 +356,8 @@ In increasing order of cost / decreasing preference:
    `scope_id` (or accept `SocketAddrV6`) through `NameServerConfig` and connection setup.
    Once available, adopt it here by parsing the `%zone` (numeric, or interface name via
    `libc::if_nametoindex`) and building scoped name servers. This is the correct fix and
-   the only one that keeps hickory in the loop. → **File a hickory feature request.**
+   the only one that keeps hickory in the loop. → **Filed:**
+   [hickory-dns/hickory-dns#3713](https://github.com/hickory-dns/hickory-dns/issues/3713).
 2. **Supported workaround (no upstream needed):** affected users build/install with
    `--no-default-features` so the `trust-dns`/`hickory-dns` feature is off and binstall
    uses reqwest's system resolver (`getaddrinfo`), which handles `%zone` correctly.
@@ -375,7 +376,8 @@ is harmless until then.
 
 ### 9.5 Action items outside this repo
 
-- [ ] Open hickory feature request: scoped/link-local nameserver support (`scope_id`). (§9.3.1)
+- [x] Open hickory feature request: scoped/link-local nameserver support (`scope_id`). (§9.3.1)
+      → [hickory-dns/hickory-dns#3713](https://github.com/hickory-dns/hickory-dns/issues/3713)
 - [ ] (Optional) Open hickory bug: `read_system_conf` should not fail wholesale on one
       bad `nameserver` line. (§9.4)
 - [ ] Add user-facing note: on IPv6-only LANs with only a link-local resolver, install

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -136,12 +136,14 @@ different implementation per OS:
 - **Linux (`system_conf/unix.rs`):** parses via `resolv_conf::Config::parse` (fail-fast)
   and maps nameservers with `ip.into()`. With `resolv-conf 0.7.6`, `parse` **succeeds** on
   a scoped address (it becomes a `ScopedIp::V6(_, Some(_))`) and `ip.into(): IpAddr`
-  **silently drops the zone**, yielding a scope-0 `fe80::1`. So `read_system_conf` returns
-  `Ok` with an unusable nameserver, and binstall's `Ok` arm uses it directly — the salvage
-  path is **not** triggered. Non-fatal when a usable nameserver coexists (the dead entry
-  is merely queried and times out); for an IPv6-only LAN whose only server is link-local
-  this leaks a dead config with no public-DNS fallback. This is a latent, Linux-only edge
-  case; the reported failure is macOS-only.
+  **silently drops the zone**, yielding a scope-0 `fe80::1`. So hickory's
+  `read_system_conf` returns `Ok` with an unusable nameserver. binstall **no longer calls
+  it on non-apple unix** (see §5.1): it parses `/etc/resolv.conf` directly through
+  `read_system_configs`, which filters the scoped entry out rather than emitting a dead
+  scope-0 server. The earlier Linux edge case (a dead link-local entry leaking through the
+  `Ok` arm) is therefore avoided; an IPv6-only LAN whose only server is link-local still
+  has no usable nameserver and falls back to public DNS. The reported failure is
+  macOS-only.
 - **Windows — cannot reproduce the wholesale failure.** binstall does not even reach
   hickory's `read_system_conf` on the normal Windows path: `get_configs()` (`#[cfg(windows)]`)
   reads `netdev::get_default_interface().dns_servers` (a `Vec<IpAddr>`) and adds each server
@@ -233,13 +235,13 @@ Two sub-options for the scoped link-local entry:
    IPv4 nameserver.
 
 Implemented as `configs_from_resolv_conf` (testable, takes a parsed `resolv_conf::Config`)
-plus `salvage_system_configs` (reads the file and calls the former). Uses the `resolv_conf`
-crate for parsing — already a transitive dep via `hickory-resolver` — instead of a
-hand-rolled line scanner. Filters `ScopedIp::V6(_, Some(_))` entries (scoped link-local)
-and propagates all other resolver options (`domain`, `search`, `ndots`, `timeout`,
-`attempts`, `edns0`) so a salvaged config carries the same options hickory would have
-built from a clean parse. The one intentional difference is the per-nameserver transport
-set, described in §5.1.1.
+plus `read_system_configs` (reads `/etc/resolv.conf` and calls the former). Uses the
+`resolv_conf` crate for parsing — already a transitive dep via `hickory-resolver` — instead
+of a hand-rolled line scanner. Filters `ScopedIp::V6(_, Some(_))` entries (scoped
+link-local) and propagates all other resolver options (`domain`, `search`, `ndots`,
+`timeout`, `attempts`, `edns0`) so a salvaged config carries the same options hickory would
+have built from a clean parse. The one intentional difference is the per-nameserver
+transport set, described in §5.1.1.
 
 Important correction after the initial refactor: `resolv_conf::Config::parse()` is
 fail-fast, so using it directly reintroduced an all-or-nothing failure mode for malformed
@@ -248,20 +250,47 @@ build a resolver config from the partial parse result, otherwise unrelated malfo
 or a bad `nameserver` entry defeat the salvage path and incorrectly force the public-DNS
 fallback.
 
+**The unix `get_configs` is split by `target_vendor`**, because hickory's
+`read_system_conf` source differs by platform (§3) and the two paths want different
+behaviour:
+
+- **apple** — `read_system_conf` (`apple.rs`) reads the **authoritative** System
+  Configuration dynamic store, *not* `/etc/resolv.conf`. So keep it as the primary source
+  and only fall through to the `read_system_configs` salvage parser (which re-reads the
+  `/etc/resolv.conf` mirror) when the all-or-nothing read hard-fails on a scoped entry.
+- **non-apple unix** — hickory's `read_system_conf` (`unix.rs`) reads the same
+  `/etc/resolv.conf` our parser does, but via fail-fast `parse` + an `ip.into()` that
+  silently drops IPv6 zone ids (§3). Our `read_system_configs` is therefore strictly
+  better and is used as the **sole primary path**, with no hickory call to fall back from.
+
+This is a deliberate divergence from earlier drafts of this section, which called
+`read_system_conf` first on *all* `#[cfg(unix)]`. On Linux that first call only ever
+returned a clean parse (our parser handles the rest) or an `Ok` carrying a zone-stripped
+dead nameserver, so it added nothing; restricting it to apple keeps the authoritative SC
+store on macOS while letting Linux use the tolerant parser unconditionally.
+
 ```rust
-#[cfg(unix)]
+#[cfg(target_vendor = "apple")]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
-    match system_conf::read_system_conf() {
-        Ok(cfg) => Ok(cfg),
-        Err(err) => {
-            debug!("read_system_conf failed ({err}); attempting to salvage \
-                    parseable nameservers from /etc/resolv.conf");
-            Ok(salvage_system_configs().unwrap_or_else(|| {
-                debug!("No usable system nameservers; falling back to public encrypted DNS");
-                public_dns_configs()
-            }))
-        }
+    // apple.rs reads the authoritative System Configuration store, so prefer it.
+    if let Ok(configs) = system_conf::read_system_conf() {
+        return Ok(configs);
     }
+    debug!("read_system_conf failed; salvaging parseable nameservers from /etc/resolv.conf");
+    Ok(read_system_configs().unwrap_or_else(|| {
+        debug!("No usable system nameservers; falling back to public encrypted DNS");
+        public_dns_configs()
+    }))
+}
+
+#[cfg(all(unix, not(target_vendor = "apple")))]
+fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
+    // unix.rs reads the same /etc/resolv.conf but drops IPv6 zones, so our parser is the
+    // sole primary path here.
+    Ok(read_system_configs().unwrap_or_else(|| {
+        debug!("No usable system nameservers; falling back to public encrypted DNS");
+        public_dns_configs()
+    }))
 }
 ```
 
@@ -350,9 +379,9 @@ a resolver built from a config containing only the salvaged IPv4 nameserver reso
       nameservers carry opportunistic-encryption transports.
 - [x] Post-fix, same command resolves and completes the dry-run with the scoped
       link-local nameserver still present in `scutil --dns` (i.e. without workaround §4a).
-      Log shows `Salvaged 1 usable system nameserver(s)` then successful fetches.
-- [x] No behavioural change on a host whose `read_system_conf()` already succeeds
-      (the `Ok` arm is untouched).
+      Log shows `Loaded 1 usable system nameserver(s)` then successful fetches.
+- [x] No behavioural change on an apple host whose `read_system_conf()` already succeeds
+      (the apple `get_configs` keeps its result untouched).
 - [x] `ip_strategy` remains `Ipv4AndIpv6`.
 
 Implemented: §5.1 option 1 (skip scoped entries), §5.1.1 (opportunistic encryption for
@@ -365,8 +394,8 @@ possible with hickory-resolver 0.26.1, see §5.1 for the dependency limitation a
 
 ## 8. Files
 
-- `crates/binstalk-downloader/src/remote/resolver.rs` — `get_configs` (unix),
-  `configs_from_resolv_conf`, `salvage_system_configs`.
+- `crates/binstalk-downloader/src/remote/resolver.rs` — `get_configs` (apple and
+  non-apple unix variants), `configs_from_resolv_conf`, `read_system_configs`.
 - `crates/binstalk-downloader/Cargo.toml` — `resolv-conf = "0.7.6"` added as a
   unix-only optional dep, enabled by the `hickory-dns` feature (already a transitive dep,
   so no new binary weight).
@@ -430,8 +459,8 @@ In increasing order of cost / decreasing preference:
 `hickory_resolver::system_conf::read_system_conf()` is all-or-nothing: one unparseable
 `nameserver` entry fails the entire load. That strictness is what forced our §5.1 salvage
 workaround. An upstream fix to skip/tolerate unparseable entries (or to parse scoped
-addresses) would make `salvage_system_configs` redundant — it could be removed once a
-fixed hickory is in `Cargo.lock`. → optional **bug report to hickory**; our workaround
+addresses) would make `read_system_configs` redundant on apple — it could be removed once
+a fixed hickory is in `Cargo.lock`. → optional **bug report to hickory**; our workaround
 is harmless until then.
 
 ### 9.5 Action items outside this repo

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -1,6 +1,6 @@
 # IPv6 / DNS Remediation Plan
 
-**Status:** implemented (§5.1 option 1) and verified on an affected host; salvage parser refactored to use `resolv_conf` crate (PR #2579), with a follow-up fix to retain best-effort salvage on malformed `resolv.conf` lines
+**Status:** implemented (§5.1 option 1) and verified on an affected host; salvage parser refactored to use `resolv_conf` crate (PR #2579), with follow-up fixes to retain best-effort salvage on malformed `resolv.conf` lines, to log all (not just the first) parse errors at debug, and to apply opportunistic encryption to salvaged nameservers (§5.1.1)
 **Scope:** restore `cargo-binstall` DNS resolution on macOS hosts where the failure
 manifests as an IPv6-related error. Other (non-IPv6) failures are out of scope.
 
@@ -177,8 +177,9 @@ plus `salvage_system_configs` (reads the file and calls the former). Uses the `r
 crate for parsing — already a transitive dep via `hickory-resolver` — instead of a
 hand-rolled line scanner. Filters `ScopedIp::V6(_, Some(_))` entries (scoped link-local)
 and propagates all other resolver options (`domain`, `search`, `ndots`, `timeout`,
-`attempts`, `edns0`) so a salvaged config is fully equivalent to what hickory would have
-built from a clean parse.
+`attempts`, `edns0`) so a salvaged config carries the same options hickory would have
+built from a clean parse. The one intentional difference is the per-nameserver transport
+set, described in §5.1.1.
 
 Important correction after the initial refactor: `resolv_conf::Config::parse()` is
 fail-fast, so using it directly reintroduced an all-or-nothing failure mode for malformed
@@ -203,6 +204,32 @@ fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
     }
 }
 ```
+
+### 5.1.1 Salvaged nameservers use opportunistic encryption — DONE
+
+Salvaged nameservers are built with `NameServerConfig::opportunistic_encryption(ip)`
+rather than `udp_and_tcp(ip)`. This attaches DNS-over-TLS and DNS-over-QUIC connections
+alongside the plaintext UDP/TCP ones, so a salvaged resolver opportunistically upgrades to
+encrypted DNS where the server supports it (many ISP resolvers do) and silently stays on
+plaintext where it does not. It is the same privacy preference §5.2 applies to the
+public-DNS fallback, extended to system nameservers.
+
+Two properties of hickory's `opportunistic_encryption` matter here:
+
+- **Connection order is plaintext-first** (`udp`, `tcp`, then `tls`, `quic`), the inverse
+  of the public-DNS fallback's encrypted-first ordering in §5.2. That is deliberate:
+  salvaged servers are typically the LAN/ISP resolver and are reachable over plaintext, so
+  there is no firewall-traversal problem to solve — plaintext-first keeps the common path
+  fast and treats encryption as a best-effort upgrade.
+- **TLS/QUIC peer certificates are not verified**, per RFC 9539 §4.6.3.4 (opportunistic
+  encryption uses the nameserver IP as the TLS server name; there is no PKI name to verify
+  against). This is the spec-mandated behaviour for opportunistic encryption and does not
+  weaken the plaintext baseline.
+
+This is a deliberate divergence from what a clean `read_system_conf()` parse would
+produce (plain UDP/TCP only); see the note in §5.1. Requires hickory's `__tls`/`__quic`
+features, which are already enabled in this workspace. Covered by the
+`salvaged_nameservers_use_opportunistic_encryption` unit test.
 
 ### 5.2 Secondary hardening — order the public-DNS fallback for reachability — DONE
 
@@ -240,6 +267,13 @@ Pure-function target: `configs_from_resolv_conf(resolv_conf::Config) -> Option<(
    without failing the whole parse (handled by `resolv_conf::Config::parse_with_errors`).
 5. **Resolver options extracted:** `ndots`, `timeout`, `attempts`, `edns0` match
    the values in the `options` line.
+6. **Salvaged nameservers use opportunistic encryption** (§5.1.1): a salvaged config's
+   per-nameserver transport set matches `NameServerConfig::opportunistic_encryption`
+   (plaintext UDP/TCP plus DoT/DoQ), confirming the wiring survives
+   `ResolverConfig::from_parts`.
+7. **Public-DNS fallback transport ordering** (§5.2):
+   `public_dns_fallback_orders_transports_for_reachability` asserts the fallback leads
+   with DoT and ends with plain DNS, with an aggressive per-query timeout.
 
 Integration-level (best-effort, network-gated, not in CI default): with hickory enabled,
 a resolver built from a config containing only the salvaged IPv4 nameserver resolves
@@ -251,8 +285,9 @@ a resolver built from a config containing only the salvaged IPv4 nameserver reso
 
 - [x] Reproduce pre-fix: `cargo-binstall binstall ripgrep --dry-run --no-confirm
       --log-level debug` → `dns error` (baseline confirmed).
-- [x] Unit tests in §6 pass (7 tests, `--features hickory-dns`), including a regression
-      test proving malformed lines do not defeat salvage.
+- [x] Unit tests in §6 pass (9 tests, `--features hickory-dns`), including a regression
+      test proving malformed lines do not defeat salvage and one asserting salvaged
+      nameservers carry opportunistic-encryption transports.
 - [x] Post-fix, same command resolves and completes the dry-run with the scoped
       link-local nameserver still present in `scutil --dns` (i.e. without workaround §4a).
       Log shows `Salvaged 1 usable system nameserver(s)` then successful fetches.
@@ -260,8 +295,9 @@ a resolver built from a config containing only the salvaged IPv4 nameserver reso
       (the `Ok` arm is untouched).
 - [x] `ip_strategy` remains `Ipv4AndIpv6`.
 
-Implemented: §5.1 option 1 (skip scoped entries) and §5.2 (public-DNS fallback transport
-ordering). Blocked: §5.1 option 2 (honour link-local servers via scope id) — not
+Implemented: §5.1 option 1 (skip scoped entries), §5.1.1 (opportunistic encryption for
+salvaged nameservers) and §5.2 (public-DNS fallback transport ordering). Blocked: §5.1
+option 2 (honour link-local servers via scope id) — not
 possible with hickory-resolver 0.26.1, see §5.1 for the dependency limitation and the
 `--no-default-features` workaround for the IPv6-only-LAN case.
 

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -1,6 +1,6 @@
 # IPv6 / DNS Remediation Plan
 
-**Status:** implemented (§5.1 option 1) and verified on an affected host; salvage parser refactored to use `resolv_conf` crate (PR #2579)
+**Status:** implemented (§5.1 option 1) and verified on an affected host; salvage parser refactored to use `resolv_conf` crate (PR #2579), with a follow-up fix to retain best-effort salvage on malformed `resolv.conf` lines
 **Scope:** restore `cargo-binstall` DNS resolution on macOS hosts where the failure
 manifests as an IPv6-related error. Other (non-IPv6) failures are out of scope.
 
@@ -180,6 +180,13 @@ and propagates all other resolver options (`domain`, `search`, `ndots`, `timeout
 `attempts`, `edns0`) so a salvaged config is fully equivalent to what hickory would have
 built from a clean parse.
 
+Important correction after the initial refactor: `resolv_conf::Config::parse()` is
+fail-fast, so using it directly reintroduced an all-or-nothing failure mode for malformed
+`resolv.conf` content. The salvage path must use `Config::parse_with_errors()` and then
+build a resolver config from the partial parse result, otherwise unrelated malformed lines
+or a bad `nameserver` entry defeat the salvage path and incorrectly force the public-DNS
+fallback.
+
 ```rust
 #[cfg(unix)]
 fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
@@ -230,7 +237,7 @@ Pure-function target: `configs_from_resolv_conf(resolv_conf::Config) -> Option<(
 2. **Plain IPv6 nameserver retained:** `2606:4700:4700::1111` → kept.
 3. **All-scoped input → `None`**, so caller uses public-DNS fallback.
 4. **Mixed garbage tolerated:** comments, `search` lines, malformed entries ignored
-   without failing the whole parse (handled by `resolv_conf::Config::parse`).
+   without failing the whole parse (handled by `resolv_conf::Config::parse_with_errors`).
 5. **Resolver options extracted:** `ndots`, `timeout`, `attempts`, `edns0` match
    the values in the `options` line.
 
@@ -244,7 +251,8 @@ a resolver built from a config containing only the salvaged IPv4 nameserver reso
 
 - [x] Reproduce pre-fix: `cargo-binstall binstall ripgrep --dry-run --no-confirm
       --log-level debug` → `dns error` (baseline confirmed).
-- [x] Unit tests in §6 pass (6 tests, `--features hickory-dns`).
+- [x] Unit tests in §6 pass (7 tests, `--features hickory-dns`), including a regression
+      test proving malformed lines do not defeat salvage.
 - [x] Post-fix, same command resolves and completes the dry-run with the scoped
       link-local nameserver still present in `scutil --dns` (i.e. without workaround §4a).
       Log shows `Salvaged 1 usable system nameserver(s)` then successful fetches.

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -16,8 +16,9 @@ connectivity — IPv6 routing on such hosts is healthy. The actual cause is:
 > identifier** (e.g. `fe80::1%en0`). `hickory-resolver`'s
 > `system_conf::read_system_conf()` cannot parse the `%en0` zone suffix, fails the
 > **entire** system-config load, and discards the working IPv4 nameserver alongside it.
-> binstall then falls back to encrypted public DNS (Cloudflare/Google over
-> QUIC/H3/TLS/HTTPS), which restrictive networks do not reliably allow, so resolution
+> binstall then falls back to public DNS (Cloudflare/Google), preferring encrypted
+> transports (DoT/DoH over TCP, then DoQ/DoH3 over UDP) and dropping to **plain UDP/TCP**
+> as a last resort — none of which restrictive networks reliably allow, so resolution
 > fails completely.
 
 A previously-considered change — switching `LookupIpStrategy::Ipv4AndIpv6` →
@@ -75,6 +76,18 @@ dynamic store (`State:/Network/Global/DNS`) and parses each entry with
 because binstall's **salvage** path re-reads that file with the tolerant `resolv_conf`
 parser (see §3 and §5.1). The original failure, though, originates in the SC store, not
 in `/etc/resolv.conf`.
+
+> **Why not `unix.rs` / `/etc/resolv.conf` on macOS?** `system_conf::read_system_conf` is
+> picked per target in `hickory-resolver 0.26.1`'s `src/system_conf/mod.rs`. The
+> `/etc/resolv.conf` reader (`unix.rs`) is gated
+> `#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]`, so apple
+> targets are *excluded* from it and instead compile `apple.rs`
+> (`#[cfg(target_vendor = "apple")]`). The `apple.rs` path is real in this workspace, not
+> theoretical: enabling hickory's `system-config` feature pulls `system-configuration` as
+> an apple-only dependency (present in `Cargo.lock`), which `apple.rs` uses to read the SC
+> dynamic store. The verbatim §2.2 error string (`failed to parse nameserver address: …`)
+> is produced only by `apple.rs`. (docs.rs "latest" may show a different `unix.rs`; the
+> pinned `0.26.1` in this tree is what determines the actual path.)
 
 ### 2.4 Both nameservers actually work
 

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -1,0 +1,338 @@
+# IPv6 / DNS Remediation Plan
+
+**Status:** implemented (§5.1 option 1) and verified on an affected host
+**Scope:** restore `cargo-binstall` DNS resolution on macOS hosts where the failure
+manifests as an IPv6-related error. Other (non-IPv6) failures are out of scope.
+
+---
+
+## 1. Executive summary
+
+On affected hosts `cargo-binstall` fails with a fatal `dns error` for *every* request
+(e.g. `https://index.crates.io/config.json`). The cause is **not** broken IPv6
+connectivity — IPv6 routing on such hosts is healthy. The actual cause is:
+
+> The system's **primary DNS nameserver is a link-local IPv6 address with a zone
+> identifier** (e.g. `fe80::1%en0`). `hickory-resolver`'s
+> `system_conf::read_system_conf()` cannot parse the `%en0` zone suffix, fails the
+> **entire** system-config load, and discards the working IPv4 nameserver alongside it.
+> binstall then falls back to encrypted public DNS (Cloudflare/Google over
+> QUIC/H3/TLS/HTTPS), which restrictive networks do not reliably allow, so resolution
+> fails completely.
+
+A previously-considered change — switching `LookupIpStrategy::Ipv4AndIpv6` →
+`Ipv4thenIpv6` ("prefer IPv4 to avoid broken-IPv6 hangs") — **does not address this**:
+`ip_strategy` only selects A vs AAAA records for the *target host* after the resolver is
+already built; it has no effect on which *nameserver* is used or on the
+`read_system_conf()` parse failure. That approach was not pursued.
+
+---
+
+## 2. Evidence
+
+### 2.1 OS-level IPv6 is healthy (rules out the "broken IPv6" theory)
+
+Direct per-family TCP connects from an affected host succeed for both IPv4 and IPv6
+(e.g. `cloudflare.com`, `google.com` connect over v6 and v4 with comparable latency;
+`github.com` has no AAAA at the apex, which is expected). A default IPv6 route exists
+(`gateway fe80::1%en0`, interface `en0`). IPv6 is not only present, it is as fast as
+IPv4 — there is no broken-IPv6 hang to fix.
+
+### 2.2 The real failure, from binstall debug logs
+
+```
+new_resolver: Using system DNS resolver configuration
+new_resolver: hickory-dns: failed to load system DNS configuration; falling back to
+  cloudflare and then google: Msg("failed to parse nameserver address: invalid IP
+  address syntax")
+new_resolver: Resolver configuration complete
+INFO  Received timeout error from reqwest. Delay future request by 200ms   (x3)
+ERROR Fatal error:
+  │ error sending request for url (https://index.crates.io/config.json)
+  ├─▶ client error (Connect)
+  ├─▶ dns error
+```
+
+So: system config load fails on a parse error → fallback to public encrypted DNS →
+that times out → fatal `dns error`.
+
+### 2.3 The offending nameserver
+
+A typical affected configuration lists two nameservers:
+
+```
+nameserver[0] : fe80::1%en0      <-- link-local IPv6 + zone id
+nameserver[1] : <LAN IPv4>       <-- plain IPv4, fine
+```
+
+`/etc/resolv.conf` mirrors this; `nameserver[0]` is the router advertising itself as the
+IPv6 DNS server via RA. The `%en0` zone id is what hickory's `IpAddr` parse chokes on.
+
+### 2.4 Both nameservers actually work
+
+Querying either nameserver directly resolves `index.crates.io` correctly — the IPv4
+server via plain DNS, and the link-local v6 server via the OS resolver (which honours the
+scope id). So the salvage path is real: keeping just the parseable IPv4 nameserver
+restores full DNS. (The link-local v6 server is also usable if handled with its scope
+id.)
+
+### 2.5 Why the fallback didn't save it
+
+The fallback path (`get_system_configs`) builds Cloudflare/Google resolvers ordered
+QUIC → H3 → TLS → HTTPS → UDP/TCP, with a 750 ms timeout. On restrictive networks the
+encrypted transports are not reliably reachable (UDP/853 QUIC in particular), so the
+fallback times out before succeeding. The fallback is a poor substitute for the working
+LAN resolver that was wrongly discarded.
+
+---
+
+## 3. Root cause (precise)
+
+`crates/binstalk-downloader/src/remote/resolver.rs`, `get_system_configs()`:
+
+```rust
+system_conf::read_system_conf().unwrap_or_else(|err| { /* public-DNS fallback */ })
+```
+
+`read_system_conf()` is **all-or-nothing**: a single unparseable nameserver entry
+(here, the scoped link-local IPv6 address) makes the whole call return `Err`, taking the
+valid IPv4 nameserver down with it. The code then jumps straight to encrypted public DNS
+instead of using the still-valid system nameservers.
+
+This is a known class of issue with `resolv-conf` / `hickory-resolver` and macOS RA-advertised
+link-local IPv6 DNS servers (zone-scoped addresses). Versions in tree:
+`hickory-resolver 0.26.1`, `reqwest 0.13.4`, `hyper-util 0.1.20`.
+
+---
+
+## 4. Immediate workaround (unblock an affected host without a rebuild)
+
+Any **one** of the following restores binstall immediately; (a) and (b) need no rebuild:
+
+**(a) Pin a non-link-local DNS server on the active service (e.g. Wi-Fi / en0).**
+This removes the unparseable entry from the resolver's view:
+```sh
+sudo networksetup -setdnsservers Wi-Fi <LAN-IPv4-resolver>
+# revert later with: sudo networksetup -setdnsservers Wi-Fi empty
+```
+
+**(b) Bypass hickory and use the OS resolver** (getaddrinfo handles scoped addresses
+fine). Build/install without the default `trust-dns` feature:
+```sh
+cargo install cargo-binstall --no-default-features \
+  --features static,rustls,fancy-no-backtrace,zstd-thin,git
+```
+
+**(c)** Use a local binary built from a branch carrying the §5 fix.
+
+Quickest unblock: **(a)** — one command, instantly verifiable with
+`cargo-binstall binstall ripgrep --dry-run --no-confirm`.
+
+---
+
+## 5. Proper fix (code change in this repo)
+
+Goal: never discard a usable system DNS config because one nameserver entry is
+unparseable. Make the unix system-config path resilient to scoped/link-local
+nameservers.
+
+### 5.1 Preferred approach — salvage parseable system nameservers
+
+In `get_system_configs()` (the `#[cfg(unix)]` path), when `read_system_conf()` fails (or
+unconditionally on macOS), read `/etc/resolv.conf` / `scutil` ourselves and build a
+`ResolverConfig` from the nameserver entries we *can* use, only falling back to public
+encrypted DNS when **zero** usable nameservers remain.
+
+Two sub-options for the scoped link-local entry:
+
+1. **Skip it, keep the rest.** Drop the `fe80::…%en0` entry, keep the IPv4 nameserver.
+   Minimal, robust, sufficient (verified working in §2.4). Recommended first cut.
+2. **Honour it. — BLOCKED by hickory-resolver 0.26.1, not implementable.**
+   The intent was to parse the zone id into a `scope_id` and build a
+   `SocketAddrV6::new(addr, 53, 0, scope_id)` name server so the link-local resolver is
+   actually used (for IPv6-only LANs whose only advertised resolver is link-local).
+   This cannot be done with the current dependency:
+   - `hickory_resolver::config::NameServerConfig.ip` is a bare `std::net::IpAddr`.
+   - `std::net::Ipv6Addr` has **no** scope/zone field — a scope only exists on
+     `SocketAddrV6` — and there is no `scope_id` anywhere in hickory-resolver 0.26.1
+     (the current major). The remote `SocketAddr` is built from `config.ip` + a default
+     port; `ConnectionConfig.bind_addr` is the *local* bind, not the destination scope.
+   - So a link-local nameserver can only be stored as `fe80::…` with scope 0, and a
+     connect to it fails (`EINVAL`/no route) on any multi-interface host.
+
+   Realistic alternatives for the IPv6-only-LAN case, none cheap:
+   (a) upstream hickory support for scoped nameserver addresses, then adopt it;
+   (b) resolve via the OS (`getaddrinfo`) for this case — i.e. document that affected
+       users build with `--no-default-features` (drops `trust-dns`, uses reqwest's
+       system resolver, which handles `%zone` correctly);
+   (c) a bespoke libc `getaddrinfo` fallback path inside `TrustDnsResolver` — significant
+       unsafe/unix code for an uncommon configuration.
+
+   Recommendation: document (b) as the supported workaround; revisit (a) if/when
+   hickory gains scope support. This gap does **not** affect hosts that have a usable
+   IPv4 nameserver.
+
+Sketch (option 1):
+
+```rust
+#[cfg(unix)]
+fn get_configs() -> Result<(ResolverConfig, ResolverOpts), BoxError> {
+    match system_conf::read_system_conf() {
+        Ok(cfg) => Ok(cfg),
+        Err(err) => {
+            debug!("read_system_conf failed ({err}); attempting to salvage \
+                    parseable nameservers from /etc/resolv.conf");
+            match build_config_from_resolv_conf() {        // strips scoped/link-local
+                Some(cfg) => Ok(cfg),
+                None => Ok(get_system_configs()),           // existing public-DNS fallback
+            }
+        }
+    }
+}
+```
+
+`build_config_from_resolv_conf()` parses nameserver lines, strips any `%zone` suffix,
+attempts `IpAddr::from_str`, and adds each successful one with
+`config.add_name_server(NameServerConfig::udp_and_tcp(SocketAddr::new(ip, 53)))`.
+Returns `None` if no nameserver parses.
+
+### 5.2 Secondary hardening — order the public-DNS fallback for reachability — DONE
+
+Implemented. hickory queries fallback servers in config order, two at a time
+(`ServerOrderingStrategy::QueryStatistics` with `num_concurrent_reqs == 2`), until it has
+RTT statistics — so the cold-start config order decides which transports are attempted
+first. The old order led with DoQ/DoH3 (UDP-based, frequently firewalled) and placed
+plain DNS last. Reordered to: DoT (853/tcp) → DoH (443/tcp) → DoQ → DoH3 → plain UDP/TCP.
+The TCP-based encrypted transports traverse UDP-blocking networks, encrypted DNS is still
+preferred for privacy, and plain DNS remains the universal last resort. Per-query timeout
+stays 750ms so a blocked transport fails fast. Covered by the
+`public_dns_fallback_orders_transports_for_reachability` unit test.
+
+### 5.3 Leave `ip_strategy` alone
+
+Keep `LookupIpStrategy::Ipv4AndIpv6`. The reverted `Ipv4thenIpv6` change:
+- does not touch this bug,
+- regresses IPv6-only / NAT64+DNS64 networks (returns A records the client can't route).
+If broken-IPv6 *connect* hangs ever become a real, reproduced problem, address them at
+the connection layer via Happy Eyeballs (RFC 8305) tuning in the reqwest/hyper-util
+connector — not by suppressing AAAA in DNS.
+
+---
+
+## 6. Tests (TDD — write first)
+
+Pure-function target: a `parse_nameservers(resolv_conf_contents: &str) -> Vec<IpAddr>`
+(or `Vec<NameServerConfig>`) extracted so it is unit-testable without touching the OS.
+
+1. **Scoped link-local v6 is skipped, IPv4 retained** (the core failure case):
+   input two nameservers `fe80::1%en0` and a plain IPv4 address →
+   output contains the IPv4 address, is non-empty.
+2. **Plain IPv6 nameserver retained:** `2606:4700:4700::1111` → kept.
+3. **All-unparseable input → `None`/empty**, so caller uses public-DNS fallback.
+4. **Mixed garbage tolerated:** comments, `search` lines, malformed entries ignored
+   without failing the whole parse.
+5. (If implementing 5.1-option-2) **zone id parsed into scope_id** for a link-local
+   entry.
+
+Integration-level (best-effort, network-gated, not in CI default): with hickory enabled,
+a resolver built from a config containing only the salvaged IPv4 nameserver resolves
+`index.crates.io` successfully.
+
+---
+
+## 7. Verification checklist
+
+- [x] Reproduce pre-fix: `cargo-binstall binstall ripgrep --dry-run --no-confirm
+      --log-level debug` → `dns error` (baseline confirmed).
+- [x] Unit tests in §6 pass (5 tests, `--features hickory-dns`).
+- [x] Post-fix, same command resolves and completes the dry-run with the scoped
+      link-local nameserver still present in `scutil --dns` (i.e. without workaround §4a).
+      Log shows `Salvaged 1 usable system nameserver(s)` then successful fetches.
+- [x] No behavioural change on a host whose `read_system_conf()` already succeeds
+      (the `Ok` arm is untouched).
+- [x] `ip_strategy` remains `Ipv4AndIpv6`.
+
+Implemented: §5.1 option 1 (skip scoped entries) and §5.2 (public-DNS fallback transport
+ordering). Blocked: §5.1 option 2 (honour link-local servers via scope id) — not
+possible with hickory-resolver 0.26.1, see §5.1 for the dependency limitation and the
+`--no-default-features` workaround for the IPv6-only-LAN case.
+
+---
+
+## 8. Files
+
+- `crates/binstalk-downloader/src/remote/resolver.rs` — `get_configs` (unix),
+  `get_system_configs`, new `parse_nameservers` / `build_config_from_resolv_conf`.
+- Tests: same crate, `#[cfg(test)]` module.
+- Note: an unrelated pre-existing `unused_imports` warning (`QUAD9`, `ConnectionConfig`,
+  `NameServerConfig`) exists after the quad9 fallback removal; tidy while in the file but
+  it is not part of this fix.
+
+---
+
+## 9. Known limitations & upstream work required
+
+### 9.1 What is fully resolved (in this repo)
+
+- The originally-reported failure: a scoped link-local IPv6 nameserver
+  (`fe80::…%en0`) crashing `read_system_conf()` and taking the usable IPv4 nameserver
+  with it. Fixed by salvaging parseable nameservers (§5.1 option 1), verified on an
+  affected host.
+- Fragile public-DNS fallback ordering. Fixed by leading with firewall-traversable
+  encrypted transports (§5.2).
+
+Both fixes live in `crates/binstalk-downloader`, which is a **first-party** member of
+this workspace (`repository = cargo-bins/cargo-binstall`, consumed by path) — i.e. this
+repo *is* its upstream. There is no separate downstream/vendor project to notify.
+
+### 9.2 What cannot be completed here, and why
+
+**IPv6-only LAN whose only advertised resolver is link-local.** If a network provides a
+single link-local IPv6 DNS server (e.g. `fe80::1%en0`) and **no** IPv4 / global-scope
+nameserver, binstall's bundled hickory resolver cannot use it. Our salvage code skips
+the scoped entry (it has no other choice), finds nothing else usable, and falls back to
+public DNS — which fails if that network also blocks outbound public resolvers.
+
+Root limitation is in the third-party dependency, **not fixable in this repo**:
+
+- `hickory_resolver::config::NameServerConfig.ip` is a bare `std::net::IpAddr`.
+- `std::net::Ipv6Addr` carries no zone/scope; a scope only exists on `SocketAddrV6`.
+  There is no `scope_id` anywhere in `hickory-resolver` 0.26.1 (current major).
+- A link-local server can therefore only be stored as scope-0 and will not connect on a
+  multi-interface host.
+
+This is an uncommon topology and does **not** affect hosts that have a usable IPv4
+nameserver.
+
+### 9.3 What would be needed to fix 9.2
+
+In increasing order of cost / decreasing preference:
+
+1. **Upstream `hickory-dns/hickory`: support scoped nameserver addresses** — carry a
+   `scope_id` (or accept `SocketAddrV6`) through `NameServerConfig` and connection setup.
+   Once available, adopt it here by parsing the `%zone` (numeric, or interface name via
+   `libc::if_nametoindex`) and building scoped name servers. This is the correct fix and
+   the only one that keeps hickory in the loop. → **File a hickory feature request.**
+2. **Supported workaround (no upstream needed):** affected users build/install with
+   `--no-default-features` so the `trust-dns`/`hickory-dns` feature is off and binstall
+   uses reqwest's system resolver (`getaddrinfo`), which handles `%zone` correctly.
+   Document this in user-facing docs. ← recommended interim answer.
+3. **Bespoke `getaddrinfo` fallback inside `TrustDnsResolver`** for the link-local-only
+   case — significant unsafe/unix-specific code for a rare configuration; not justified.
+
+### 9.4 Related upstream item (optional, would simplify this repo)
+
+`hickory_resolver::system_conf::read_system_conf()` is all-or-nothing: one unparseable
+`nameserver` entry fails the entire load. That strictness is what forced our §5.1 salvage
+workaround. An upstream fix to skip/tolerate unparseable entries (or to parse scoped
+addresses) would make `parse_nameservers` / `salvage_system_configs` redundant — they
+could be removed once a fixed hickory is in `Cargo.lock`. → optional **bug report to
+hickory**; our workaround is harmless until then.
+
+### 9.5 Action items outside this repo
+
+- [ ] Open hickory feature request: scoped/link-local nameserver support (`scope_id`). (§9.3.1)
+- [ ] (Optional) Open hickory bug: `read_system_conf` should not fail wholesale on one
+      bad `nameserver` line. (§9.4)
+- [ ] Add user-facing note: on IPv6-only LANs with only a link-local resolver, install
+      with `--no-default-features`. (§9.3.2)

--- a/docs/ipv6-dns-remediation.md
+++ b/docs/ipv6-dns-remediation.md
@@ -142,6 +142,21 @@ different implementation per OS:
   is merely queried and times out); for an IPv6-only LAN whose only server is link-local
   this leaks a dead config with no public-DNS fallback. This is a latent, Linux-only edge
   case; the reported failure is macOS-only.
+- **Windows — cannot reproduce the wholesale failure.** binstall does not even reach
+  hickory's `read_system_conf` on the normal Windows path: `get_configs()` (`#[cfg(windows)]`)
+  reads `netdev::get_default_interface().dns_servers` (a `Vec<IpAddr>`) and adds each server
+  to the `ResolverConfig` in an independent loop; hickory's `system_conf/windows.rs`
+  (the fallback used only when `netdev` returns zero servers) likewise iterates
+  `ipconfig` adapter `dns_servers()` and pushes each `IpAddr` independently. Two
+  consequences: (1) the IPv6 **zone is already gone** — both Win32 sources hand back
+  parsed `IpAddr` values, so there is no `%zone` string for `IpAddr::from_str` to choke
+  on, unlike `apple.rs`; (2) because servers are added one-by-one, a single unusable
+  entry can **never** discard the working ones. The worst case on Windows is the milder
+  Linux-style outcome — a scope-0 link-local entry added as a dead nameserver that is
+  queried and times out — and only when such a server is active alongside no usable one.
+  There is therefore no Windows analogue of the macOS all-or-nothing crash, and the §5.1
+  salvage parser (which is inherently a `/etc/resolv.conf` reader) neither applies to nor
+  is needed on Windows.
 
 Both symptoms share one root: there is nowhere in hickory's `NameServerConfig` to carry a
 scope id (tracked upstream as [hickory-dns/hickory-dns#3713](https://github.com/hickory-dns/hickory-dns/issues/3713)).


### PR DESCRIPTION
Issue with DNS on some IPv6 networks when primary system nameserver is a link-local IPv6 address. hickory's read_system_conf() is all-or-nothing, so that one unparseable entry discarded your working IPv4 nameserver too, forcing a fall back to encrypted public DNS that your network blocks → fatal dns error on every request.

The fix (crates/binstalk-downloader/src/remote/resolver.rs): on the unix path, when read_system_conf() fails, parse /etc/resolv.conf ourselves and build a resolver from the usable nameservers — skipping scoped/link-local entries (unusable without a scope id) and non-IP tokens — only falling back to public DNS when none remain. The public-DNS fallback was extracted into public_dns_configs(), the dead QUAD9 import dropped, and ip_strategy left as Ipv4AndIpv6.