### PR TITLE
feat: add --allow-insecure-http to permit plaintext HTTP

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -168,6 +168,11 @@ Some crate installation strategies may collect anonymized usage statistics by de
 
   Possible values: `1.2`, `1.3`
 
+* `--allow-insecure-http` — Allow plaintext HTTP requests to remote endpoints.
+
+   The default is to only allow HTTPS, rejecting any plaintext HTTP url. This option relaxes that so registries and download urls served over plain HTTP can be used, which is handy for talking to a local registry during testing.
+
+   Note that this is insecure and not recommended outside of testing.
 * `--root-certificates <PATH>` — Specify the root certificates to use for https connections, in addition to default system-wide ones
 * `--json-output` — Print logs in json format to be parsable
 * `--github-token <TOKEN>` — Provide the github token for accessing the restful API of api.github.com

--- a/crates/bin/src/args.rs
+++ b/crates/bin/src/args.rs
@@ -364,6 +364,16 @@ pub struct Args {
     #[clap(help_heading = "Options", long, value_enum, value_name = "VERSION")]
     pub(crate) min_tls_version: Option<TLSVersion>,
 
+    /// Allow plaintext HTTP requests to remote endpoints.
+    ///
+    /// The default is to only allow HTTPS, rejecting any plaintext HTTP url. This option relaxes
+    /// that so registries and download urls served over plain HTTP can be used, which is handy for
+    /// talking to a local registry during testing.
+    ///
+    /// Note that this is insecure and not recommended outside of testing.
+    #[clap(help_heading = "Options", long)]
+    pub(crate) allow_insecure_http: bool,
+
     /// Specify the root certificates to use for https connections,
     /// in addition to default system-wide ones.
     #[clap(

--- a/crates/bin/src/entry.rs
+++ b/crates/bin/src/entry.rs
@@ -93,6 +93,7 @@ pub fn install_crates(
     let client = Client::new(
         concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
         args.min_tls_version.map(|v| v.into()),
+        args.allow_insecure_http,
         rate_limit.duration,
         rate_limit.request_count,
         read_root_certs(

--- a/crates/binstalk-downloader/src/download.rs
+++ b/crates/binstalk-downloader/src/download.rs
@@ -294,6 +294,7 @@ mod test {
         let client = crate::remote::Client::new(
             concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
             None,
+            false,
             NonZeroU16::new(10).unwrap(),
             1.try_into().unwrap(),
             [],

--- a/crates/binstalk-downloader/src/remote.rs
+++ b/crates/binstalk-downloader/src/remote.rs
@@ -95,17 +95,25 @@ impl Client {
     ///   each `per_millis` duration.
     ///
     /// The [`reqwest::Client`] constructed has secure defaults, such as allowing
-    /// only TLS v1.2 and above, and disallowing plaintext HTTP altogether. If you
-    /// need more control, use the `from_builder` variant.
+    /// only TLS v1.2 and above, and disallowing plaintext HTTP altogether. Set
+    /// `allow_insecure_http` to `true` to permit plaintext HTTP requests, which
+    /// is useful for talking to a registry served over HTTP (e.g. in tests). If
+    /// you need more control, use the `from_builder` variant.
     pub fn new(
         user_agent: impl AsRef<str>,
         min_tls: Option<TLSVersion>,
+        allow_insecure_http: bool,
         per_millis: NonZeroU16,
         num_request: NonZeroU64,
         certificates: impl IntoIterator<Item = Certificate>,
     ) -> Result<Self, Error> {
         Self::from_builder(
-            Self::default_builder(user_agent.as_ref(), min_tls, &mut certificates.into_iter()),
+            Self::default_builder(
+                user_agent.as_ref(),
+                min_tls,
+                allow_insecure_http,
+                &mut certificates.into_iter(),
+            ),
             per_millis,
             num_request,
         )
@@ -119,11 +127,12 @@ impl Client {
     pub fn default_builder(
         user_agent: &str,
         min_tls: Option<TLSVersion>,
+        allow_insecure_http: bool,
         certificates: &mut dyn Iterator<Item = Certificate>,
     ) -> reqwest::ClientBuilder {
         let mut builder = reqwest::ClientBuilder::new()
             .user_agent(user_agent)
-            .https_only(true)
+            .https_only(!allow_insecure_http)
             .tcp_nodelay(false);
 
         #[cfg(feature = "hickory-dns")]
@@ -458,8 +467,26 @@ fn parse_header_ratelimit_reset_with_current_time(
 mod tests {
     use super::*;
 
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
     fn epoch(secs: u64) -> Duration {
         Duration::from_secs(secs)
+    }
+
+    fn test_client(allow_insecure_http: bool) -> Client {
+        Client::new(
+            "cargo-binstall-test",
+            None,
+            allow_insecure_http,
+            NonZeroU16::new(10).unwrap(),
+            NonZeroU64::new(1).unwrap(),
+            [],
+        )
+        .unwrap()
     }
 
     #[test]
@@ -494,5 +521,46 @@ mod tests {
         let dur =
             parse_header_ratelimit_reset_with_current_time(&hv, epoch(2145916800 - 600)).unwrap();
         assert_eq!(dur, Duration::from_secs(600));
+    }
+
+    #[tokio::test]
+    async fn allow_insecure_http_permits_plaintext_http() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+            stream.flush().unwrap();
+        });
+
+        let url = Url::parse(&format!("http://{addr}/")).unwrap();
+        let body = test_client(true)
+            .get(url)
+            .send(true)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"ok");
+
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn https_only_rejects_plaintext_http_by_default() {
+        // No server is needed here: with `https_only` the request is rejected
+        // before any connection is attempted.
+        let url = Url::parse("http://127.0.0.1:1/").unwrap();
+        let res = test_client(false).get(url).send(true).await;
+        assert!(
+            res.is_err(),
+            "plaintext http should be rejected unless allow_insecure_http is set"
+        );
     }
 }

--- a/crates/binstalk-fetchers/src/lib.rs
+++ b/crates/binstalk-fetchers/src/lib.rs
@@ -443,6 +443,7 @@ mod test {
             Client::new(
                 "user-agent",
                 None,
+                false,
                 NonZeroU16::new(1000).unwrap(),
                 NonZeroU64::new(1000).unwrap(),
                 [],

--- a/crates/binstalk-fetchers/src/quickinstall.rs
+++ b/crates/binstalk-fetchers/src/quickinstall.rs
@@ -348,6 +348,7 @@ mod test {
         Client::new(
             concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
             None,
+            false,
             NonZeroU16::new(10).unwrap(),
             1.try_into().unwrap(),
             [],

--- a/crates/binstalk-git-repo-api/src/gh_api_client.rs
+++ b/crates/binstalk-git-repo-api/src/gh_api_client.rs
@@ -508,6 +508,7 @@ mod test {
         remote::Client::new(
             concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
             None,
+            false,
             NonZeroU16::new(300).unwrap(),
             1.try_into().unwrap(),
             [],

--- a/crates/binstalk-registry/src/lib.rs
+++ b/crates/binstalk-registry/src/lib.rs
@@ -296,6 +296,7 @@ mod test {
         Client::new(
             concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
             None,
+            false,
             NonZeroU16::new(10).unwrap(),
             1.try_into().unwrap(),
             [],


### PR DESCRIPTION
This adds an opt-in `--allow-insecure-http` flag so binstall can talk to endpoints served over plain HTTP, addressing #2606.

Right now the reqwest client is always built with `https_only(true)`, which means any `http://` url is rejected before a connection is even attempted. That's a good default, but it makes it impossible to point binstall at a registry served over plain HTTP, which is exactly what you end up with when running against a local mock registry in tests (the original use case in the issue).

The flag simply flips `https_only` off when it's set. The default is unchanged, so HTTPS stays enforced unless you explicitly pass `--allow-insecure-http`. I threaded the `allow_insecure_http` bool through `remote::Client::new` and `default_builder` right next to the existing `min_tls` option so it follows the same path, and documented it in the same "insecure, don't use outside testing" spirit as `--skip-signatures`.

There are two small tests in `remote.rs`: one spins up a throwaway local TCP server and checks a GET over `http://` succeeds when the flag is on, and one checks that a plaintext request is still rejected by default. HELP.md is regenerated.