### PR TITLE
feat: support `aliases` to symlink extra names to the installed binary

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -26,6 +26,8 @@ With the following configuration keys:
   for your crate (defaults to empty array).
   If `--strategies` is passed on the command line, then the `disabled-strategies` in `package.metadata` will be ignored.
   Otherwise, the `disabled-strategies` in `package.metadata` and `--disable-strategies` will be merged.
+- `aliases` is a list of extra names to symlink to the installed binary, for example `aliases = ["mcr"]` would also create an `mcr` symlink next to it.
+  This is only honoured for crates that ship a single binary, and the symlinks are skipped when `--no-symlinks` is set. Aliases are removed on uninstall just like the binary itself.
 
 
 `pkg-url` and `bin-dir` are templated to support different names for different versions / architectures / etc.
@@ -53,7 +55,7 @@ with the following variables available:
 [`target_lexicon::Environment`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Environment.html
 [`target_lexicon::Vendor`]: https://docs.rs/target-lexicon/latest/target_lexicon/enum.Vendor.html
 
-`pkg-url`, `pkg-fmt` and `bin-dir` can be overridden on a per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip` archives this could be set via:
+`pkg-url`, `pkg-fmt`, `bin-dir` and `aliases` can be overridden on a per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip` archives this could be set via:
 
 ```toml
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]

--- a/crates/binstalk-bins/src/lib.rs
+++ b/crates/binstalk-bins/src/lib.rs
@@ -93,12 +93,24 @@ pub fn infer_bin_dir_template(
         .unwrap_or(default_bin_dir_template)
 }
 
+/// An extra name symlinked to the installed binary.
+pub struct AliasLink {
+    /// Alias file name, including the binary extension (e.g. `.exe` on Windows).
+    pub name: CompactString,
+    /// Absolute path of the alias symlink, i.e. `install_path/<name>`.
+    pub path: PathBuf,
+}
+
 pub struct BinFile {
     pub base_name: CompactString,
     pub source: PathBuf,
     pub archive_source_path: PathBuf,
     pub dest: PathBuf,
     pub link: Option<PathBuf>,
+    /// Extra symlinks pointing at the same target as `link`.
+    ///
+    /// Always empty when `link` is `None`, since aliases are symlinks too.
+    pub aliases: Vec<AliasLink>,
 }
 
 impl BinFile {
@@ -108,6 +120,7 @@ impl BinFile {
         base_name: &str,
         tt: &Template<'_>,
         no_symlinks: bool,
+        aliases: &[CompactString],
     ) -> Result<Self, Error> {
         let binary_ext = if data.target.contains("windows") {
             ".exe"
@@ -170,12 +183,28 @@ impl BinFile {
             (dest_with_ver, Some(dest))
         };
 
+        // Aliases are symlinks, so they only make sense when the primary
+        // symlink is created too.
+        let aliases = if link.is_some() {
+            aliases
+                .iter()
+                .map(|alias| {
+                    let name = format_compact!("{alias}{binary_ext}");
+                    let path = data.install_path.join(name.as_str());
+                    AliasLink { name, path }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         Ok(Self {
             base_name: format_compact!("{base_name}{binary_ext}"),
             source,
             archive_source_path,
             dest,
             link,
+            aliases,
         })
     }
 
@@ -202,6 +231,7 @@ impl BinFile {
             base_name: &self.base_name,
             source: link.display(),
             dest: self.link_dest().display(),
+            aliases: &self.aliases,
         }))
     }
 
@@ -268,6 +298,15 @@ impl BinFile {
                 dest.display()
             );
             atomic_symlink_file(dest, link)?;
+
+            for alias in &self.aliases {
+                debug!(
+                    "Create alias link '{}' pointing to '{}'",
+                    alias.path.display(),
+                    dest.display()
+                );
+                atomic_symlink_file(dest, &alias.path)?;
+            }
         }
 
         Ok(())
@@ -282,6 +321,15 @@ impl BinFile {
                 dest.display()
             );
             atomic_symlink_file_noclobber(dest, link)?;
+
+            for alias in &self.aliases {
+                debug!(
+                    "Create alias link '{}' pointing to '{}' only if dst not exists",
+                    alias.path.display(),
+                    dest.display()
+                );
+                atomic_symlink_file_noclobber(dest, &alias.path)?;
+            }
         }
 
         Ok(())
@@ -348,11 +396,22 @@ struct LazyFormat<'a> {
     base_name: &'a str,
     source: path::Display<'a>,
     dest: path::Display<'a>,
+    aliases: &'a [AliasLink],
 }
 
 impl fmt::Display for LazyFormat<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({} -> {})", self.base_name, self.source, self.dest)
+        write!(f, "{} ({} -> {})", self.base_name, self.source, self.dest)?;
+        if !self.aliases.is_empty() {
+            write!(f, ", aliases: ")?;
+            for (i, alias) in self.aliases.iter().enumerate() {
+                if i != 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", alias.name)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -365,5 +424,89 @@ impl fmt::Display for OptionalLazyFormat<'_> {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use binstalk_types::cargo_toml_binstall::PkgMeta;
+
+    struct NoValues;
+    impl leon::Values for NoValues {
+        fn get_value(&self, _key: &str) -> Option<Cow<'_, str>> {
+            None
+        }
+    }
+
+    fn bin_file(target: &str, no_symlinks: bool, aliases: &[CompactString]) -> BinFile {
+        let bin_path = Path::new("/tmp/pkg/mycrate");
+        let install_path = Path::new("/home/user/.cargo/bin");
+        let data = Data {
+            name: "mycrate",
+            target,
+            version: "1.2.3",
+            repo: None,
+            meta: PkgMeta {
+                pkg_fmt: Some(PkgFmt::Bin),
+                ..Default::default()
+            },
+            bin_path,
+            install_path,
+            target_related_info: &NoValues,
+        };
+
+        // With `PkgFmt::Bin` the template is never rendered, but `new` still
+        // requires one.
+        let tt = Template::parse("{ bin }{ binary-ext }").unwrap();
+        BinFile::new(&data, "mycrate", &tt, no_symlinks, aliases).unwrap()
+    }
+
+    #[test]
+    fn aliases_symlink_alongside_the_binary() {
+        let bin = bin_file(
+            "x86_64-unknown-linux-gnu",
+            false,
+            &["mcr".into(), "myc".into()],
+        );
+
+        assert_eq!(
+            bin.link.as_deref(),
+            Some(Path::new("/home/user/.cargo/bin/mycrate"))
+        );
+        assert_eq!(bin.dest, Path::new("/home/user/.cargo/bin/mycrate-v1.2.3"));
+
+        let aliases: Vec<_> = bin
+            .aliases
+            .iter()
+            .map(|alias| (alias.name.as_str(), alias.path.as_path()))
+            .collect();
+        assert_eq!(
+            aliases,
+            [
+                ("mcr", Path::new("/home/user/.cargo/bin/mcr")),
+                ("myc", Path::new("/home/user/.cargo/bin/myc")),
+            ]
+        );
+    }
+
+    #[test]
+    fn aliases_get_the_windows_binary_extension() {
+        let bin = bin_file("x86_64-pc-windows-msvc", false, &["mcr".into()]);
+
+        assert_eq!(bin.aliases.len(), 1);
+        assert_eq!(bin.aliases[0].name, "mcr.exe");
+        assert_eq!(
+            bin.aliases[0].path,
+            Path::new("/home/user/.cargo/bin/mcr.exe")
+        );
+    }
+
+    #[test]
+    fn aliases_are_dropped_without_symlinks() {
+        let bin = bin_file("x86_64-unknown-linux-gnu", true, &["mcr".into()]);
+
+        assert!(bin.link.is_none());
+        assert!(bin.aliases.is_empty());
     }
 }

--- a/crates/binstalk-types/src/cargo_toml_binstall.rs
+++ b/crates/binstalk-types/src/cargo_toml_binstall.rs
@@ -5,6 +5,7 @@
 use std::borrow::Cow;
 
 use cargo_platform::{Cfg, Platform};
+use compact_str::CompactString;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use strum_macros::{EnumCount, VariantArray};
@@ -82,6 +83,12 @@ pub struct PkgMeta {
     /// Strategies to disable
     pub disabled_strategies: Option<Box<[Strategy]>>,
 
+    /// Extra names to symlink to the installed binary.
+    ///
+    /// Only honoured when the crate ships a single binary, and only when
+    /// symlinks are enabled (i.e. not with `--no-symlinks`).
+    pub aliases: Option<Vec<CompactString>>,
+
     /// Target specific overrides
     pub overrides: PkgOverrides,
 }
@@ -97,6 +104,9 @@ impl PkgMeta {
         }
         if let Some(o) = &pkg_override.bin_dir {
             self.bin_dir = Some(o.clone());
+        }
+        if let Some(o) = &pkg_override.aliases {
+            self.aliases = Some(o.clone());
         }
     }
 
@@ -136,6 +146,12 @@ impl PkgMeta {
                 .into_iter()
                 .find_map(|pkg_override| pkg_override.signing.clone())
                 .or_else(|| self.signing.clone()),
+
+            aliases: pkg_overrides
+                .clone()
+                .into_iter()
+                .find_map(|pkg_override| pkg_override.aliases.clone())
+                .or_else(|| self.aliases.clone()),
 
             disabled_strategies: if ignore_disabled_strategies {
                 None
@@ -179,6 +195,9 @@ pub struct PkgOverride {
 
     /// Package signing configuration
     pub signing: Option<PkgSigning>,
+
+    /// Extra names to symlink to the installed binary.
+    pub aliases: Option<Vec<CompactString>>,
 
     #[serde(skip)]
     pub ignore_disabled_strategies: bool,
@@ -356,6 +375,33 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].pkg_fmt, Some(PkgFmt::Tgz)); // Unix.
         assert_eq!(matches[1].pkg_fmt, Some(PkgFmt::Tar)); // Linux.
+    }
+
+    #[test]
+    fn test_aliases_parse_and_override() {
+        let base: PkgMeta = serde_json::from_value(json!({
+            "aliases": ["mcr"],
+        }))
+        .unwrap();
+        assert_eq!(base.aliases.as_deref(), Some(["mcr".into()].as_slice()));
+
+        // A target override replaces the base aliases entirely.
+        let override_win = PkgOverride {
+            aliases: Some(vec!["mcr".into(), "mycrate-win".into()]),
+            ..Default::default()
+        };
+        let merged = base.merge_overrides([&override_win]);
+        assert_eq!(
+            merged.aliases.as_deref(),
+            Some(["mcr".into(), "mycrate-win".into()].as_slice())
+        );
+
+        // Without an override the base aliases are kept.
+        let empty = PkgOverride::default();
+        assert_eq!(
+            base.merge_overrides([&empty]).aliases.as_deref(),
+            Some(["mcr".into()].as_slice())
+        );
     }
 
     #[test]

--- a/crates/binstalk/src/ops/resolve.rs
+++ b/crates/binstalk/src/ops/resolve.rs
@@ -390,11 +390,38 @@ fn collect_bin_files(
 
     let template = Template::parse(&bin_dir)?;
 
+    // Aliases are only meaningful for single-binary crates: with more than one
+    // binary it is ambiguous which one an alias should point at.
+    let aliases: &[CompactString] = match bin_data.meta.aliases.as_deref() {
+        Some(aliases) if !aliases.is_empty() => {
+            if package_info.binaries.len() == 1 {
+                aliases
+            } else {
+                warn!(
+                    "Ignoring `aliases` for {}: aliases are only supported for crates that \
+provide exactly one binary, but this crate provides {}",
+                    package_info.name,
+                    package_info.binaries.len()
+                );
+                &[]
+            }
+        }
+        _ => &[],
+    };
+
     // Create bin_files
     let bin_files = package_info
         .binaries
         .iter()
-        .map(|bin| bins::BinFile::new(&bin_data, bin.name.as_str(), &template, no_symlinks))
+        .map(|bin| {
+            bins::BinFile::new(
+                &bin_data,
+                bin.name.as_str(),
+                &template,
+                no_symlinks,
+                aliases,
+            )
+        })
         .collect::<Result<Vec<_>, bins::Error>>()?;
 
     let mut source_set = BTreeSet::new();

--- a/crates/binstalk/src/ops/resolve/resolution.rs
+++ b/crates/binstalk/src/ops/resolve/resolution.rs
@@ -98,13 +98,18 @@ impl ResolutionFetch {
     ) -> Vec<CompactString> {
         // We need to filter crate_bin_files by user_specified_bins in case the prebuilt doesn't
         // have featured-gated (optional) binary (gated behind feature).
+        //
+        // Aliases follow their parent binary: they are recorded (so uninstall
+        // removes them) whenever the binary they point at is installed.
         crate_bin_files
             .into_iter()
-            .map(|bin| bin.base_name)
-            .filter(|bin_name| {
+            .filter(|bin| {
                 user_specified_bins
                     .as_ref()
-                    .map_or(true, |bins| bins.binary_search(bin_name).is_ok())
+                    .map_or(true, |bins| bins.binary_search(&bin.base_name).is_ok())
+            })
+            .flat_map(|bin| {
+                iter::once(bin.base_name).chain(bin.aliases.into_iter().map(|alias| alias.name))
             })
             .collect()
     }


### PR DESCRIPTION
Closes #2032.

Adds an `aliases` key to `[package.metadata.binstall]` so a crate can ask binstall to create extra names next to the installed binary. For example `aliases = ["mcr"]` also creates an `mcr` symlink pointing at the same target as the usual one.

Since aliases are symlinks, they follow the same rules as the primary symlink: they are skipped under `--no-symlinks`, and they get recorded in the manifest so `cargo uninstall` cleans them up too. It only applies when the crate ships a single binary, because with more than one it is ambiguous which binary an alias should point at, so in that case it is ignored with a warning. It can also be set per target under `overrides`.
