### PR TITLE
hickory-dns: Prefer ipv6

### DIFF
--- a/crates/binstalk-downloader/src/remote/resolver.rs
+++ b/crates/binstalk-downloader/src/remote/resolver.rs
@@ -235,7 +235,7 @@ fn new_resolver() -> Result<TokioAsyncResolver, BoxError> {
 
     debug!("Resolver configuration complete");
 
-    opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+    opts.ip_strategy = LookupIpStrategy::Ipv6AndIpv4;
 
     let mut builder = TokioAsyncResolver::builder_with_config(config, Default::default());
     *builder.options_mut() = opts;


### PR DESCRIPTION
Ipv6 is recommended as no NAT requires and it'll eventually replace ipv4

ref: seanmonstar/reqwest#3063