### PR TITLE
fix: reduce unix command line installer noise

### DIFF
--- a/install-from-binstall-release.sh
+++ b/install-from-binstall-release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eux
+set -eu
 
 do_curl() {
     curl --retry 10 -A "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0" -L --proto '=https' --tlsv1.2 -sSf "$@"


### PR DESCRIPTION
The install script mentioned in the project README uses `set -x`, which causes the shell to output every line executed to stdout. This isn't useful to end-users (and may cause confusion in some cases), so I believe it should be removed.

Output before pull request:
<img width="721" height="600" alt="image" src="https://github.com/user-attachments/assets/b27f6630-0ab3-4983-a035-791d9e5a4ca3" />

Output after pull request:
<img width="718" height="105" alt="image" src="https://github.com/user-attachments/assets/ea7aacf6-7c8e-4191-9623-e3ad25bdc55e" />