### PR TITLE
fix: honour --version for git or local manifest

### DIFF
--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -9,7 +9,7 @@ use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use leon::Template;
 use maybe_owned::MaybeOwned;
-use semver::{Version, VersionReq};
+use semver::{Comparator, Op as ComparatorOp, Version, VersionReq};
 use tokio::{task::spawn_blocking, time::timeout};
 use tracing::{debug, error, info, instrument, warn};
 use url::Url;
@@ -508,16 +508,14 @@ impl PackageInfo {
             return Err(BinstallError::CargoTomlMissingPackage(name));
         };
 
-        let new_version_str = package.version().to_compact_string();
-        let new_version = match Version::parse(&new_version_str) {
-            Ok(new_version) => new_version,
-            Err(err) => {
-                return Err(Box::new(VersionParseError {
-                    v: new_version_str,
-                    err,
-                })
-                .into())
-            }
+        let manifest_version_str = package.version().to_compact_string();
+        let (new_version_str, new_version) = if opts.cargo_toml_fetch_override.is_some() {
+            exact_version_req(version_req).map_or_else(
+                || parse_package_version(manifest_version_str),
+                |version| Ok((version.to_compact_string(), version)),
+            )?
+        } else {
+            parse_package_version(manifest_version_str)?
         };
 
         if let Some(curr_version) = curr_version {
@@ -563,6 +561,42 @@ impl PackageInfo {
                 repo: package.repository().map(ToString::to_string),
             }))
         }
+    }
+}
+
+fn parse_package_version(
+    version_str: CompactString,
+) -> Result<(CompactString, Version), BinstallError> {
+    let version = match Version::parse(&version_str) {
+        Ok(version) => version,
+        Err(err) => {
+            return Err(Box::new(VersionParseError {
+                v: version_str,
+                err,
+            })
+            .into())
+        }
+    };
+
+    Ok((version_str, version))
+}
+
+fn exact_version_req(version_req: &VersionReq) -> Option<Version> {
+    match version_req.comparators.as_slice() {
+        [Comparator {
+            op: ComparatorOp::Exact,
+            major,
+            minor: Some(minor),
+            patch: Some(patch),
+            pre,
+        }] => Some(Version {
+            major: *major,
+            minor: *minor,
+            patch: *patch,
+            pre: pre.clone(),
+            build: Default::default(),
+        }),
+        _ => None,
     }
 }
 

--- a/e2e-tests/git.sh
+++ b/e2e-tests/git.sh
@@ -34,6 +34,19 @@ cp manifests/github-test-Cargo.toml "$GIT/Cargo.toml"
 
 test_cargo_binstall_install
 
+perl -0pi -e 's/version = "0.12.0"/version = "0.12.0-dev"/' "$GIT/Cargo.toml"
+(
+  cd "$GIT"
+  git add Cargo.toml
+  git commit -m "Use development manifest version"
+)
+
+# Install a release from a git manifest whose in-tree version differs from the
+# requested release version.
+"$1" binstall --force --git "file://$GIT" --version 0.12.0 --no-confirm cargo-binstall
+
+test_cargo_binstall_install
+
 cp -r manifests/workspace/* "$GIT"
 (
   cd "$GIT"


### PR DESCRIPTION
## Summary

- Use an exact requested version for git/manifest package resolution when rendering package URLs.
- Keep manifest versions for wildcard or range version requests.
- Add a Git e2e regression where the manifest uses a `-dev` version but `--version` requests a release artifact.

## Why

Fixes #2165. A git manifest can use a development version while the user requests a released artifact with `--version`. In that case `{ version }` should resolve to the requested exact version, not the in-tree manifest version.

## Validation

- `just e2e-test-git` — failed before the resolver fix on `0.12.0-dev` fallback, passed after rebuild
- `cargo fmt --all -- --check`
- `cargo test -p binstalk --lib`
- `cargo clippy -p binstalk --all-targets -- -D warnings`
- `git diff --check`